### PR TITLE
Pass `jboolean` directly to `JValue` instead of using bool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+- `From<jboolean>` implementation for `JValue` (#173)
+
 ## [0.12.2]
 
 ### Changed

--- a/src/wrapper/jnienv.rs
+++ b/src/wrapper/jnienv.rs
@@ -78,11 +78,11 @@ use JavaVM;
 ///
 /// ## `null` Java references
 /// `null` Java references are handled by the following rules:
-///   - If a `null` Java reference is passed to a method that expects a non-`null` 
+///   - If a `null` Java reference is passed to a method that expects a non-`null`
 ///   argument, an `Err` result with the kind `NullPtr` is returned.
 ///   - If a JNI function returns `null` to indicate an error (e.g. `new_int_array`),
-///     it is converted to `Err`/`NullPtr` or, where possible, to a more applicable 
-///     error type, such as `MethodNotFound`. If the JNI function also throws 
+///     it is converted to `Err`/`NullPtr` or, where possible, to a more applicable
+///     error type, such as `MethodNotFound`. If the JNI function also throws
 ///     an exception, the `JavaException` error kind will be preferred.
 ///   - If a JNI function may return `null` Java reference as one of possible reference
 ///     values (e.g., `get_object_array_element` or `get_field_unchecked`),
@@ -656,14 +656,13 @@ impl<'a> JNIEnv<'a> {
             JavaType::Method(_) => unimplemented!(),
             JavaType::Primitive(p) => {
                 let v: JValue = match p {
-                    Primitive::Boolean => (jni_non_void_call!(
+                    Primitive::Boolean => jni_non_void_call!(
                         self.internal,
                         CallStaticBooleanMethodA,
                         class,
                         method_id,
                         jni_args
-                    ) == sys::JNI_TRUE)
-                        .into(),
+                    ).into(),
                     Primitive::Char => jni_non_void_call!(
                         self.internal,
                         CallStaticCharMethodA,
@@ -761,14 +760,13 @@ impl<'a> JNIEnv<'a> {
             JavaType::Method(_) => unimplemented!(),
             JavaType::Primitive(p) => {
                 let v: JValue = match p {
-                    Primitive::Boolean => (jni_non_void_call!(
+                    Primitive::Boolean => jni_non_void_call!(
                         self.internal,
                         CallBooleanMethodA,
                         obj,
                         method_id,
                         jni_args
-                    ) == sys::JNI_TRUE)
-                        .into(),
+                    ).into(),
                     Primitive::Char => {
                         jni_non_void_call!(self.internal, CallCharMethodA, obj, method_id, jni_args)
                             .into()
@@ -1535,9 +1533,7 @@ impl<'a> JNIEnv<'a> {
             JavaType::Primitive(p) => {
                 let v: JValue = match p {
                     Primitive::Boolean => {
-                        (jni_unchecked!(self.internal, GetBooleanField, obj, field)
-                            == sys::JNI_TRUE)
-                            .into()
+                        jni_unchecked!(self.internal, GetBooleanField, obj, field).into()
                     }
                     Primitive::Char => {
                         jni_unchecked!(self.internal, GetCharField, obj, field).into()
@@ -1704,9 +1700,7 @@ impl<'a> JNIEnv<'a> {
             JavaType::Primitive(p) => {
                 let v: JValue = match p {
                     Primitive::Boolean => {
-                        (jni_unchecked!(self.internal, GetStaticBooleanField, class, field_id)
-                            == sys::JNI_TRUE)
-                            .into()
+                        jni_unchecked!(self.internal, GetStaticBooleanField, class, field_id).into()
                     }
                     Primitive::Char => {
                         jni_unchecked!(self.internal, GetStaticCharField, class, field_id).into()

--- a/src/wrapper/objects/jvalue.rs
+++ b/src/wrapper/objects/jvalue.rs
@@ -99,7 +99,7 @@ impl<'a> JValue<'a> {
     /// Try to unwrap to a boolean.
     pub fn z(self) -> Result<bool> {
         match self {
-            JValue::Bool(b) => Ok(b != 0),
+            JValue::Bool(b) => Ok(b == JNI_TRUE),
             _ => Err(ErrorKind::WrongJValueType("bool", self.type_name()).into()),
         }
     }
@@ -175,10 +175,16 @@ impl<'a> From<JObject<'a>> for JValue<'a> {
     }
 }
 
-// jbool
 impl<'a> From<bool> for JValue<'a> {
     fn from(other: bool) -> Self {
-        JValue::Bool(other as jboolean)
+        JValue::Bool(if other { JNI_TRUE } else { JNI_FALSE })
+    }
+}
+
+// jbool
+impl<'a> From<jboolean> for JValue<'a> {
+    fn from(other: jboolean) -> Self {
+        JValue::Bool(other)
     }
 }
 

--- a/tests/jmap.rs
+++ b/tests/jmap.rs
@@ -19,7 +19,8 @@ pub fn jmap_push_and_iterate() {
     let env = attach_current_thread();
     let data = &["hello", "world", "from", "test"];
 
-    let map_object = unwrap(&env, env.new_object("java/util/HashMap", "()V", &[]));
+    // Create a new map. Use LinkedHashMap to have predictable iteration order
+    let map_object = unwrap(&env, env.new_object("java/util/LinkedHashMap", "()V", &[]));
     let map = unwrap(&env, JMap::from_env(&env, map_object));
 
     // Push all strings
@@ -32,6 +33,7 @@ pub fn jmap_push_and_iterate() {
         }),
     );
 
+    // Collect the keys using the JMap iterator
     let mut collected = Vec::new();
     unwrap(
         &env,
@@ -42,9 +44,7 @@ pub fn jmap_push_and_iterate() {
             })
         }),
     );
-    collected.sort();
 
-    let mut orig = data.to_vec();
-    orig.sort();
+    let orig = data.to_vec();
     assert_eq!(orig, collected);
 }

--- a/tests/jmap.rs
+++ b/tests/jmap.rs
@@ -1,0 +1,50 @@
+#![cfg(feature = "invocation")]
+
+extern crate error_chain;
+extern crate jni;
+
+use jni::objects::{
+    JMap,
+    JObject,
+};
+
+mod util;
+use util::{
+    attach_current_thread,
+    unwrap,
+};
+
+#[test]
+pub fn jmap_push_and_iterate() {
+    let env = attach_current_thread();
+    let data = &["hello", "world", "from", "test"];
+
+    let map_object = unwrap(&env, env.new_object("java/util/HashMap", "()V", &[]));
+    let map = unwrap(&env, JMap::from_env(&env, map_object));
+
+    // Push all strings
+    unwrap(
+        &env,
+        data.iter().try_for_each(|s| {
+            env.new_string(s)
+                .map(|s| JObject::from(s))
+                .and_then(|s| map.put(s, s).map(|_| ()))
+        }),
+    );
+
+    let mut collected = Vec::new();
+    unwrap(
+        &env,
+        map.iter().and_then(|mut iter| {
+            iter.try_for_each(|e| {
+                env.get_string(e.0.into())
+                    .map(|s| collected.push(String::from(s)))
+            })
+        }),
+    );
+    collected.sort();
+
+    let mut orig = data.to_vec();
+    orig.sort();
+    assert_eq!(orig, collected);
+}

--- a/tests/util/mod.rs
+++ b/tests/util/mod.rs
@@ -1,9 +1,18 @@
-use std::sync::{Arc, Once, ONCE_INIT};
+use std::sync::{
+    Arc,
+    Once,
+    ONCE_INIT,
+};
 
 use error_chain::ChainedError;
-use jni::{AttachGuard, InitArgsBuilder, JNIEnv, JNIVersion, JavaVM};
 use jni::errors::Result;
-
+use jni::{
+    AttachGuard,
+    InitArgsBuilder,
+    JNIEnv,
+    JNIVersion,
+    JavaVM,
+};
 
 pub fn jvm() -> &'static Arc<JavaVM> {
     static mut JVM: Option<Arc<JavaVM>> = None;
@@ -17,8 +26,8 @@ pub fn jvm() -> &'static Arc<JavaVM> {
             .build()
             .unwrap_or_else(|e| panic!("{}", e.display_chain().to_string()));
 
-        let jvm = JavaVM::new(jvm_args)
-            .unwrap_or_else(|e| panic!("{}", e.display_chain().to_string()));
+        let jvm =
+            JavaVM::new(jvm_args).unwrap_or_else(|e| panic!("{}", e.display_chain().to_string()));
 
         unsafe {
             JVM = Some(Arc::new(jvm));
@@ -29,12 +38,13 @@ pub fn jvm() -> &'static Arc<JavaVM> {
 }
 
 pub fn attach_current_thread() -> AttachGuard<'static> {
-    jvm().attach_current_thread().expect("failed to attach jvm thread")
+    jvm()
+        .attach_current_thread()
+        .expect("failed to attach jvm thread")
 }
 
 pub fn print_exception(env: &JNIEnv) {
-    let exception_occurred = env.exception_check()
-        .unwrap_or_else(|e| panic!("{:?}", e));
+    let exception_occurred = env.exception_check().unwrap_or_else(|e| panic!("{:?}", e));
     if exception_occurred {
         env.exception_describe()
             .unwrap_or_else(|e| panic!("{:?}", e));


### PR DESCRIPTION
## Overview

So I had this bug with calling a `hasNext` that always returned `false`. After debugging it for a while, I found that adding `println!` fixed the error:
```
let res = jni_non_void_call!(
  self.internal,
  CallBooleanMethodA,
  obj,
  method_id,
  jni_args
);

println!("HELLO {}", res);

(res == sys::JNI_TRUE).into()
```

This pr solves this by forwarding the `jboolean` to `JValue` directly, instead of converting it first into `bool` and then into `jboolean` again. The compiler probably generated some incorrect code or the `bool as jboolean` failed, I'm not quite sure. However, it now works for me and make the code cleaner.

### Definition of Done

- [x] There are no TODOs left in the code
- [ ] Change is covered by automated [tests](https://github.com/jni-rs/jni-rs/blob/master/CONTRIBUTING.md#tests)
- [ ] The [coding guidelines](https://github.com/jni-rs/jni-rs/blob/master/CONTRIBUTING.md#the-code-style) are followed
- [ ] Public API has documentation
- [ ] This change is not breaking **or** mentioned in the Changelog
- [ ] The [continuous integration build](https://www.travis-ci.org/jni-rs/jni-rs) passes
