### PR TITLE
Use repr(transparent) and not repr(C) for transparent wrappers

### DIFF
--- a/src/wrapper/jnienv.rs
+++ b/src/wrapper/jnienv.rs
@@ -112,7 +112,7 @@ use JavaVM;
 /// Calling unchecked methods with invalid arguments and/or invalid class and
 /// method descriptors may lead to segmentation fault.
 #[derive(Clone)]
-#[repr(C)]
+#[repr(transparent)]
 pub struct JNIEnv<'a> {
     internal: *mut sys::JNIEnv,
     lifetime: PhantomData<&'a ()>,

--- a/src/wrapper/objects/jbytebuffer.rs
+++ b/src/wrapper/objects/jbytebuffer.rs
@@ -4,7 +4,7 @@ use sys::jobject;
 
 /// Lifetime'd representation of a `jobject` that is an instance of the
 /// ByteBuffer Java class. Just a `JObject` wrapped in a new class.
-#[repr(C)]
+#[repr(transparent)]
 #[derive(Clone, Copy)]
 pub struct JByteBuffer<'a>(JObject<'a>);
 

--- a/src/wrapper/objects/jclass.rs
+++ b/src/wrapper/objects/jclass.rs
@@ -7,7 +7,7 @@ use sys::{
 
 /// Lifetime'd representation of a `jclass`. Just a `JObject` wrapped in a new
 /// class.
-#[repr(C)]
+#[repr(transparent)]
 #[derive(Clone, Copy, Debug)]
 pub struct JClass<'a>(JObject<'a>);
 

--- a/src/wrapper/objects/jfieldid.rs
+++ b/src/wrapper/objects/jfieldid.rs
@@ -7,7 +7,7 @@ use sys::jfieldID;
 /// under us. It matches C's representation of the raw pointer, so it can be
 /// used in any of the extern function argument positions that would take a
 /// `jfieldid`.
-#[repr(C)]
+#[repr(transparent)]
 #[derive(Copy, Clone)]
 pub struct JFieldID<'a> {
     internal: jfieldID,

--- a/src/wrapper/objects/jmethodid.rs
+++ b/src/wrapper/objects/jmethodid.rs
@@ -7,7 +7,7 @@ use sys::jmethodID;
 /// under us. It matches C's representation of the raw pointer, so it can be
 /// used in any of the extern function argument positions that would take a
 /// `jmethodid`.
-#[repr(C)]
+#[repr(transparent)]
 #[derive(Copy, Clone, Debug)]
 pub struct JMethodID<'a> {
     internal: jmethodID,

--- a/src/wrapper/objects/jobject.rs
+++ b/src/wrapper/objects/jobject.rs
@@ -10,7 +10,7 @@ use sys::jobject;
 ///
 /// Most other types in the `objects` module deref to this, as they do in the C
 /// representation.
-#[repr(C)]
+#[repr(transparent)]
 #[derive(Clone, Copy, Debug)]
 pub struct JObject<'a> {
     internal: jobject,

--- a/src/wrapper/objects/jstaticfieldid.rs
+++ b/src/wrapper/objects/jstaticfieldid.rs
@@ -7,7 +7,7 @@ use sys::jfieldID;
 /// from under us. It matches C's representation of the raw pointer, so it can
 /// be used in any of the extern function argument positions that would take a
 /// `jstaticfieldid`.
-#[repr(C)]
+#[repr(transparent)]
 #[derive(Copy, Clone)]
 pub struct JStaticFieldID<'a> {
     internal: jfieldID,

--- a/src/wrapper/objects/jstaticmethodid.rs
+++ b/src/wrapper/objects/jstaticmethodid.rs
@@ -9,7 +9,7 @@ use sys::jmethodID;
 /// used in any of the extern function argument positions that would take a
 /// `jmethodid`. This represents static methods only since they require a
 /// different set of JNI signatures.
-#[repr(C)]
+#[repr(transparent)]
 #[derive(Copy, Clone)]
 pub struct JStaticMethodID<'a> {
     internal: jmethodID,

--- a/src/wrapper/objects/jstring.rs
+++ b/src/wrapper/objects/jstring.rs
@@ -7,7 +7,7 @@ use sys::{
 
 /// Lifetime'd representation of a `jstring`. Just a `JObject` wrapped in a new
 /// class.
-#[repr(C)]
+#[repr(transparent)]
 #[derive(Clone, Copy)]
 pub struct JString<'a>(JObject<'a>);
 

--- a/src/wrapper/objects/jthrowable.rs
+++ b/src/wrapper/objects/jthrowable.rs
@@ -7,7 +7,7 @@ use sys::{
 
 /// Lifetime'd representation of a `jthrowable`. Just a `JObject` wrapped in a
 /// new class.
-#[repr(C)]
+#[repr(transparent)]
 pub struct JThrowable<'a>(JObject<'a>);
 
 impl<'a> From<jthrowable> for JThrowable<'a> {


### PR DESCRIPTION
## Overview

`#[repr(C)] struct Foo(T)` isn't guaranteed to behave identically to `T`, but `#[repr(transparent)]` is. In practice, these two are often different, although for pointers (which is how they're used in `jni-rs`) they're _typically_ the same.

This changes the uses of `#[repr(C)]` where identical behavior is desired/required to use `#[repr(transparent)]`.

In practice this _I think_ this won't matter for most modern systems, since these are wrappers around pointers (it might matter on arm64 if you have a method with many arguments), and they're only present as function arguments. However, this is the reason `#[repr(transparent)]` exists, and it seems like tempting fate not to use it.

This should be a non-breaking change.

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Change is covered by automated [tests](https://github.com/jni-rs/jni-rs/blob/master/CONTRIBUTING.md#tests)
    - Covered by existing tests, not practical to add new tests specifically for this since platforms where it matters are not common.
- [x] The [coding guidelines](https://github.com/jni-rs/jni-rs/blob/master/CONTRIBUTING.md#the-code-style) are followed
- [x] Public API has documentation
    - Not a public API
- [x] This change is not breaking **or** mentioned in the Changelog
    - non-breaking
- [x] The [continuous integration build](https://www.travis-ci.org/jni-rs/jni-rs) passes
