### PR TITLE
Detach daemon threads automatically

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+- `JavaVM#attach_current_thread_as_daemon` now returns `JNIEnv` wrapped in
+  `AttachGuard` which automatically detaches the thread when it gets out of the scope.
+
 ## [0.10.2]
 
 ### Added

--- a/src/wrapper/java_vm/vm.rs
+++ b/src/wrapper/java_vm/vm.rs
@@ -1,5 +1,5 @@
-use JNIEnv;
 use errors::*;
+use JNIEnv;
 
 use sys;
 
@@ -67,7 +67,7 @@ impl JavaVM {
     }
 
     /// Attaches the current thread to a Java VM as a daemon.
-    pub fn attach_current_thread_as_daemon(&self) -> Result<JNIEnv> {
+    pub fn attach_current_thread_as_daemon(&self) -> Result<AttachGuard> {
         let mut ptr = ptr::null_mut();
         unsafe {
             let res = java_vm_unchecked!(
@@ -78,7 +78,11 @@ impl JavaVM {
             );
             jni_error_code_to_result(res)?;
 
-            JNIEnv::from_raw(ptr as *mut sys::JNIEnv)
+            let env = JNIEnv::from_raw(ptr as *mut sys::JNIEnv)?;
+            Ok(AttachGuard {
+                java_vm: self,
+                env: env,
+            })
         }
     }
 


### PR DESCRIPTION
## Overview

This is a breaking API change that is required to make the library more safe to use. Daemon threads are not special in regard to cleanup: they must be detached in the very same way as common threads (by calling `DetachCurrentThread`). Not managing to do so may result in unexpected behaviour and memory leaks.

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Change is covered by automated [tests](https://github.com/jni-rs/jni-rs/blob/master/CONTRIBUTING.md#tests)
- [x] The [coding guidelines](https://github.com/jni-rs/jni-rs/blob/master/CONTRIBUTING.md#the-code-style) are followed
- [x] Public API has documentation
- [x] This change is not breaking **or** mentioned in the Changelog
- [ ] The [continuous integration build](https://www.travis-ci.org/jni-rs/jni-rs) passes
