### PR TITLE
Rename jni_x_call macros

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,12 @@ to call if there is a pending exception (#124):
   - `delete_global_ref` and `release_string_utf_chars` won't print incorrect
   log messages
 
+- Rename some macros to better express their intent (see #123):
+  - Rename `jni_call` to `jni_non_null_call` as it checks the return value
+  to be non-null.
+  - Rename `jni_non_null_call` (which may return nulls) to `jni_non_void_call`.
+
+
 ## [0.10.2]
 
 ### Added

--- a/src/wrapper/macros.rs
+++ b/src/wrapper/macros.rs
@@ -1,11 +1,14 @@
-macro_rules! jni_call {
+// A JNI call that is expected to return a non-null pointer when successful.
+// If a null pointer is returned, it is converted to an Err.
+macro_rules! jni_non_null_call {
     ( $jnienv:expr, $name:tt $(, $args:expr )* ) => ({
-        let res = jni_non_null_call!($jnienv, $name $(, $args)*);
+        let res = jni_non_void_call!($jnienv, $name $(, $args)*);
         non_null!(res, concat!(stringify!($name), " result")).into()
     })
 }
 
-macro_rules! jni_non_null_call {
+// A non-void JNI call. May return anything — primitives, references, error codes.
+macro_rules! jni_non_void_call {
     ( $jnienv:expr, $name:tt $(, $args:expr )* ) => ({
         trace!("calling checked jni method: {}", stringify!($name));
         #[allow(unused_unsafe)]

--- a/src/wrapper/macros.rs
+++ b/src/wrapper/macros.rs
@@ -1,5 +1,6 @@
 // A JNI call that is expected to return a non-null pointer when successful.
 // If a null pointer is returned, it is converted to an Err.
+// Returns Err if there is a pending exception after the call.
 macro_rules! jni_non_null_call {
     ( $jnienv:expr, $name:tt $(, $args:expr )* ) => ({
         let res = jni_non_void_call!($jnienv, $name $(, $args)*);
@@ -8,6 +9,7 @@ macro_rules! jni_non_null_call {
 }
 
 // A non-void JNI call. May return anything — primitives, references, error codes.
+// Returns Err if there is a pending exception after the call.
 macro_rules! jni_non_void_call {
     ( $jnienv:expr, $name:tt $(, $args:expr )* ) => ({
         trace!("calling checked jni method: {}", stringify!($name));
@@ -32,6 +34,8 @@ macro_rules! non_null {
     }
 }
 
+// A void JNI call.
+// Returns Err if there is a pending exception after the call.
 macro_rules! jni_void_call {
     ( $jnienv:expr, $name:tt $(, $args:expr )* ) => ({
         trace!("calling checked jni method: {}", stringify!($name));
@@ -45,6 +49,8 @@ macro_rules! jni_void_call {
     })
 }
 
+// A JNI call that does not check for exceptions or verify
+// error codes (if any).
 macro_rules! jni_unchecked {
     ( $jnienv:expr, $name:tt $(, $args:expr )* ) => ({
         trace!("calling unchecked jni method: {}", stringify!($name));

--- a/src/wrapper/macros.rs
+++ b/src/wrapper/macros.rs
@@ -1,3 +1,24 @@
+macro_rules! jni_call {
+    ( $jnienv:expr, $name:tt $(, $args:expr )* ) => ({
+        let res = jni_non_null_call!($jnienv, $name $(, $args)*);
+        non_null!(res, concat!(stringify!($name), " result")).into()
+    })
+}
+
+macro_rules! jni_non_null_call {
+    ( $jnienv:expr, $name:tt $(, $args:expr )* ) => ({
+        trace!("calling checked jni method: {}", stringify!($name));
+        #[allow(unused_unsafe)]
+        unsafe {
+            trace!("entering unsafe");
+            let res = jni_method!($jnienv, $name)($jnienv, $($args),*);
+            check_exception!($jnienv);
+            trace!("exiting unsafe");
+            res
+        }
+    })
+}
+
 macro_rules! non_null {
     ( $obj:expr, $ctx:expr ) => {
         if $obj.is_null() {
@@ -8,14 +29,25 @@ macro_rules! non_null {
     }
 }
 
-macro_rules! deref {
-    ( $obj:expr, $ctx:expr ) => {
-        if $obj.is_null() {
-            return Err($crate::errors::ErrorKind::NullDeref($ctx).into());
-        } else {
-            *$obj
+macro_rules! jni_void_call {
+    ( $jnienv:expr, $name:tt $(, $args:expr )* ) => ({
+        trace!("calling checked jni method: {}", stringify!($name));
+        #[allow(unused_unsafe)]
+        unsafe {
+            trace!("entering unsafe");
+            jni_method!($jnienv, $name)($jnienv, $($args),*);
+            check_exception!($jnienv);
+            trace!("exiting unsafe");
         }
-    };
+    })
+}
+
+macro_rules! jni_unchecked {
+    ( $jnienv:expr, $name:tt $(, $args:expr )* ) => ({
+        trace!("calling unchecked jni method: {}", stringify!($name));
+        let res = jni_method!($jnienv, $name)($jnienv, $($args),*);
+        res
+    })
 }
 
 macro_rules! jni_method {
@@ -52,48 +84,6 @@ macro_rules! check_exception {
     }
 }
 
-macro_rules! jni_unchecked {
-    ( $jnienv:expr, $name:tt $(, $args:expr )* ) => ({
-        trace!("calling unchecked jni method: {}", stringify!($name));
-        let res = jni_method!($jnienv, $name)($jnienv, $($args),*);
-        res
-    })
-}
-
-macro_rules! jni_non_null_call {
-    ( $jnienv:expr, $name:tt $(, $args:expr )* ) => ({
-        trace!("calling checked jni method: {}", stringify!($name));
-        #[allow(unused_unsafe)]
-        unsafe {
-            trace!("entering unsafe");
-            let res = jni_method!($jnienv, $name)($jnienv, $($args),*);
-            check_exception!($jnienv);
-            trace!("exiting unsafe");
-            res
-        }
-    })
-}
-
-macro_rules! jni_void_call {
-    ( $jnienv:expr, $name:tt $(, $args:expr )* ) => ({
-        trace!("calling checked jni method: {}", stringify!($name));
-        #[allow(unused_unsafe)]
-        unsafe {
-            trace!("entering unsafe");
-            jni_method!($jnienv, $name)($jnienv, $($args),*);
-            check_exception!($jnienv);
-            trace!("exiting unsafe");
-        }
-    })
-}
-
-macro_rules! jni_call {
-    ( $jnienv:expr, $name:tt $(, $args:expr )* ) => ({
-        let res = jni_non_null_call!($jnienv, $name $(, $args)*);
-        non_null!(res, concat!(stringify!($name), " result")).into()
-    })
-}
-
 macro_rules! catch {
     ( move $b:block ) => {
         (move || $b)()
@@ -101,6 +91,14 @@ macro_rules! catch {
     ( $b:block ) => {
         (|| $b)()
     };
+}
+
+macro_rules! java_vm_unchecked {
+    ( $java_vm:expr, $name:tt $(, $args:expr )* ) => ({
+        trace!("calling unchecked JavaVM method: {}", stringify!($name));
+        let res = java_vm_method!($java_vm, $name)($java_vm, $($args),*);
+        res
+    })
 }
 
 macro_rules! java_vm_method {
@@ -121,10 +119,12 @@ macro_rules! java_vm_method {
     })
 }
 
-macro_rules! java_vm_unchecked {
-    ( $java_vm:expr, $name:tt $(, $args:expr )* ) => ({
-        trace!("calling unchecked JavaVM method: {}", stringify!($name));
-        let res = java_vm_method!($java_vm, $name)($java_vm, $($args),*);
-        res
-    })
+macro_rules! deref {
+    ( $obj:expr, $ctx:expr ) => {
+        if $obj.is_null() {
+            return Err($crate::errors::ErrorKind::NullDeref($ctx).into());
+        } else {
+            *$obj
+        }
+    };
 }


### PR DESCRIPTION
## Overview
Rename macros to better express their intent:
- Rename `jni_call` to `jni_non_null_call` as it checks the return value
to be non-null.
- Rename `jni_non_null_call` (which *may* return nulls) to
`jni_non_void_call`.

Also, reorder the macro definitions to be in 'call' order.

---

See also: #123 

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Change is covered by automated [tests](https://github.com/jni-rs/jni-rs/blob/master/CONTRIBUTING.md#tests)
- [x] The [coding guidelines](https://github.com/jni-rs/jni-rs/blob/master/CONTRIBUTING.md#the-code-style) are followed
- [x] Public API has documentation
- [x] This change is not breaking **or** mentioned in the Changelog
- [x] The [continuous integration build](https://www.travis-ci.org/jni-rs/jni-rs) passes
