### PR TITLE
Adds support for setting a global class loader

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ cesu8 = "1.1.0"
 combine = "3.4.1"
 jni-sys = "0.3.0"
 log = "0.4.4"
+lazy_static = "1"
 
 [build-dependencies]
 walkdir = "2"
@@ -28,9 +29,6 @@ walkdir = "2"
 [dependencies.error-chain]
 default-features = false
 version = "0.12.0"
-
-[dev-dependencies]
-lazy_static = "1"
 
 
 [features]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -228,6 +228,8 @@ extern crate combine;
 
 extern crate cesu8;
 
+extern crate lazy_static;
+
 mod wrapper {
     mod version;
     pub use self::version::*;
@@ -257,6 +259,9 @@ mod wrapper {
     /// Java VM interface
     mod java_vm;
     pub use self::java_vm::*;
+
+    /// Interface for loading classes.
+    pub mod class_loader;
 }
 
 pub use wrapper::*;

--- a/src/wrapper/class_loader.rs
+++ b/src/wrapper/class_loader.rs
@@ -1,0 +1,59 @@
+use std::sync::Mutex;
+
+use errors::*;
+
+use JNIEnv;
+
+use objects::{GlobalRef, JObject, JClass, JValue};
+
+use strings::JNIString;
+
+use lazy_static::lazy_static;
+
+/// The `loadClass` function name.
+const LOAD_CLASS: &str = "loadClass";
+/// The `loadClass` signature.
+const LOAD_CLASS_SIG: &str = "(Ljava/lang/String;)Ljava/lang/Class;";
+
+lazy_static! {
+    /// The global class loader instance.
+    static ref CLASS_LOADER: Mutex<Option<GlobalRef>> = Mutex::default();
+}
+
+/// Register the given object as the global class loader instance.
+pub fn register_class_loader<'a>(env: &JNIEnv<'a>, class_loader: JObject<'a>) -> Result<()> {
+    // Check that the `loadClass` function is present.
+    env.get_method_id(class_loader, LOAD_CLASS, LOAD_CLASS_SIG)?;
+
+    *CLASS_LOADER.lock().unwrap() = Some(env.new_global_ref(class_loader)?);
+
+    Ok(())
+}
+
+/// Unregister the global class loader instance.
+pub fn unregister_class_loader() {
+    *CLASS_LOADER.lock().unwrap() = None;
+}
+
+/// Look up a class by name.
+///
+/// Either it uses the registered `CLASS_LOADER` or it falls back to use the
+/// JNI env function `FindClass`.
+pub(crate) fn load_class<'a>(env: &JNIEnv<'a>, name: JNIString) -> Result<JClass<'a>> {
+    match *CLASS_LOADER.lock().unwrap() {
+        Some(ref class_loader) => {
+            let name = env.new_string(name)?;
+            let res = env.call_method(
+                class_loader.as_obj(),
+                LOAD_CLASS,
+                LOAD_CLASS_SIG,
+                &[JValue::Object(name.into())]
+            )?;
+            res.l().map(Into::into)
+        },
+        None => {
+            let class = jni_non_null_call!(env.get_native_interface(), FindClass, name.as_ptr());
+            Ok(class)
+        }
+    }
+}

--- a/src/wrapper/jnienv.rs
+++ b/src/wrapper/jnienv.rs
@@ -60,6 +60,8 @@ use signature::JavaType;
 use signature::Primitive;
 use signature::TypeSignature;
 
+use class_loader;
+
 use JNIVersion;
 use JavaVM;
 
@@ -78,11 +80,11 @@ use JavaVM;
 ///
 /// ## `null` Java references
 /// `null` Java references are handled by the following rules:
-///   - If a `null` Java reference is passed to a method that expects a non-`null` 
+///   - If a `null` Java reference is passed to a method that expects a non-`null`
 ///   argument, an `Err` result with the kind `NullPtr` is returned.
 ///   - If a JNI function returns `null` to indicate an error (e.g. `new_int_array`),
-///     it is converted to `Err`/`NullPtr` or, where possible, to a more applicable 
-///     error type, such as `MethodNotFound`. If the JNI function also throws 
+///     it is converted to `Err`/`NullPtr` or, where possible, to a more applicable
+///     error type, such as `MethodNotFound`. If the JNI function also throws
 ///     an exception, the `JavaException` error kind will be preferred.
 ///   - If a JNI function may return `null` Java reference as one of possible reference
 ///     values (e.g., `get_object_array_element` or `get_field_unchecked`),
@@ -165,8 +167,7 @@ impl<'a> JNIEnv<'a> {
         S: Into<JNIString>,
     {
         let name = name.into();
-        let class = jni_non_null_call!(self.internal, FindClass, name.as_ptr());
-        Ok(class)
+        class_loader::load_class(&self, name)
     }
 
     /// Returns the superclass for a particular class OR `JObject::null()` for `java.lang.Object` or


### PR DESCRIPTION
New functions:
- `register_class_loader` to register a global class loader
- `unregister_class_loader` to unregister a global class loader

The global class loader will be used by `find_class`, instead of
`JNIEnv::FindClass`.

## Overview

Please describe your changes here and list any open questions you might have.

### Definition of Done

- [x] There are no TODOs left in the code
- [ ] Change is covered by automated [tests](https://github.com/jni-rs/jni-rs/blob/master/CONTRIBUTING.md#tests)
- [ ] The [coding guidelines](https://github.com/jni-rs/jni-rs/blob/master/CONTRIBUTING.md#the-code-style) are followed
- [x] Public API has documentation
- [x] This change is not breaking **or** mentioned in the Changelog
- [ ] The [continuous integration build](https://www.travis-ci.org/jni-rs/jni-rs) passes
