### PR TITLE
Make V8 the default for Invocation API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 - `From<jboolean>` implementation for `JValue` (#173)
 
+### Changed
+- The default JNI API version in `InitArgsBuilder` from V1 to V8.
+
 ## [0.12.2]
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,15 +15,15 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+- The default JNI API version in `InitArgsBuilder` from V1 to V8. (#178)
+
 ## [0.12.3]
 
 ### Added
 - `From<jboolean>` implementation for `JValue` (#173)
 - `Debug` trait for InitArgsBuilder. (#175)
 - `InitArgsBuilder#options` returning the collected JVM options. (#177)
-
-### Changed
-- The default JNI API version in `InitArgsBuilder` from V1 to V8.
 
 ## [0.12.2]
 

--- a/src/wrapper/java_vm/init_args.rs
+++ b/src/wrapper/java_vm/init_args.rs
@@ -20,7 +20,7 @@ error_chain! {
 pub struct InitArgsBuilder {
     opts: Vec<String>,
     ignore_unrecognized: bool,
-    version: i32,
+    version: JNIVersion,
 }
 
 impl Default for InitArgsBuilder {
@@ -28,7 +28,7 @@ impl Default for InitArgsBuilder {
         InitArgsBuilder {
             opts: vec![],
             ignore_unrecognized: false,
-            version: JNIVersion::V1.into(),
+            version: JNIVersion::V8,
         }
     }
 }
@@ -57,10 +57,10 @@ impl InitArgsBuilder {
 
     /// Set JNI version for the init args
     ///
-    /// Default: V1
+    /// Default: V8
     pub fn version(self, version: JNIVersion) -> Self {
         let mut s = self;
-        s.version = version.into();
+        s.version = version;
         s
     }
 
@@ -95,7 +95,7 @@ impl InitArgsBuilder {
 
         Ok(InitArgs {
             inner: JavaVMInitArgs {
-                version: self.version,
+                version: self.version.into(),
                 ignoreUnrecognized: self.ignore_unrecognized as _,
                 options: opts.as_ptr() as _,
                 nOptions: opts.len() as _,

--- a/tests/util/mod.rs
+++ b/tests/util/mod.rs
@@ -22,7 +22,6 @@ pub fn jvm() -> &'static Arc<JavaVM> {
         let jvm_args = InitArgsBuilder::new()
             .version(JNIVersion::V8)
             .option("-Xcheck:jni")
-            .option("-Xdebug")
             .build()
             .unwrap_or_else(|e| panic!("{}", e.display_chain().to_string()));
 


### PR DESCRIPTION
## Overview

As most users of JavaVM::new are on desktop with JVM 8+,
it makes sense to use V8 as the default.

### Definition of Done

- [x] There are no TODOs left in the code
- [ ] Change is covered by automated [tests](https://github.com/jni-rs/jni-rs/blob/master/CONTRIBUTING.md#tests)
- [x] The [coding guidelines](https://github.com/jni-rs/jni-rs/blob/master/CONTRIBUTING.md#the-code-style) are followed
- [x] Public API has documentation
- [x] This change is not breaking **or** mentioned in the Changelog
- [x] The [continuous integration build](https://www.travis-ci.org/jni-rs/jni-rs) passes
