### PR TITLE
Release 0.11.0 version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [0.11.0]
+
 ### Added
 - Invocation API support on Windows and AppVeyor CI (#149)
 
@@ -77,6 +79,7 @@ to call if there is a pending exception (#124):
 ## [0.10.1]
 - No changes has been made to the Changelog until this release.
 
-[Unreleased]: https://github.com/jni-rs/jni-rs/compare/v0.10.2...HEAD
+[Unreleased]: https://github.com/jni-rs/jni-rs/compare/v0.11.0...HEAD
+[0.11.0]: https://github.com/jni-rs/compare/v0.10.2...v0.11.0
 [0.10.2]: https://github.com/jni-rs/compare/v0.10.1...v0.10.2
 [0.10.1]: https://github.com/jni-rs/compare/v0.1...v0.10.1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ keywords = [
 license = "MIT/Apache-2.0"
 name = "jni"
 repository = "https://github.com/jni-rs/jni-rs"
-version = "0.10.2"
+version = "0.11.0"
 
 [dependencies]
 cesu8 = "1.1.0"


### PR DESCRIPTION
## Overview

Bump the crate version in order to make changes accessible by the crates.io users.

Closes #160.

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Change is covered by automated [tests](https://github.com/jni-rs/jni-rs/blob/master/CONTRIBUTING.md#tests)
- [x] The [coding guidelines](https://github.com/jni-rs/jni-rs/blob/master/CONTRIBUTING.md#the-code-style) are followed
- [x] Public API has documentation
- [x] This change is not breaking **or** mentioned in the Changelog
- [x] The [continuous integration build](https://www.travis-ci.org/jni-rs/jni-rs) passes
