### PR TITLE
Update Cargo.toml for better documentation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,6 @@
 authors = ["Josh Chase <josh@prevoty.com>"]
 description = "Rust bindings to the JNI"
 documentation = "https://docs.rs/jni"
-homepage = "https://docs.rs/jni"
 readme = "README.md"
 keywords = [
     "ffi",
@@ -37,3 +36,6 @@ lazy_static = "1"
 invocation = []
 backtrace = ["error-chain/backtrace"]
 default = ["backtrace"]
+
+[package.metadata.docs.rs]
+features = ["invocation"]

--- a/src/wrapper/java_vm/init_args.rs
+++ b/src/wrapper/java_vm/init_args.rs
@@ -16,7 +16,10 @@ error_chain! {
     }
 }
 
-/// Builder for JavaVM InitArgs
+/// Builder for JavaVM InitArgs.
+/// 
+/// *This API requires "invocation" feature to be enabled, 
+/// see ["Launching JVM from Rust"](struct.JavaVM.html#launching-jvm-from-rust).*
 #[derive(Debug)]
 pub struct InitArgsBuilder {
     opts: Vec<String>,
@@ -111,7 +114,10 @@ impl InitArgsBuilder {
     }
 }
 
-/// JavaVM InitArgs
+/// JavaVM InitArgs.
+/// 
+/// *This API requires "invocation" feature to be enabled, 
+/// see ["Launching JVM from Rust"](struct.JavaVM.html#launching-jvm-from-rust).*
 pub struct InitArgs {
     inner: JavaVMInitArgs,
     opts: Vec<JavaVMOption>,

--- a/src/wrapper/java_vm/init_args.rs
+++ b/src/wrapper/java_vm/init_args.rs
@@ -17,8 +17,8 @@ error_chain! {
 }
 
 /// Builder for JavaVM InitArgs.
-/// 
-/// *This API requires "invocation" feature to be enabled, 
+///
+/// *This API requires "invocation" feature to be enabled,
 /// see ["Launching JVM from Rust"](struct.JavaVM.html#launching-jvm-from-rust).*
 #[derive(Debug)]
 pub struct InitArgsBuilder {
@@ -115,8 +115,8 @@ impl InitArgsBuilder {
 }
 
 /// JavaVM InitArgs.
-/// 
-/// *This API requires "invocation" feature to be enabled, 
+///
+/// *This API requires "invocation" feature to be enabled,
 /// see ["Launching JVM from Rust"](struct.JavaVM.html#launching-jvm-from-rust).*
 pub struct InitArgs {
     inner: JavaVMInitArgs,

--- a/src/wrapper/java_vm/vm.rs
+++ b/src/wrapper/java_vm/vm.rs
@@ -140,8 +140,8 @@ impl JavaVM {
     /// Unlike original JNI API, the main thread (the thread from which this method is called) will
     /// not be attached to JVM. You must explicitly use `attach_current_thread…` methods (refer
     /// to [Attaching Native Threads section](#attaching-native-threads)).
-    /// 
-    /// *This API requires "invocation" feature to be enabled, 
+    ///
+    /// *This API requires "invocation" feature to be enabled,
     /// see ["Launching JVM from Rust"](struct.JavaVM.html#launching-jvm-from-rust).*
     #[cfg(feature = "invocation")]
     pub fn new(args: InitArgs) -> Result<Self> {

--- a/src/wrapper/java_vm/vm.rs
+++ b/src/wrapper/java_vm/vm.rs
@@ -140,6 +140,9 @@ impl JavaVM {
     /// Unlike original JNI API, the main thread (the thread from which this method is called) will
     /// not be attached to JVM. You must explicitly use `attach_current_thread…` methods (refer
     /// to [Attaching Native Threads section](#attaching-native-threads)).
+    /// 
+    /// *This API requires "invocation" feature to be enabled, 
+    /// see ["Launching JVM from Rust"](struct.JavaVM.html#launching-jvm-from-rust).*
     #[cfg(feature = "invocation")]
     pub fn new(args: InitArgs) -> Result<Self> {
         use std::os::raw::c_void;


### PR DESCRIPTION
This updates the Cargo manifest with two improvements:

- Instruct docs.rs to build docs with the `invocation` feature, so that all necessary parts of the Java invocation API appear on docs.rs.
- Remove the `homepage` field from the manifest, as this one should only be used for dedicated project websites and should not be redundant with the repository or documentation ([C-METADATA](https://rust-lang-nursery.github.io/api-guidelines/documentation.html#c-metadata)).