### PR TITLE
Implemented Clone for JNIEnv.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,8 @@ to call if there is a pending exception (#124):
   - `call_static_method_unsafe` and `get_static_field_unsafe` methods are allowed to return NULL object.
   - Added checking for pending exception to the `call_static_method_unsafe` method (eliminated WARNING messages in log). 
 
+- Implemented Clone for JNIEnv (#147).
+
 ### Fixed
 - The issue with early detaching of a thread by nested AttachGuard. (#139)
 

--- a/src/wrapper/jnienv.rs
+++ b/src/wrapper/jnienv.rs
@@ -79,6 +79,7 @@ use JavaVM;
 /// argument is passed to a method or when a null would be returned. Where
 /// applicable, the null error is changed to a more applicable error type, such
 /// as `MethodNotFound`.
+#[derive(Clone)]
 #[repr(C)]
 pub struct JNIEnv<'a> {
     internal: *mut sys::JNIEnv,


### PR DESCRIPTION
## Overview

JNIEnv derives Clone now.

### Definition of Done

- [x] There are no TODOs left in the code
- [x] The [coding guidelines](https://github.com/jni-rs/jni-rs/blob/master/CONTRIBUTING.md#the-code-style) are followed
- [x] Public API has documentation
- [x] This change is not breaking **or** mentioned in the Changelog
- [x] The [continuous integration build](https://www.travis-ci.org/jni-rs/jni-rs) passes
