### PR TITLE
Allow JNIEnv lifetimes to be more flexible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+- `JString`, `JMap` and `JavaStr` and their respective iterators now require an extra lifetime so
+  that they can now work with `&'b JNIEnv<'a>`, where `'a: 'b`.
+
 ## [0.11.0]
 
 ### Highlights

--- a/src/wrapper/strings/java_str.rs
+++ b/src/wrapper/strings/java_str.rs
@@ -14,16 +14,16 @@ use strings::JNIStr;
 /// returned by GetStringUTFChars. Calls ReleaseStringUTFChars on Drop.
 /// Can be converted to a `&JNIStr` with the same cost as the `&CStr.from_ptr`
 /// conversion.
-pub struct JavaStr<'a> {
+pub struct JavaStr<'a: 'b, 'b> {
     internal: *const c_char,
     obj: JString<'a>,
-    env: &'a JNIEnv<'a>,
+    env: &'b JNIEnv<'a>,
 }
 
-impl<'a> JavaStr<'a> {
+impl<'a: 'b, 'b> JavaStr<'a, 'b> {
     /// Build a `JavaStr` from an object and a reference to the environment. You
     /// probably want to use `JNIEnv::get_string` instead.
-    pub fn from_env(env: &'a JNIEnv<'a>, obj: JString<'a>) -> Result<Self> {
+    pub fn from_env(env: &'b JNIEnv<'a>, obj: JString<'a>) -> Result<Self> {
         let ptr = env.get_string_utf_chars(obj)?;
         let java_str = JavaStr {
             internal: ptr,
@@ -40,34 +40,34 @@ impl<'a> JavaStr<'a> {
     }
 }
 
-impl<'a> ::std::ops::Deref for JavaStr<'a> {
+impl<'a: 'b, 'b> ::std::ops::Deref for JavaStr<'a, 'b> {
     type Target = JNIStr;
     fn deref(&self) -> &Self::Target {
         self.into()
     }
 }
 
-impl<'a> From<&'a JavaStr<'a>> for &'a JNIStr {
-    fn from(other: &'a JavaStr) -> &'a JNIStr {
+impl<'a: 'b, 'b: 'c, 'c> From<&'c JavaStr<'a, 'b>> for &'c JNIStr {
+    fn from(other: &'c JavaStr) -> &'c JNIStr {
         unsafe { JNIStr::from_ptr(other.internal) }
     }
 }
 
-impl<'a> From<&'a JavaStr<'a>> for Cow<'a, str> {
-    fn from(other: &'a JavaStr) -> Cow<'a, str> {
+impl<'a: 'b, 'b: 'c, 'c> From<&'c JavaStr<'a, 'b>> for Cow<'c, str> {
+    fn from(other: &'c JavaStr) -> Cow<'c, str> {
         let jni_str: &JNIStr = &*other;
         jni_str.into()
     }
 }
 
-impl<'a> From<JavaStr<'a>> for String {
+impl<'a: 'b, 'b> From<JavaStr<'a, 'b>> for String {
     fn from(other: JavaStr) -> String {
         let cow: Cow<str> = (&other).into();
         cow.into_owned()
     }
 }
 
-impl<'a> Drop for JavaStr<'a> {
+impl<'a: 'b, 'b> Drop for JavaStr<'a, 'b> {
     fn drop(&mut self) {
         match self.env.release_string_utf_chars(self.obj, self.internal) {
             Ok(()) => {}


### PR DESCRIPTION
## Overview

In some cases, it was only possible to call certain methods if the
lifetime of the JNIEnv borrow was the same of the JNIEnv type (i.e., in
`&'a JNIEnv<'b>`, `'a` had to be equal to `'b`). This PR changes this so
that `'a: 'b` (i.e., the type lives at least as much as the borrow).

This lead to some changes to certain wrapper types (`JList`, `JMap` and
`JavaStr`), which now require both lifetimes to be explicit.

Another requirement was that some implicit lifetimes had to become
explicit, otherwise they would be infered to be the lifetime of `&self`,
i.e., the borrow, not the type.

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Change is covered by automated [tests](https://github.com/jni-rs/jni-rs/blob/master/CONTRIBUTING.md#tests)
- [ ] The [coding guidelines](https://github.com/jni-rs/jni-rs/blob/master/CONTRIBUTING.md#the-code-style) are followed
- [x] Public API has documentation
- [x] This change is not breaking **or** mentioned in the Changelog
- [x] The [continuous integration build](https://www.travis-ci.org/jni-rs/jni-rs) passes
