### PR TITLE
Some methods are allowed to return NULL if not error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,9 @@ to call if there is a pending exception (#124):
 
 - Implemented Clone for JNIEnv (#147).
 
+- The get_superclass(), get_field_unchecked() and get_object_array_element() are allowed to return NULL object according
+ to the specification (#163). 
+
 ### Fixed
 - The issue with early detaching of a thread by nested AttachGuard. (#139)
 

--- a/src/wrapper/jnienv.rs
+++ b/src/wrapper/jnienv.rs
@@ -76,15 +76,17 @@ use JavaVM;
 /// will _not_ clear the exception - it's up to the caller to decide whether to
 /// do so or to let it continue being thrown.
 ///
-/// Handling null pointers is non-trivial. This may occur when either a null argument
-/// is passed to a method that requires non-null arguments or when a null would
-/// be returned. In the latter case method could return null as possible value
-/// (like `get_object_array_element`) or as indication of an error (e.g.
-/// `new_int_array` which never returns null if everything is OK). Only expected
-/// return values of null are converted to `JObject::null()`, in any other situation
-/// null pointers are converted to `Err` result with the kind `NullPtr`. Where
-/// applicable, the null error is changed to a more applicable error type, such
-/// as `MethodNotFound`.
+/// ## `null` Java references
+/// `null` Java references are handled by the following rules:
+///   - If a `null` Java reference is passed to a method that expects a non-`null` 
+///   argument, an `Err` result with the kind `NullPtr` is returned.
+///   - If a JNI function returns `null` to indicate an error (e.g. `new_int_array`),
+///     it is converted to `Err`/`NullPtr` or, where possible, to a more applicable 
+///     error type, such as `MethodNotFound`. If the JNI function also throws 
+///     an exception, the `JavaException` error kind will be preferred.
+///   - If a JNI function may return `null` Java reference as one of possible reference
+///     values (e.g., `get_object_array_element` or `get_field_unchecked`),
+///     it is converted to `JObject::null()`.
 ///
 /// # Checked and unchecked methods
 ///

--- a/src/wrapper/jnienv.rs
+++ b/src/wrapper/jnienv.rs
@@ -76,9 +76,13 @@ use JavaVM;
 /// will _not_ clear the exception - it's up to the caller to decide whether to
 /// do so or to let it continue being thrown.
 ///
-/// Because null pointers are a thing in Java, this also converts them to an
-/// `Err` result with the kind `NullPtr`. This may occur when either a null
-/// argument is passed to a method or when a null would be returned. Where
+/// Handling null pointers is non-trivial. This may occur when either a null argument
+/// is passed to a method that requires non-null arguments or when a null would
+/// be returned. In the latter case method could return null as possible value
+/// (like `get_object_array_element`) or as indication of an error (e.g.
+/// `new_int_array` which never returns null if everything is OK). Only expected
+/// return values of null are converted to `JObject::null()`, in any other situation
+/// null pointers are converted to `Err` result with the kind `NullPtr`. Where
 /// applicable, the null error is changed to a more applicable error type, such
 /// as `MethodNotFound`.
 ///

--- a/src/wrapper/jnienv.rs
+++ b/src/wrapper/jnienv.rs
@@ -167,8 +167,8 @@ impl<'a> JNIEnv<'a> {
         Ok(class)
     }
 
-    /// Get the superclass for a particular class. As with `find_class`, takes
-    /// a descriptor.
+    /// Returns the superclass for a particular class OR `JObject::null()` for `java.lang.Object` or
+    /// an interface. As with `find_class`, takes a descriptor.
     pub fn get_superclass<T>(&self, class: T) -> Result<JClass>
     where
         T: Desc<'a, JClass<'a>>,

--- a/src/wrapper/jnienv.rs
+++ b/src/wrapper/jnienv.rs
@@ -170,7 +170,7 @@ impl<'a> JNIEnv<'a> {
         T: Desc<'a, JClass<'a>>,
     {
         let class = class.lookup(self)?;
-        Ok(jni_non_null_call!(self.internal, GetSuperclass, class.into_inner()))
+        Ok(jni_non_void_call!(self.internal, GetSuperclass, class.into_inner()).into())
     }
 
     /// Tests whether class1 is assignable from class2.
@@ -1033,12 +1033,12 @@ impl<'a> JNIEnv<'a> {
     /// Returns an element of the `jobjectArray` array.
     pub fn get_object_array_element(&self, array: jobjectArray, index: jsize) -> Result<JObject> {
         non_null!(array, "get_object_array_element array argument");
-        Ok(jni_non_null_call!(
+        Ok(jni_non_void_call!(
             self.internal,
             GetObjectArrayElement,
             array,
             index
-        ))
+        ).into())
     }
 
     /// Sets an element of the `jobjectArray` array.
@@ -1465,7 +1465,7 @@ impl<'a> JNIEnv<'a> {
         // TODO clean this up
         Ok(match ty {
             JavaType::Object(_) | JavaType::Array(_) => {
-                let obj: JObject = jni_non_null_call!(self.internal, GetObjectField, obj, field);
+                let obj: JObject = jni_non_void_call!(self.internal, GetObjectField, obj, field).into();
                 obj.into()
             }
             // JavaType::Object

--- a/tests/jni_api.rs
+++ b/tests/jni_api.rs
@@ -20,6 +20,7 @@ static EXCEPTION_CLASS: &str = "java/lang/Exception";
 static ARITHMETIC_EXCEPTION_CLASS: &str = "java/lang/ArithmeticException";
 static INTEGER_CLASS: &str = "java/lang/Integer";
 static MATH_CLASS: &str = "java/lang/Math";
+static STRING_CLASS: &str = "java/lang/String";
 static MATH_ABS_METHOD_NAME: &str = "abs";
 static MATH_TO_INT_METHOD_NAME: &str = "toIntExact";
 static MATH_ABS_SIGNATURE: &str = "(I)I";
@@ -404,7 +405,8 @@ fn get_super_class_ok() {
 fn get_super_class_null() {
     let env = attach_current_thread();
     let result = env.get_superclass("java/lang/Object");
-    assert!(result.is_err());
+    assert!(result.is_ok());
+    assert!(result.unwrap().is_null());
 }
 
 #[test]
@@ -450,6 +452,17 @@ fn auto_local_null() {
         assert!(auto_ref.as_obj().is_null());
     }
     assert!(null_obj.is_null());
+}
+
+#[test]
+fn get_object_array_element() {
+    let env = attach_current_thread();
+    let array = env.new_object_array(1, STRING_CLASS, JObject::null()).unwrap();
+    assert!(!array.is_null());
+    assert!(env.get_object_array_element(array, 0).unwrap().is_null());
+    let test_str = env.new_string("test").unwrap();
+    env.set_object_array_element(array,0,test_str.into()).unwrap();
+    assert!(!env.get_object_array_element(array, 0).unwrap().is_null());
 }
 
 // Helper method that asserts that result is Error and the cause is JavaException.


### PR DESCRIPTION
## Overview

Some of JNI functions can return NULL as a possible value but current implementation treats this as an error. This PR allows such methods to return a NULL object.

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Change is covered by automated [tests](https://github.com/jni-rs/jni-rs/blob/master/CONTRIBUTING.md#tests)
- [x] The [coding guidelines](https://github.com/jni-rs/jni-rs/blob/master/CONTRIBUTING.md#the-code-style) are followed
- [x] Public API has documentation
- [x] This change is not breaking **or** mentioned in the Changelog
- [x] The [continuous integration build](https://www.travis-ci.org/jni-rs/jni-rs) passes
