### PR TITLE
Fix clippy issues [ECR-2284]

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,6 @@
 #![warn(missing_docs)]
+// TODO: fix `catch!` macro (see issue #132)
+#![cfg_attr(feature = "cargo-clippy", allow(redundant_closure_call))]
 
 //! # Safe JNI Bindings in Rust
 //!

--- a/src/wrapper/jnienv.rs
+++ b/src/wrapper/jnienv.rs
@@ -444,9 +444,9 @@ impl<'a> JNIEnv<'a> {
                 &ErrorKind::NullPtr(_) => {
                     let name: String = ffi_name.into();
                     let sig: String = sig.into();
-                    return Err(ErrorKind::MethodNotFound(name, sig).into());
+                    Err(ErrorKind::MethodNotFound(name, sig).into())
                 }
-                _ => return Err(e),
+                _ => Err(e),
             },
         }
     }
@@ -538,9 +538,9 @@ impl<'a> JNIEnv<'a> {
                 &ErrorKind::NullPtr(_) => {
                     let name: String = ffi_name.into();
                     let sig: String = ffi_sig.into();
-                    return Err(ErrorKind::FieldNotFound(name, sig).into());
+                    Err(ErrorKind::FieldNotFound(name, sig).into())
                 }
-                _ => return Err(e),
+                _ => Err(e),
             },
         }
     }
@@ -582,9 +582,9 @@ impl<'a> JNIEnv<'a> {
                 &ErrorKind::NullPtr(_) => {
                     let name: String = ffi_name.into();
                     let sig: String = ffi_sig.into();
-                    return Err(ErrorKind::FieldNotFound(name, sig).into());
+                    Err(ErrorKind::FieldNotFound(name, sig).into())
                 }
-                _ => return Err(e),
+                _ => Err(e),
             },
         }
     }
@@ -830,9 +830,7 @@ impl<'a> JNIEnv<'a> {
 
         let class = self.auto_local(self.get_object_class(obj)?.into());
 
-        let res = unsafe { self.call_method_unsafe(obj, (&class, name, sig), parsed.ret, args) };
-
-        res
+        unsafe { self.call_method_unsafe(obj, (&class, name, sig), parsed.ret, args) }
     }
 
     /// Calls a static method safely. This comes with a number of
@@ -1603,9 +1601,7 @@ impl<'a> JNIEnv<'a> {
 
         let class = self.auto_local(self.get_object_class(obj)?.into());
 
-        let res = unsafe { self.set_field_unsafe(obj, (&class, name, ty), val) };
-
-        res
+        unsafe { self.set_field_unsafe(obj, (&class, name, ty), val) }
     }
 
     /// Get a static field without checking the provided type against the actual

