### PR TITLE
Add more benchmarks:

### DIFF
--- a/benches/api_calls.rs
+++ b/benches/api_calls.rs
@@ -1,4 +1,4 @@
-#![feature(invocation)]
+#![cfg(feature = "invocation")]
 #![feature(test)]
 
 extern crate test;
@@ -187,6 +187,21 @@ mod tests {
         env.delete_local_ref(obj).unwrap();
 
         b.iter(|| env.new_global_ref(global_ref.as_obj()).unwrap());
+    }
+
+    /// Checks the overhead of checking if exception has occurred.
+    ///
+    /// Such checks are required each time a Java method is called, but
+    /// can be omitted if we call a JNI method that returns an error status.
+    ///
+    /// See also #58
+    #[bench]
+    fn jni_check_exception(b: &mut Bencher) {
+        let env = VM.attach_current_thread().unwrap();
+
+        b.iter(|| {
+            env.exception_check().unwrap()
+        });
     }
 
     #[bench]

--- a/benches/api_calls.rs
+++ b/benches/api_calls.rs
@@ -217,7 +217,7 @@ mod tests {
 
     /// A benchmark of the overhead of attaching and detaching a native thread.
     ///
-    /// TL;DR: It is HUGE — two orders of magnitude higher than calling a single
+    /// It is *huge* — two orders of magnitude higher than calling a single
     /// Java method using unchecked APIs (e.g., `jni_call_static_unsafe`).
     ///
     #[bench]


### PR DESCRIPTION
## Overview
- Push/PopLocalFrame overhead benchmark — such operations
are *required* if one attaches a long-running native thread
to the JVM because there is no 'return-from-native-method'
event when created local references are freed, hence no way for
the JVM to know that the local references are no longer used
in the native code.

- A benchmark of the overhead of attaching and detaching
a native thread. It is expectedly HUGE — two orders of magnitude
higher than calling a single Java method using unchecked APIs
(e.g., `jni_call_static_unsafe`).

<details>
<summary><b>Results</b></summary>

```
$ cargo +nightly-2018-08-01 bench --features=invocation,backtrace 
   …

running 16 tests
test tests::jni_call_object_method_safe          ... bench:       2,049 ns/iter (+/- 64)
test tests::jni_call_object_method_unsafe        ... bench:         276 ns/iter (+/- 25)

test tests::jni_call_static_method_safe          ... bench:       2,577 ns/iter (+/- 65)
test tests::jni_call_static_method_unsafe_jclass ... bench:         293 ns/iter (+/- 11)
test tests::jni_call_static_method_unsafe_str    ... bench:         840 ns/iter (+/- 32)

test tests::jni_get_java_vm                      ... bench:          11 ns/iter (+/- 0)

test tests::jni_new_global_ref                   ... bench:         195 ns/iter (+/- 1)

test tests::jni_new_object_by_id_jclass          ... bench:         251 ns/iter (+/- 13)
test tests::jni_new_object_by_id_str             ... bench:         765 ns/iter (+/- 65)
test tests::jni_new_object_jclass                ... bench:       1,917 ns/iter (+/- 47)
test tests::jni_new_object_str                   ... bench:       2,561 ns/iter (+/- 84)

test tests::jni_noop_with_local_frame            ... bench:          96 ns/iter (+/- 0)
test tests::jvm_noop_attach_detach_native_thread ... bench:      26,616 ns/iter (+/- 2,445)

test tests::native_arc                           ... bench:          11 ns/iter (+/- 0)
test tests::native_call_function                 ... bench:           2 ns/iter (+/- 0)
test tests::native_rc                            ... bench:           3 ns/iter (+/- 0)

test result: ok. 0 passed; 0 failed; 0 ignored; 16 measured; 0 filtered out
```
</details>

### Definition of Done

- [ ] There are no TODOs left in the code
- [x] Change is covered by automated [tests](https://github.com/jni-rs/jni-rs/blob/master/CONTRIBUTING.md#tests)
- [x] The [coding guidelines](https://github.com/jni-rs/jni-rs/blob/master/CONTRIBUTING.md#the-code-style) are followed
- [x] Public API has documentation
- [x] This change is not breaking **or** mentioned in the Changelog
- [x] The [continuous integration build](https://www.travis-ci.org/jni-rs/jni-rs) passes
