### PR TITLE
Update the documentation on thread attachment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,11 +16,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 
 ### Added
-- `JavaVM::attach_current_thread_permanently` method, which effectively attaches
-  current thread and detaches it when the thread finished. Daemon threads attached
-  with `JavaVM::attach_current_thread_as_daemon` also automatically detaches when
-  finished. The number of currently attached threads may be acquired using
-  `JavaVM::threads_attached` method. Current thread may be detached by calling
+- `JavaVM::attach_current_thread_permanently` method, which attaches the current 
+  thread and detaches it when the thread finishes. Daemon threads attached 
+  with `JavaVM::attach_current_thread_as_daemon` also automatically detach themselves
+  when finished. The number of currently attached threads may be acquired using
+  `JavaVM::threads_attached` method. The current thread may be detached by calling
   `JavaVM::detach_current_thread`. (#180)
 
 ### Changed

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -154,27 +154,8 @@
 //!
 //! ## Launching JVM from Rust
 //!
-//! If you need to use the part of the [Invocation API]
-//! that allows to launch a JVM
-//! from a native process, you must enable `invocation` feature.
-//! The application will require linking to the dynamic `jvm`
-//! library, which is distributed with the JVM.
-//!
-//! During build time, the JVM installation path is determined:
-//! 1. By `JAVA_HOME` environment variable, if it is set.
-//! 2. Otherwise — from `java` output.
-//!
-//! It is recommended to set `JAVA_HOME` to have reproducible builds, especially, in case of multiple VMs installed.
-//!
-//! At application run time, you must specify the path
-//! to the `jvm` library so that the loader can locate it.
-//! * On **Windows**, append the path to `jvm.dll` to `PATH` environment variable.
-//! * On **MacOS**, append the path to `libjvm.dylib` to `LD_LIBRARY_PATH` environment variable.
-//! * On **Linux**, append the path to `libjvm.so` to `LD_LIBRARY_PATH` environment variable.
-//!
-//! The exact relative path to `jvm` library is version-specific.
-//!
-//! For more information - see documentation in [build.rs](https://github.com/jni-rs/jni-rs/tree/master/build.rs).
+//! It is possible to launch a JVM from a native process using the [Invocation API], provided
+//! by [`JavaVM`](struct.JavaVM.html).
 //!
 //! ## See Also
 //!

--- a/src/wrapper/objects/auto_local.rs
+++ b/src/wrapper/objects/auto_local.rs
@@ -6,10 +6,10 @@ use JNIEnv;
 
 /// Auto-delete wrapper for local refs.
 ///
-/// Anything passed to a foreign method is considered a local ref unless it's
-/// explicitly turned into a global. These refs are automatically deleted once
-/// the foreign method exits, but it's possible that they may reach the
-/// JVM-imposed limit before that happens.
+/// Anything passed to a foreign method _and_ returned from JNI methods is considered a local ref
+/// unless it is specified otherwise.
+/// These refs are automatically deleted once the foreign method exits, but it's possible that
+/// they may reach the JVM-imposed limit before that happens.
 ///
 /// This wrapper provides automatic local ref deletion when it goes out of
 /// scope.
@@ -17,6 +17,12 @@ use JNIEnv;
 /// NOTE: This comes with some potential safety risks. DO NOT use this to wrap
 /// something unless you're SURE it won't be used after this wrapper gets
 /// dropped. Otherwise, you'll get a nasty JVM crash.
+///
+/// See also the [JNI specification][spec-references] for details on referencing Java objects
+/// and some [extra information][android-jni-references].
+///
+/// [spec-references]: https://docs.oracle.com/en/java/javase/12/docs/specs/jni/design.html#referencing-java-objects
+/// [android-jni-references]: https://developer.android.com/training/articles/perf-jni#local-and-global-references
 pub struct AutoLocal<'a> {
     obj: JObject<'a>,
     env: &'a JNIEnv<'a>,


### PR DESCRIPTION
## Overview

Update the documentation on thread attachment.

See #179 and #180 

### Definition of Done

- [x] There are no TODOs left in the code
- [x] The [coding guidelines](https://github.com/jni-rs/jni-rs/blob/master/CONTRIBUTING.md#the-code-style) are followed
- [x] Public API has documentation
- [x] This change is not breaking **or** mentioned in the Changelog
- [x] The [continuous integration build](https://www.travis-ci.org/jni-rs/jni-rs) passes
