### PR TITLE
Implemented Sync for GlobalRef

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,8 @@ to call if there is a pending exception (#124):
 
 - `from_str` method of the `JavaType` has been replaced by the `FromStr`
   implementation
+  
+- Implemented Sync for GlobalRef (#102).
 
 ### Fixed
 - The issue with early detaching of a thread by nested AttachGuard. (#139)

--- a/src/wrapper/objects/global_ref.rs
+++ b/src/wrapper/objects/global_ref.rs
@@ -38,6 +38,7 @@ struct GlobalRefGuard {
 
 
 unsafe impl Send for GlobalRef {}
+unsafe impl Sync for GlobalRef {}
 
 
 impl<'a> From<&'a GlobalRef> for JObject<'a> {


### PR DESCRIPTION
## Overview

Implemented the Sync trait (in addition to already implemented Send) for GlobalRef.
Fixes #102.

### Definition of Done

- [x] There are no TODOs left in the code
- [x] The [coding guidelines](https://github.com/jni-rs/jni-rs/blob/master/CONTRIBUTING.md#the-code-style) are followed
- [x] This change is not breaking **or** mentioned in the Changelog
- [x] The [continuous integration build](https://www.travis-ci.org/jni-rs/jni-rs) passes
