### PR TITLE
adt: Fix tests and improve documentation

### DIFF
--- a/.travis/run_travis_job.sh
+++ b/.travis/run_travis_job.sh
@@ -15,7 +15,7 @@ export JAVA_HOME="$(java -XshowSettings:properties -version \
 export LD_LIBRARY_PATH="$(find -L ${JAVA_HOME} -type f -name libjvm.* | xargs -n1 dirname)"
 
 # Install clippy
-if rustc --version | grep -q "nightly"
+if [[ ${TRAVIS_RUST_VERSION} == "nightly" ]];
 then
     # Install nightly clippy
     rustup component add clippy --toolchain=nightly || cargo install --git https://github.com/rust-lang/rust-clippy/ --force clippy
@@ -36,5 +36,10 @@ cargo fmt --all -- --check
 # Run clippy static analysis.
 cargo clippy --all --tests --all-features -- -D warnings
 
-# Run all tests
+# Run tests with default features (stable-only)
+if [[ ${TRAVIS_RUST_VERSION} == "stable" ]]; then
+  cargo test
+fi
+
+# Run all tests with invocation feature (enables JavaVM ITs)
 cargo test --features=backtrace,invocation

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,14 +20,17 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   thread and detaches it when the thread finishes. Daemon threads attached 
   with `JavaVM::attach_current_thread_as_daemon` also automatically detach themselves
   when finished. The number of currently attached threads may be acquired using
-  `JavaVM::threads_attached` method. The current thread may be detached by calling
-  `JavaVM::detach_current_thread`. (#180)
-- `Executor` struct - a simple thread attachment manager which helps to safely
-  execute a closure in attached thread context and to auto-free created local
-  references at closure exit. (#186)
+  `JavaVM::threads_attached` method. (#179, #180)
+- `Executor` — a simple thread attachment manager which helps to safely
+  execute a closure in attached thread context and to automatically free 
+  created local references at closure exit. (#186)
 
 ### Changed
 - The default JNI API version in `InitArgsBuilder` from V1 to V8. (#178)
+
+### Fixed
+- Native threads attached with `JavaVM::attach_current_thread_as_daemon` now automatically detach
+  themselves on exit, preventing Java Thread leaks. (#179)
 
 ## [0.12.3]
 

--- a/src/wrapper/executor.rs
+++ b/src/wrapper/executor.rs
@@ -6,8 +6,49 @@ use std::sync::Arc;
 /// value Hotspot uses when calling native Java methods.
 pub const DEFAULT_LOCAL_FRAME_CAPACITY: i32 = 32;
 
-/// Thread attachment manager. Attaches threads as daemons, hence they do not block
-/// JVM exit. Finished threads detach automatically.
+/// Thread attachment manager. It allows to execute closures in attached threads with automatic
+/// local references management done with `with_local_frame`. It combines the performance benefits
+/// of permanent attaches whilst removing the risk of local references leaks if used consistently.
+///
+/// Although all locals are freed on closure exit, it might be needed to manually free
+/// locals _inside_ the closure if an unbounded number of them is created (e.g., in a loop).
+/// See ["Local Reference Management"](struct.JavaVM.html#local-reference-management) for details.
+///
+/// Threads using the Executor are attached on the first invocation as daemons,
+/// hence they do not block JVM exit. Finished threads detach automatically.
+///
+/// ## Example
+///
+/// ```rust
+/// # use jni::errors;
+/// # //
+/// # fn main() -> errors::Result<()> {
+/// # // Ignore this test without invocation feature, so that simple `cargo test` works
+/// # #[cfg(feature = "invocation")] {
+/// # //
+/// # use jni::{objects::JValue, Executor, InitArgsBuilder, JavaVM, sys::jint};
+/// # use std::sync::Arc;
+/// # //
+/// # let jvm_args = InitArgsBuilder::new()
+/// #         .build()
+/// #         .unwrap();
+/// # // Create a new VM
+/// # let jvm = Arc::new(JavaVM::new(jvm_args)?);
+///
+/// let exec = Executor::new(jvm);
+///
+/// let val: jint = exec.with_attached(|env| {
+///    let x = JValue::from(-10);
+///    let val: jint = env.call_static_method("java/lang/Math", "abs", "(I)I", &[x])?
+///      .i()?;
+///    Ok(val)
+/// })?;
+///
+/// assert_eq!(val, 10);
+///
+/// # }
+/// # Ok(()) }
+/// ```
 #[derive(Clone)]
 pub struct Executor {
     vm: Arc<JavaVM>,

--- a/tests/executor.rs
+++ b/tests/executor.rs
@@ -1,3 +1,4 @@
+#![cfg(feature = "invocation")]
 extern crate jni;
 
 use jni::sys::jint;

--- a/tests/executor_nested_attach.rs
+++ b/tests/executor_nested_attach.rs
@@ -1,3 +1,4 @@
+#![cfg(feature = "invocation")]
 extern crate jni;
 
 use jni::{errors::ErrorKind, Executor, JavaVM};


### PR DESCRIPTION
## Overview

- Fix tests requiring invocation feature: they did not compile with `cargo test`.
Also, test that they work on Travis CI.

- Improve Executor and JavaVM documentation:

  - Clarify the Executor properties and user obligations on local
reference management.

  - Add an example of Executor usage.

  - Fix the doc test in JavaVM (it used to be always ignored).

### Definition of Done

- [ ] There are no TODOs left in the code
- [ ] Change is covered by automated [tests](https://github.com/jni-rs/jni-rs/blob/master/CONTRIBUTING.md#tests)
- [ ] The [coding guidelines](https://github.com/jni-rs/jni-rs/blob/master/CONTRIBUTING.md#the-code-style) are followed
- [ ] Public API has documentation
- [ ] This change is not breaking **or** mentioned in the Changelog
- [ ] The [continuous integration build](https://www.travis-ci.org/jni-rs/jni-rs) passes
