### PR TITLE
Fix class leaks in wrapper types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Changed
 - The default JNI API version in `InitArgsBuilder` from V1 to V8. (#178)
+- Extended the lifetimes of `AutoLocal` to make it more flexible. (#190)
+
+### Fixed
+- Local reference leaks in `JList`, `JMap` and `JMapIter`. (#190, #191)
 
 ## [0.12.3]
 

--- a/src/wrapper/descriptors/class_desc.rs
+++ b/src/wrapper/descriptors/class_desc.rs
@@ -31,7 +31,7 @@ impl<'a, 'b> Desc<'a, JClass<'b>> for &'b GlobalRef {
 }
 
 /// This conversion assumes that the `AutoLocal` is a pointer to a class object.
-impl<'a, 'b, 'c> Desc<'a, JClass<'b>> for &'b AutoLocal<'c>
+impl<'a, 'b, 'c> Desc<'a, JClass<'b>> for &'b AutoLocal<'c, '_>
 where
     'c: 'b,
 {

--- a/src/wrapper/jnienv.rs
+++ b/src/wrapper/jnienv.rs
@@ -326,7 +326,7 @@ impl<'a> JNIEnv<'a> {
     /// when you create a bounded number of local references in a method but
     /// can't rely on automatic de-allocation (e.g., in case of recursion
     /// or just deep call stacks).
-    pub fn auto_local(&'a self, obj: JObject<'a>) -> AutoLocal<'a> {
+    pub fn auto_local<'b>(&'b self, obj: JObject<'a>) -> AutoLocal<'a, 'b> {
         AutoLocal::new(self, obj)
     }
 

--- a/src/wrapper/objects/jlist.rs
+++ b/src/wrapper/objects/jlist.rs
@@ -44,13 +44,13 @@ impl<'a: 'b, 'b> JList<'a, 'b> {
     /// necessary class and method ids to call all of the methods on it so that
     /// exra work doesn't need to be done on every method call.
     pub fn from_env(env: &'b JNIEnv<'a>, obj: JObject<'a>) -> Result<JList<'a, 'b>> {
-        let class = env.find_class("java/util/List")?;
+        let class = env.auto_local(env.find_class("java/util/List")?.into());
 
-        let get = env.get_method_id(class, "get", "(I)Ljava/lang/Object;")?;
-        let add = env.get_method_id(class, "add", "(Ljava/lang/Object;)Z")?;
-        let add_idx = env.get_method_id(class, "add", "(ILjava/lang/Object;)V")?;
-        let remove = env.get_method_id(class, "remove", "(I)Ljava/lang/Object;")?;
-        let size = env.get_method_id(class, "size", "()I")?;
+        let get = env.get_method_id(&class, "get", "(I)Ljava/lang/Object;")?;
+        let add = env.get_method_id(&class, "add", "(Ljava/lang/Object;)Z")?;
+        let add_idx = env.get_method_id(&class, "add", "(ILjava/lang/Object;)V")?;
+        let remove = env.get_method_id(&class, "remove", "(I)Ljava/lang/Object;")?;
+        let size = env.get_method_id(&class, "size", "()I")?;
 
         Ok(JList {
             internal: obj,

--- a/src/wrapper/objects/jmap.rs
+++ b/src/wrapper/objects/jmap.rs
@@ -142,13 +142,15 @@ impl<'a: 'b, 'b> JMap<'a, 'b> {
             )?
             .l()?;
 
-        let iter_class = self.env.find_class("java/util/Iterator")?;
+        let iter_class = self
+            .env
+            .auto_local(self.env.find_class("java/util/Iterator")?.into());
 
-        let has_next = self.env.get_method_id(iter_class, "hasNext", "()Z")?;
+        let has_next = self.env.get_method_id(&iter_class, "hasNext", "()Z")?;
 
         let next = self
             .env
-            .get_method_id(iter_class, "next", "()Ljava/lang/Object;")?;
+            .get_method_id(&iter_class, "next", "()Ljava/lang/Object;")?;
 
         let entry_class = self.env.find_class("java/util/Map$Entry")?;
 

--- a/src/wrapper/objects/jmap.rs
+++ b/src/wrapper/objects/jmap.rs
@@ -13,7 +13,7 @@ use signature::{JavaType, Primitive};
 /// call.
 pub struct JMap<'a: 'b, 'b> {
     internal: JObject<'a>,
-    class: AutoLocal<'b>,
+    class: AutoLocal<'a, 'b>,
     get: JMethodID<'a>,
     put: JMethodID<'a>,
     remove: JMethodID<'a>,


### PR DESCRIPTION
## Overview

I realized that when I created `JList` objects in a separate thread, that thread would eventually crash due to a full local reference table. From the crash log, I realized it was full o `Class` instances. This is because `JList` creates a local reference to the `Class<List>` in order to get method IDs to be used later on. This reference is never deleted or stored for later usage, so it gets leaked.

This PR ensures the reference is deleted, and also implements `Drop` for `JMap` so the local reference to `Class<Map>` used there is also removed when no longer needed.

I'm not sure how to test this code. I tried writing a test case that uses `env.with_local_frame` and creates more `JList` objects that the value specified, but the test doesn't fail, it just outputs a warning that the capacity was exceeded.

### Definition of Done

- [x] There are no TODOs left in the code
- [ ] Change is covered by automated [tests](https://github.com/jni-rs/jni-rs/blob/master/CONTRIBUTING.md#tests)
- [x] The [coding guidelines](https://github.com/jni-rs/jni-rs/blob/master/CONTRIBUTING.md#the-code-style) are followed
- [x] Public API has documentation
- [x] This change is not breaking **or** mentioned in the Changelog
- [x] The [continuous integration build](https://www.travis-ci.org/jni-rs/jni-rs) passes
