### PR TITLE
Recompile if JAVA_HOME changed

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -49,6 +49,7 @@ fn main() {
             println!("cargo:rustc-link-search={}", lib_path.display());
         }
 
+        println!("cargo:rerun-if-env-changed=JAVA_HOME");
         println!("cargo:rustc-link-lib=dylib=jvm");
     }
 }


### PR DESCRIPTION
## Overview

The compilation depends on the environment variable `JAVA_HOME`, so I think it's a good idea to recompile whenever `JAVA_HOME` changes.

### Definition of Done

- [x] There are no TODOs left in the code
- [ ] Change is covered by automated [tests](https://github.com/jni-rs/jni-rs/blob/master/CONTRIBUTING.md#tests)
- [x] The [coding guidelines](https://github.com/jni-rs/jni-rs/blob/master/CONTRIBUTING.md#the-code-style) are followed
- [x] Public API has documentation
- [x] This change is not breaking **or** mentioned in the Changelog
- [x] The [continuous integration build](https://www.travis-ci.org/jni-rs/jni-rs) passes
