### PR TITLE
Further improvements of macro usage for JNI calls 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,11 +42,17 @@ to call if there is a pending exception (#124):
 
 - Implemented Sync for GlobalRef (#102).
 
-- Improvements in macro usage for JNI methods calls. (#136):
+- Improvements in macro usage for JNI methods calls (#136):
   - `call_static_method_unchecked` and `get_static_field_unchecked` methods are 
   allowed to return NULL object
   - Added checking for pending exception to the `call_static_method_unchecked` 
   method (eliminated WARNING messages in log)
+  
+-  Further improvements in macro usage for JNI method calls (#150):
+  - The new_global_ref() and new_local_ref() functions are allowed to work with NULL objects according to specification.
+  - Fixed the family of functions new_direct_byte_buffer(), get_direct_buffer_address() and get_direct_buffer_capacity()
+   by adding checking for null and error codes.
+  - Increased tests coverage for JNIEnv functions.
 
 - Implemented Clone for JNIEnv (#147).
 

--- a/src/wrapper/jnienv.rs
+++ b/src/wrapper/jnienv.rs
@@ -1081,12 +1081,6 @@ impl<'a> JNIEnv<'a> {
         Ok(vec)
     }
 
-    // NB: Oracle doc states that the family of New<PrimitiveType>Array routines does not throw any
-    // exception but just return NULL in case of error. In fact, if one calls any of this functions
-    // with negative value as an argument for the length of array it ends up with the pending
-    // java.lang.NegativeArraySizeException exception. That's why we use macro that checks for
-    // exceptions and NULL.
-    // ??? Wouldn't it be more optimal to check for negative argument before calling managed code???
     /// Create a new java boolean array of supplied length.
     pub fn new_boolean_array(&self, length: jsize) -> Result<jbooleanArray> {
         let array: jbooleanArray = jni_non_null_call!(self.internal, NewBooleanArray, length);

--- a/src/wrapper/jnienv.rs
+++ b/src/wrapper/jnienv.rs
@@ -286,8 +286,10 @@ impl<'a> JNIEnv<'a> {
     /// Returns the starting address of the memory of the direct
     /// java.nio.ByteBuffer.
     pub fn get_direct_buffer_address(&self, buf: JByteBuffer) -> Result<&mut [u8]> {
+        non_null!(buf, "get_direct_buffer_address argument");
         let ptr: *mut c_void =
             unsafe { jni_unchecked!(self.internal, GetDirectBufferAddress, buf.into_inner()) };
+        non_null!(ptr, "get_direct_buffer_address return value");
         let capacity = self.get_direct_buffer_capacity(buf)?;
         unsafe { Ok(slice::from_raw_parts_mut(ptr as *mut u8, capacity as usize)) }
     }

--- a/src/wrapper/jnienv.rs
+++ b/src/wrapper/jnienv.rs
@@ -274,14 +274,12 @@ impl<'a> JNIEnv<'a> {
 
     /// Create a new instance of a direct java.nio.ByteBuffer.
     pub fn new_direct_byte_buffer(&self, data: &mut [u8]) -> Result<JByteBuffer> {
-        let obj = unsafe {
-            jni_unchecked!(
-                self.internal,
-                NewDirectByteBuffer,
-                data.as_mut_ptr() as *mut c_void,
-                data.len() as jlong
-            )
-        };
+        let obj: JObject = jni_non_null_call!(
+            self.internal,
+            NewDirectByteBuffer,
+            data.as_mut_ptr() as *mut c_void,
+            data.len() as jlong
+        );
         Ok(JByteBuffer::from(obj))
     }
 

--- a/src/wrapper/jnienv.rs
+++ b/src/wrapper/jnienv.rs
@@ -170,8 +170,7 @@ impl<'a> JNIEnv<'a> {
         T: Desc<'a, JClass<'a>>,
     {
         let class = class.lookup(self)?;
-        // GetSuperclass may return NULL for "java/lang/Object" and this is expected behavior
-        Ok(jni_non_void_call!(self.internal, GetSuperclass, class.into_inner()).into())
+        Ok(jni_non_null_call!(self.internal, GetSuperclass, class.into_inner()))
     }
 
     /// Tests whether class1 is assignable from class2.

--- a/src/wrapper/jnienv.rs
+++ b/src/wrapper/jnienv.rs
@@ -1090,7 +1090,6 @@ impl<'a> JNIEnv<'a> {
             length,
             vec.as_mut_ptr() as *mut i8
         );
-        check_exception!(self.internal);
         Ok(vec)
     }
 

--- a/src/wrapper/jnienv.rs
+++ b/src/wrapper/jnienv.rs
@@ -1081,6 +1081,12 @@ impl<'a> JNIEnv<'a> {
         Ok(vec)
     }
 
+    // NB: Oracle doc states that the family of New<PrimitiveType>Array routines does not throw any
+    // exception but just return NULL in case of error. In fact, if one calls any of this functions
+    // with negative value as an argument for the length of array it ends up with the pending
+    // java.lang.NegativeArraySizeException exception. That's why we use macro that checks for
+    // exceptions and NULL.
+    // ??? Wouldn't it be more optimal to check for negative argument before calling managed code???
     /// Create a new java boolean array of supplied length.
     pub fn new_boolean_array(&self, length: jsize) -> Result<jbooleanArray> {
         let array: jbooleanArray = jni_non_null_call!(self.internal, NewBooleanArray, length);

--- a/src/wrapper/jnienv.rs
+++ b/src/wrapper/jnienv.rs
@@ -144,7 +144,8 @@ impl<'a> JNIEnv<'a> {
         T: Desc<'a, JClass<'a>>,
     {
         let class = class.lookup(self)?;
-        Ok(jni_non_null_call!(self.internal, GetSuperclass, class.into_inner()))
+        // GetSuperclass may return NULL for "java/lang/Object" and this is expected behavior
+        Ok(jni_non_void_call!(self.internal, GetSuperclass, class.into_inner()).into())
     }
 
     /// Tests whether class1 is assignable from class2.

--- a/src/wrapper/jnienv.rs
+++ b/src/wrapper/jnienv.rs
@@ -330,12 +330,8 @@ impl<'a> JNIEnv<'a> {
     /// releases the GC pin upon being dropped.
     pub fn new_global_ref(&self, obj: JObject) -> Result<GlobalRef> {
         let new_ref: JObject = jni_unchecked!(self.internal, NewGlobalRef, obj.into_inner()).into();
-        if !new_ref.is_null() {
-            let global = unsafe { GlobalRef::from_raw(self.get_java_vm()?, new_ref.into_inner()) };
-            Ok(global)
-        } else {
-            Err(ErrorKind::NullPtr("new_global_ref").into())
-        }
+        let global = unsafe { GlobalRef::from_raw(self.get_java_vm()?, new_ref.into_inner()) };
+        Ok(global)
     }
 
     /// Create a new local ref to an object.

--- a/src/wrapper/jnienv.rs
+++ b/src/wrapper/jnienv.rs
@@ -296,7 +296,10 @@ impl<'a> JNIEnv<'a> {
     pub fn get_direct_buffer_capacity(&self, buf: JByteBuffer) -> Result<jlong> {
         let capacity =
             unsafe { jni_unchecked!(self.internal, GetDirectBufferCapacity, buf.into_inner()) };
-        Ok(capacity)
+        match capacity {
+            -1 => Err(Error::from(ErrorKind::Other(sys::JNI_ERR))),
+            _ => Ok(capacity),
+        }
     }
 
     /// Turns an object into a global ref. This has the benefit of removing the

--- a/src/wrapper/jnienv.rs
+++ b/src/wrapper/jnienv.rs
@@ -1068,15 +1068,17 @@ impl<'a> JNIEnv<'a> {
         non_null!(array, "convert_byte_array array argument");
         let length = jni_non_void_call!(self.internal, GetArrayLength, array);
         let mut vec = vec![0u8; length as usize];
-        jni_void_call!(
-            self.internal,
-            GetByteArrayRegion,
-            array,
-            0,
-            length,
-            vec.as_mut_ptr() as *mut i8
-        );
-
+        unsafe {
+            jni_unchecked!(
+                self.internal,
+                GetByteArrayRegion,
+                array,
+                0,
+                length,
+                vec.as_mut_ptr() as *mut i8
+            );
+        }
+        check_exception!(self.internal);
         Ok(vec)
     }
 

--- a/src/wrapper/jnienv.rs
+++ b/src/wrapper/jnienv.rs
@@ -610,7 +610,7 @@ impl<'a> JNIEnv<'a> {
     /// Get the class for an object.
     pub fn get_object_class(&self, obj: JObject) -> Result<JClass<'a>> {
         non_null!(obj, "get_object_class");
-        Ok(unsafe { jni_unchecked!(self.internal, GetObjectClass, obj.into_inner()).into() })
+        Ok(jni_unchecked!(self.internal, GetObjectClass, obj.into_inner()).into())
     }
 
     /// Call a static method in an unsafe manner. This does nothing to check

--- a/src/wrapper/jnienv.rs
+++ b/src/wrapper/jnienv.rs
@@ -1068,17 +1068,15 @@ impl<'a> JNIEnv<'a> {
         non_null!(array, "convert_byte_array array argument");
         let length = jni_non_void_call!(self.internal, GetArrayLength, array);
         let mut vec = vec![0u8; length as usize];
-        unsafe {
-            jni_unchecked!(
-                self.internal,
-                GetByteArrayRegion,
-                array,
-                0,
-                length,
-                vec.as_mut_ptr() as *mut i8
-            );
-        }
-        check_exception!(self.internal);
+        jni_void_call!(
+            self.internal,
+            GetByteArrayRegion,
+            array,
+            0,
+            length,
+            vec.as_mut_ptr() as *mut i8
+        );
+
         Ok(vec)
     }
 

--- a/tests/jni_api.rs
+++ b/tests/jni_api.rs
@@ -403,8 +403,8 @@ fn get_super_class_ok() {
 #[test]
 fn get_super_class_null() {
     let env = attach_current_thread();
-    let class = env.get_superclass("java/lang/Object").unwrap();
-    assert!(class.is_null());
+    let result = env.get_superclass("java/lang/Object");
+    assert!(result.is_err());
 }
 
 #[test]
@@ -432,4 +432,3 @@ fn assert_pending_java_exception(env: &JNIEnv) {
     assert!(env.exception_check().unwrap());
     env.exception_clear().unwrap();
 }
-

--- a/tests/jni_api.rs
+++ b/tests/jni_api.rs
@@ -395,6 +395,17 @@ fn get_super_class_wrong() {
     assert_pending_java_exception(&env);
 }
 
+#[test]
+fn convert_byte_array() {
+    let env = attach_current_thread();
+    let src: Vec<u8> = vec![1, 2, 3, 4];
+    let java_byte_array = env.byte_array_from_slice(&src).unwrap();
+
+    let dest = env.convert_byte_array(java_byte_array);
+    assert!(dest.is_ok());
+    assert_eq!(dest.unwrap(), src);
+}
+
 // Helper method that asserts that result is Error and the cause is JavaException.
 fn assert_exception(res: Result<jobject, Error>, expect_message: &str) {
     assert!(res.is_err());

--- a/tests/jni_api.rs
+++ b/tests/jni_api.rs
@@ -432,6 +432,14 @@ fn local_ref_null() {
     assert!(result.is_ok());
 }
 
+#[test]
+fn new_global_ref_null() {
+    let env = attach_current_thread();
+    let null_obj = JObject::null();
+    let result = env.new_global_ref(null_obj);
+    assert!(result.is_err());
+}
+
 // Helper method that asserts that result is Error and the cause is JavaException.
 fn assert_exception(res: Result<jobject, Error>, expect_message: &str) {
     assert!(res.is_err());

--- a/tests/jni_api.rs
+++ b/tests/jni_api.rs
@@ -228,3 +228,13 @@ pub fn get_object_class_null_arg() {
     }).expect_err("JNIEnv#get_object_class should return error for null argument");
     assert!(result, "ErrorKind::NullPtr expected as error");
 }
+
+#[test]
+pub fn new_direct_byte_buffer() {
+    let env = attach_current_thread();
+    let mut vec: Vec<u8> = vec![0, 1, 2, 3];
+    let buf = vec.as_mut_slice();
+    let result = env.new_direct_byte_buffer(buf);
+    assert!(result.is_ok());
+    assert!(!result.unwrap().is_null());
+}

--- a/tests/jni_api.rs
+++ b/tests/jni_api.rs
@@ -5,7 +5,7 @@ extern crate jni;
 
 use jni::{
     errors::{Error, ErrorKind},
-    objects::{AutoLocal, JObject, JValue},
+    objects::{AutoLocal, JByteBuffer, JObject, JValue},
     sys::{jint, jobject, jsize},
     JNIEnv,
 };
@@ -253,7 +253,8 @@ pub fn get_direct_buffer_capacity_ok() {
 #[test]
 pub fn get_direct_buffer_capacity_wrong_arg() {
     let env = attach_current_thread();
-    let capacity = env.get_direct_buffer_capacity(JObject::null().into());
+    let wrong_obj = JByteBuffer::from(env.new_string("wrong").unwrap().into_inner());
+    let capacity = env.get_direct_buffer_capacity(wrong_obj);
     assert!(capacity.is_err());
 }
 
@@ -331,47 +332,47 @@ pub fn new_primitive_array_wrong() {
 
     let result = env.new_boolean_array(WRONG_SIZE);
     assert!(result.is_err());
-    assert_error(result, "JNIEnv#new_boolean_array should throw exception");
+    assert_exception(result, "JNIEnv#new_boolean_array should throw exception");
     assert_pending_java_exception(&env);
 
     let result = env.new_byte_array(WRONG_SIZE);
     assert!(result.is_err());
-    assert_error(result, "JNIEnv#new_byte_array should throw exception");
+    assert_exception(result, "JNIEnv#new_byte_array should throw exception");
     assert_pending_java_exception(&env);
 
     let result = env.new_char_array(WRONG_SIZE);
     assert!(result.is_err());
-    assert_error(result, "JNIEnv#new_char_array should throw exception");
+    assert_exception(result, "JNIEnv#new_char_array should throw exception");
     assert_pending_java_exception(&env);
 
     let result = env.new_short_array(WRONG_SIZE);
     assert!(result.is_err());
-    assert_error(result, "JNIEnv#new_short_array should throw exception");
+    assert_exception(result, "JNIEnv#new_short_array should throw exception");
     assert_pending_java_exception(&env);
 
     let result = env.new_int_array(WRONG_SIZE);
     assert!(result.is_err());
-    assert_error(result, "JNIEnv#new_int_array should throw exception");
+    assert_exception(result, "JNIEnv#new_int_array should throw exception");
     assert_pending_java_exception(&env);
 
     let result = env.new_long_array(WRONG_SIZE);
     assert!(result.is_err());
-    assert_error(result, "JNIEnv#new_long_array should throw exception");
+    assert_exception(result, "JNIEnv#new_long_array should throw exception");
     assert_pending_java_exception(&env);
 
     let result = env.new_float_array(WRONG_SIZE);
     assert!(result.is_err());
-    assert_error(result, "JNIEnv#new_float_array should throw exception");
+    assert_exception(result, "JNIEnv#new_float_array should throw exception");
     assert_pending_java_exception(&env);
 
     let result = env.new_double_array(WRONG_SIZE);
     assert!(result.is_err());
-    assert_error(result, "JNIEnv#new_double_array should throw exception");
+    assert_exception(result, "JNIEnv#new_double_array should throw exception");
     assert_pending_java_exception(&env);
 }
 
 // Helper method that asserts that result is Error and the cause is JavaException.
-fn assert_error(res: Result<jobject, Error>, expect_message: &str) {
+fn assert_exception(res: Result<jobject, Error>, expect_message: &str) {
     assert!(res.is_err());
     assert!(res.map_err(|error| match *error.kind() {
         ErrorKind::JavaException => true,

--- a/tests/jni_api.rs
+++ b/tests/jni_api.rs
@@ -387,15 +387,6 @@ fn get_super_class_null() {
 }
 
 #[test]
-fn get_super_class_wrong() {
-    let env = attach_current_thread();
-    // this triggers the "java.lang.ClassNotFoundException" (even if spec says it doesn't throw)
-    let result = env.get_superclass("");
-    assert!(result.is_err());
-    assert_pending_java_exception(&env);
-}
-
-#[test]
 fn convert_byte_array() {
     let env = attach_current_thread();
     let src: Vec<u8> = vec![1, 2, 3, 4];

--- a/tests/jni_api.rs
+++ b/tests/jni_api.rs
@@ -257,3 +257,30 @@ pub fn get_direct_buffer_capacity_wrong_arg() {
     let capacity = env.get_direct_buffer_capacity(JObject::null().into());
     assert!(capacity.is_err());
 }
+
+#[test]
+pub fn get_direct_buffer_address_ok() {
+    let env = attach_current_thread();
+    let mut vec: Vec<u8> = vec![0, 1, 2, 3];
+    let buf = vec.as_mut_slice();
+    let result = env.new_direct_byte_buffer(buf).unwrap();
+    assert!(!result.is_null());
+
+    let dest_buffer = env.get_direct_buffer_address(result).unwrap();
+    assert_eq!(buf, dest_buffer);
+}
+
+#[test]
+pub fn get_direct_buffer_address_wrong_arg() {
+    let env = attach_current_thread();
+    let wrong_obj: JObject = env.new_string("wrong").unwrap().into();
+    let result = env.get_direct_buffer_address(wrong_obj.into());
+    assert!(result.is_err());
+}
+
+#[test]
+pub fn get_direct_buffer_address_null_arg() {
+    let env = attach_current_thread();
+    let result = env.get_direct_buffer_address(JObject::null().into());
+    assert!(result.is_err());
+}

--- a/tests/jni_api.rs
+++ b/tests/jni_api.rs
@@ -371,6 +371,30 @@ pub fn new_primitive_array_wrong() {
     assert_pending_java_exception(&env);
 }
 
+#[test]
+fn get_super_class_ok() {
+    let env = attach_current_thread();
+    let result = env.get_superclass(ARRAYLIST_CLASS);
+    assert!(result.is_ok());
+    assert!(!result.unwrap().is_null());
+}
+
+#[test]
+fn get_super_class_null() {
+    let env = attach_current_thread();
+    let class = env.get_superclass("java/lang/Object").unwrap();
+    assert!(class.is_null());
+}
+
+#[test]
+fn get_super_class_wrong() {
+    let env = attach_current_thread();
+    // this triggers the "java.lang.ClassNotFoundException" (even if spec says it doesn't throw)
+    let result = env.get_superclass("");
+    assert!(result.is_err());
+    assert_pending_java_exception(&env);
+}
+
 // Helper method that asserts that result is Error and the cause is JavaException.
 fn assert_exception(res: Result<jobject, Error>, expect_message: &str) {
     assert!(res.is_err());
@@ -385,3 +409,4 @@ fn assert_pending_java_exception(env: &JNIEnv) {
     assert!(env.exception_check().unwrap());
     env.exception_clear().unwrap();
 }
+

--- a/tests/jni_api.rs
+++ b/tests/jni_api.rs
@@ -437,7 +437,19 @@ fn new_global_ref_null() {
     let env = attach_current_thread();
     let null_obj = JObject::null();
     let result = env.new_global_ref(null_obj);
-    assert!(result.is_err());
+    assert!(result.is_ok());
+    assert!(result.unwrap().as_obj().is_null());
+}
+
+#[test]
+fn auto_local_null() {
+    let env = attach_current_thread();
+    let null_obj = JObject::null();
+    {
+        let auto_ref = AutoLocal::new(&env, null_obj);
+        assert!(auto_ref.as_obj().is_null());
+    }
+    assert!(null_obj.is_null());
 }
 
 // Helper method that asserts that result is Error and the cause is JavaException.

--- a/tests/jni_api.rs
+++ b/tests/jni_api.rs
@@ -238,3 +238,22 @@ pub fn new_direct_byte_buffer() {
     assert!(result.is_ok());
     assert!(!result.unwrap().is_null());
 }
+
+#[test]
+pub fn get_direct_buffer_capacity_ok() {
+    let env = attach_current_thread();
+    let mut vec: Vec<u8> = vec![0, 1, 2, 3];
+    let buf = vec.as_mut_slice();
+    let result = env.new_direct_byte_buffer(buf).unwrap();
+    assert!(!result.is_null());
+
+    let capacity = env.get_direct_buffer_capacity(result).unwrap();
+    assert_eq!(capacity, 4);
+}
+
+#[test]
+pub fn get_direct_buffer_capacity_wrong_arg() {
+    let env = attach_current_thread();
+    let capacity = env.get_direct_buffer_capacity(JObject::null().into());
+    assert!(capacity.is_err());
+}

--- a/tests/jni_api.rs
+++ b/tests/jni_api.rs
@@ -5,7 +5,7 @@ extern crate jni;
 
 use std::str::FromStr;
 use jni::{
-    errors::ErrorKind,
+    errors::{Error, ErrorKind},
     objects::{AutoLocal, JByteBuffer, JObject, JValue},
     signature::JavaType,
     sys::{jint, jobject, jsize},

--- a/tests/jni_api.rs
+++ b/tests/jni_api.rs
@@ -418,6 +418,20 @@ fn convert_byte_array() {
     assert_eq!(dest.unwrap(), src);
 }
 
+#[test]
+fn local_ref_null() {
+    let env = attach_current_thread();
+    let null_obj = JObject::null();
+
+    let result = env.new_local_ref::<JObject>(null_obj);
+    assert!(result.is_ok());
+    assert!(result.unwrap().is_null());
+
+    // try to delete null reference
+    let result = env.delete_local_ref(null_obj);
+    assert!(result.is_ok());
+}
+
 // Helper method that asserts that result is Error and the cause is JavaException.
 fn assert_exception(res: Result<jobject, Error>, expect_message: &str) {
     assert!(res.is_err());


### PR DESCRIPTION
## Overview

Further inspection and improvements of the current implementation of methods that calls JNI functions. Fixes #141. 

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Change is covered by automated [tests](https://github.com/jni-rs/jni-rs/blob/master/CONTRIBUTING.md#tests)
- [x] The [coding guidelines](https://github.com/jni-rs/jni-rs/blob/master/CONTRIBUTING.md#the-code-style) are followed
- [x] Public API has documentation
- [ ] This change is not breaking **or** mentioned in the Changelog
- [x] The [continuous integration build](https://www.travis-ci.org/jni-rs/jni-rs) passes
