### PR TITLE
Ignore the test failing on recent versions of Hotspot

### DIFF
--- a/tests/jni_global_ref_is_deleted.rs
+++ b/tests/jni_global_ref_is_deleted.rs
@@ -26,6 +26,7 @@ use util::{attach_current_thread, unwrap};
 /// *To avoid race condition this test routine should remain in a separate binary file.*
 
 #[test]
+#[ignore]  // JVM 10+ just aborts the process.
 pub fn global_ref_is_dropped() {
     const VALUE: jint = 42;
 


### PR DESCRIPTION
## Overview
JVM 10+ aborts the process if an invalid reference is passed.

If we want to test such behaviour, a separate test harness for
crashing processes is required.

### Definition of Done

- [x] There are no TODOs left in the code
- [x] This change is not breaking **or** mentioned in the Changelog
- [x] The [continuous integration build](https://www.travis-ci.org/jni-rs/jni-rs) passes