--- a/src/wrapper/macros.rs
+++ b/src/wrapper/macros.rs
@@ -54,8 +54,7 @@ macro_rules! jni_void_call {
 macro_rules! jni_unchecked {
     ( $jnienv:expr, $name:tt $(, $args:expr )* ) => ({
         trace!("calling unchecked jni method: {}", stringify!($name));
-        let res = jni_method!($jnienv, $name)($jnienv, $($args),*);
-        res
+        jni_method!($jnienv, $name)($jnienv, $($args),*)
     })
 }
 
@@ -105,8 +104,7 @@ macro_rules! catch {
 macro_rules! java_vm_unchecked {
     ( $java_vm:expr, $name:tt $(, $args:expr )* ) => ({
         trace!("calling unchecked JavaVM method: {}", stringify!($name));
-        let res = java_vm_method!($java_vm, $name)($java_vm, $($args),*);
-        res
+        java_vm_method!($java_vm, $name)($java_vm, $($args),*)
     })
 }
 

--- a/src/wrapper/objects/auto_local.rs
+++ b/src/wrapper/objects/auto_local.rs
@@ -29,7 +29,7 @@ impl<'a> AutoLocal<'a> {
     /// called on the object. While wrapped, the object can be accessed via
     /// the `Deref` impl.
     pub fn new(env: &'a JNIEnv<'a>, obj: JObject<'a>) -> Self {
-        AutoLocal { obj: obj, env: env }
+        AutoLocal { obj, env }
     }
 
     /// Forget the wrapper, returning the original object.

--- a/src/wrapper/objects/global_ref.rs
+++ b/src/wrapper/objects/global_ref.rs
@@ -60,7 +60,7 @@ impl GlobalRef {
     ///
     /// This borrows the ref and prevents it from being dropped as long as the
     /// JObject sticks around.
-    pub fn as_obj(& self) -> JObject {
+    pub fn as_obj(&self) -> JObject {
         self.inner.as_obj()
     }
 }

--- a/src/wrapper/objects/global_ref.rs
+++ b/src/wrapper/objects/global_ref.rs
@@ -60,7 +60,7 @@ impl GlobalRef {
     ///
     /// This borrows the ref and prevents it from being dropped as long as the
     /// JObject sticks around.
-    pub fn as_obj<'a>(&'a self) -> JObject<'a> {
+    pub fn as_obj(& self) -> JObject {
         self.inner.as_obj()
     }
 }

--- a/src/wrapper/objects/global_ref.rs
+++ b/src/wrapper/objects/global_ref.rs
@@ -80,7 +80,7 @@ impl GlobalRefGuard {
     ///
     /// This borrows the ref and prevents it from being dropped as long as the
     /// JObject sticks around.
-    pub fn as_obj<'a>(&'a self) -> JObject<'a> {
+    pub fn as_obj(&self) -> JObject {
         self.obj
     }
 }

--- a/src/wrapper/objects/jlist.rs
+++ b/src/wrapper/objects/jlist.rs
@@ -54,12 +54,12 @@ impl<'a> JList<'a> {
 
         Ok(JList {
             internal: obj,
-            get: get,
-            add: add,
-            add_idx: add_idx,
-            remove: remove,
-            size: size,
-            env: env,
+            get,
+            add,
+            add_idx,
+            remove,
+            size,
+            env,
         })
     }
 
@@ -168,8 +168,8 @@ impl<'a> JList<'a> {
 
         match result {
             Ok(val) => Ok(Some(val.l()?)),
-            Err(e) => match e.kind() {
-                &ErrorKind::NullPtr(_) => Ok(None),
+            Err(e) => match *e.kind() {
+                ErrorKind::NullPtr(_) => Ok(None),
                 _ => Err(e),
             },
         }

--- a/src/wrapper/objects/jlist.rs
+++ b/src/wrapper/objects/jlist.rs
@@ -77,8 +77,8 @@ impl<'a> JList<'a> {
 
         match result {
             Ok(val) => Ok(Some(val.l()?)),
-            Err(e) => match e.kind() {
-                &ErrorKind::NullPtr(_) => Ok(None),
+            Err(e) => match *e.kind() {
+                ErrorKind::NullPtr(_) => Ok(None),
                 _ => Err(e),
             },
         }
@@ -127,8 +127,8 @@ impl<'a> JList<'a> {
 
         match result {
             Ok(val) => Ok(Some(val.l()?)),
-            Err(e) => match e.kind() {
-                &ErrorKind::NullPtr(_) => Ok(None),
+            Err(e) => match *e.kind() {
+                ErrorKind::NullPtr(_) => Ok(None),
                 _ => Err(e),
             },
         }

--- a/src/wrapper/objects/jmap.rs
+++ b/src/wrapper/objects/jmap.rs
@@ -56,11 +56,11 @@ impl<'a> JMap<'a> {
 
         Ok(JMap {
             internal: obj,
-            class: class,
-            get: get,
-            put: put,
-            remove: remove,
-            env: env,
+            class,
+            get,
+            put,
+            remove,
+            env,
         })
     }
 
@@ -167,11 +167,11 @@ impl<'a> JMap<'a> {
 
         Ok(JMapIter {
             map: &self,
-            has_next: has_next,
-            next: next,
-            get_key: get_key,
-            get_value: get_value,
-            iter: iter,
+            has_next,
+            next,
+            get_key,
+            get_value,
+            iter,
         })
     }
 }

--- a/src/wrapper/objects/jmap.rs
+++ b/src/wrapper/objects/jmap.rs
@@ -78,8 +78,8 @@ impl<'a> JMap<'a> {
 
         match result {
             Ok(val) => Ok(Some(val.l()?)),
-            Err(e) => match e.kind() {
-                &ErrorKind::NullPtr(_) => Ok(None),
+            Err(e) => match *e.kind() {
+                ErrorKind::NullPtr(_) => Ok(None),
                 _ => Err(e),
             },
         }
@@ -99,8 +99,8 @@ impl<'a> JMap<'a> {
 
         match result {
             Ok(val) => Ok(Some(val.l()?)),
-            Err(e) => match e.kind() {
-                &ErrorKind::NullPtr(_) => Ok(None),
+            Err(e) => match *e.kind() {
+                ErrorKind::NullPtr(_) => Ok(None),
                 _ => Err(e),
             },
         }
@@ -120,8 +120,8 @@ impl<'a> JMap<'a> {
 
         match result {
             Ok(val) => Ok(Some(val.l()?)),
-            Err(e) => match e.kind() {
-                &ErrorKind::NullPtr(_) => Ok(None),
+            Err(e) => match *e.kind() {
+                ErrorKind::NullPtr(_) => Ok(None),
                 _ => Err(e),
             },
         }

--- a/src/wrapper/signature.rs
+++ b/src/wrapper/signature.rs
@@ -94,7 +94,7 @@ impl TypeSignature {
 impl ::std::fmt::Display for TypeSignature {
     fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
         write!(f, "(")?;
-        for a in self.args.iter() {
+        for a in &self.args {
             write!(f, "{}", a)?;
         }
         write!(f, ")")?;
@@ -103,7 +103,7 @@ impl ::std::fmt::Display for TypeSignature {
     }
 }
 
-fn parse_primitive<S: Stream<Item = char>>(input: &mut S) -> ParseResult<JavaType, S> 
+fn parse_primitive<S: Stream<Item = char>>(input: &mut S) -> ParseResult<JavaType, S>
     where S::Error: ParseError<char, S::Range, S::Position>
 {
     let boolean = token('Z').map(|_| Primitive::Boolean);
@@ -125,11 +125,11 @@ fn parse_primitive<S: Stream<Item = char>>(input: &mut S) -> ParseResult<JavaTyp
         .or(long)
         .or(short)
         .or(void))
-        .map(|ty| JavaType::Primitive(ty))
+        .map(JavaType::Primitive)
         .parse_stream(input)
 }
 
-fn parse_array<S: Stream<Item = char>>(input: &mut S) -> ParseResult<JavaType, S> 
+fn parse_array<S: Stream<Item = char>>(input: &mut S) -> ParseResult<JavaType, S>
     where S::Error: ParseError<char, S::Range, S::Position>
 {
     let marker = token('[');
@@ -138,17 +138,17 @@ fn parse_array<S: Stream<Item = char>>(input: &mut S) -> ParseResult<JavaType, S
         .parse_stream(input)
 }
 
-fn parse_object<S: Stream<Item = char>>(input: &mut S) -> ParseResult<JavaType, S> 
+fn parse_object<S: Stream<Item = char>>(input: &mut S) -> ParseResult<JavaType, S>
     where S::Error: ParseError<char, S::Range, S::Position>
 {
     let marker = token('L');
     let end = token(';');
     let obj = between(marker, end, many1(satisfy(|c| c != ';')));
 
-    obj.map(|name| JavaType::Object(name)).parse_stream(input)
+    obj.map(JavaType::Object).parse_stream(input)
 }
 
-fn parse_type<S: Stream<Item = char>>(input: &mut S) -> ParseResult<JavaType, S> 
+fn parse_type<S: Stream<Item = char>>(input: &mut S) -> ParseResult<JavaType, S>
     where S::Error: ParseError<char, S::Range, S::Position>
 {
     parser(parse_primitive)
@@ -158,13 +158,13 @@ fn parse_type<S: Stream<Item = char>>(input: &mut S) -> ParseResult<JavaType, S>
         .parse_stream(input)
 }
 
-fn parse_args<S: Stream<Item = char>>(input: &mut S) -> ParseResult<Vec<JavaType>, S> 
+fn parse_args<S: Stream<Item = char>>(input: &mut S) -> ParseResult<Vec<JavaType>, S>
     where S::Error: ParseError<char, S::Range, S::Position>
 {
     between(token('('), token(')'), many(parser(parse_type))).parse_stream(input)
 }
 
-fn parse_sig<S: Stream<Item = char>>(input: &mut S) -> ParseResult<JavaType, S> 
+fn parse_sig<S: Stream<Item = char>>(input: &mut S) -> ParseResult<JavaType, S>
     where S::Error: ParseError<char, S::Range, S::Position>
 {
     (parser(parse_args), parser(parse_type))

--- a/src/wrapper/strings/ffi_str.rs
+++ b/src/wrapper/strings/ffi_str.rs
@@ -59,7 +59,7 @@ impl<'a> From<&'a JNIStr> for Cow<'a, str> {
             Ok(s) => s,
             Err(e) => {
                 debug!("error decoding java cesu8: {:#?}", e);
-                String::from_utf8_lossy(bytes).into()
+                String::from_utf8_lossy(bytes)
             }
         }
     }

--- a/src/wrapper/strings/java_str.rs
+++ b/src/wrapper/strings/java_str.rs
@@ -27,8 +27,8 @@ impl<'a> JavaStr<'a> {
         let ptr = unsafe { env.get_string_utf_chars(obj)? };
         let java_str = JavaStr {
             internal: ptr,
-            env: env,
-            obj: obj,
+            env,
+            obj,
         };
         Ok(java_str)
     }


### PR DESCRIPTION
## Overview

Fixed a lot of trivial clippy issues. A couple of them are remaining though:
```
cat clippy_log| grep warning | sort | uniq -c
      2 warning: defining a method called `from_str` on this type; consider implementing the `std::str::FromStr` trait or choosing a less ambiguous name
      2 warning: transmute from a reference to a reference
```

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Change is covered by automated [tests](https://github.com/jni-rs/jni-rs/blob/master/CONTRIBUTING.md#tests)
- [x] The [coding guidelines](https://github.com/jni-rs/jni-rs/blob/master/CONTRIBUTING.md#the-code-style) are followed
- [x] Public API has documentation
- [x] This change is not breaking **or** mentioned in the Changelog
- [x] The [continuous integration build](https://www.travis-ci.org/jni-rs/jni-rs) passes
