### PR TITLE
Fixed the issue with early detaching of a thread by nested AttachGuard.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,8 @@ to call if there is a pending exception (#124):
   to be non-null.
   - Rename `jni_non_null_call` (which may return nulls) to `jni_non_void_call`.
 
-- Fixed the issue with early detaching of a thread by nested AttachGuard. (#139)
+### Fixed
+- The issue with early detaching of a thread by nested AttachGuard. (#139)
 
 ## [0.10.2]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ to call if there is a pending exception (#124):
   to be non-null.
   - Rename `jni_non_null_call` (which may return nulls) to `jni_non_void_call`.
 
+- Fixed the issue with early detaching of a thread by nested AttachGuard.
 
 ## [0.10.2]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,7 @@ to call if there is a pending exception (#124):
   to be non-null.
   - Rename `jni_non_null_call` (which may return nulls) to `jni_non_void_call`.
 
-- Fixed the issue with early detaching of a thread by nested AttachGuard.
+- Fixed the issue with early detaching of a thread by nested AttachGuard. (#139)
 
 ## [0.10.2]
 

--- a/src/wrapper/java_vm/vm.rs
+++ b/src/wrapper/java_vm/vm.rs
@@ -51,7 +51,7 @@ impl JavaVM {
 
     /// Attaches the current thread to a Java VM. The resulting `AttachGuard`
     /// can be dereferenced to a `JNIEnv` and automatically detaches the thread
-    /// when dropped.
+    /// when dropped. Calling this for a thread that is already attached is a no-op.
     pub fn attach_current_thread(&self) -> Result<AttachGuard> {
         let (env, requires_detach) = match self.get_env() {
             Ok(env) => (env, false),
@@ -134,7 +134,7 @@ impl<'a> Deref for AttachGuard<'a> {
 impl<'a> Drop for AttachGuard<'a> {
     fn drop(&mut self) {
         if let Err(e) = self.detach() {
-            debug!("error detaching current thread: {:#?}", e);
+            warn!("Error detaching current thread: {:#?}", e);
         }
     }
 }

--- a/tests/vm.rs
+++ b/tests/vm.rs
@@ -1,0 +1,33 @@
+#![cfg(feature = "invocation")]
+extern crate error_chain;
+extern crate jni;
+
+use jni::{
+    objects::JValue,
+    sys::jint,
+};
+
+mod util;
+use util::attach_current_thread;
+
+#[test]
+pub fn nested_attach_guard_should_not_detach_thread() {
+    let env = attach_current_thread();
+    let val = env.call_static_method("java/lang/Math", "abs", "(I)I", &[JValue::from(-1 as jint)])
+        .unwrap().i().unwrap();
+    assert_eq!(val, 1);
+
+    // create nested AttachGuard
+    {
+        let env_nested = attach_current_thread();
+        let val = env_nested
+            .call_static_method("java/lang/Math", "abs", "(I)I", &[JValue::from(-2 as jint)])
+            .unwrap().i().unwrap();
+        assert_eq!(val, 2);
+    }
+
+    // attach after nested guard has been dropped -> check that thread has not been detached
+    let val = env.call_static_method("java/lang/Math", "abs", "(I)I", &[JValue::from(-3 as jint)])
+        .unwrap().i().unwrap();
+    assert_eq!(val, 3);
+}

--- a/tests/vm.rs
+++ b/tests/vm.rs
@@ -17,7 +17,7 @@ pub fn nested_attach_guard_should_not_detach_thread() {
         .unwrap().i().unwrap();
     assert_eq!(val, 1);
 
-    // create nested AttachGuard
+    // Create nested AttachGuard.
     {
         let env_nested = attach_current_thread();
         let val = env_nested
@@ -26,7 +26,8 @@ pub fn nested_attach_guard_should_not_detach_thread() {
         assert_eq!(val, 2);
     }
 
-    // attach after nested guard has been dropped -> check that thread has not been detached
+    // Call a Java method after nested guard has been dropped to check that 
+    // this thread has not been detached.
     let val = env.call_static_method("java/lang/Math", "abs", "(I)I", &[JValue::from(-3 as jint)])
         .unwrap().i().unwrap();
     assert_eq!(val, 3);


### PR DESCRIPTION
## Overview

The current implementation of AttachGuard detaches thread unconditionally which can lead to the issue with early thread detach in case of nested AttachGuard. Fixed it by adding checking for the state of the current thread before attaching it to JVM.

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Change is covered by automated [tests](https://github.com/jni-rs/jni-rs/blob/master/CONTRIBUTING.md#tests)
- [x] The [coding guidelines](https://github.com/jni-rs/jni-rs/blob/master/CONTRIBUTING.md#the-code-style) are followed
- [x] Public API has documentation
- [x] This change is not breaking **or** mentioned in the Changelog
- [x] The [continuous integration build](https://www.travis-ci.org/jni-rs/jni-rs) passes
