### PR TITLE
Migrate off deprecated API:

### DIFF
--- a/tests/util/mod.rs
+++ b/tests/util/mod.rs
@@ -1,4 +1,4 @@
-use std::sync::{Arc, Once, ONCE_INIT};
+use std::sync::{Arc, Once};
 
 use error_chain::ChainedError;
 use jni::{
@@ -11,7 +11,7 @@ pub use self::example_proxy::AtomicIntegerProxy;
 
 pub fn jvm() -> &'static Arc<JavaVM> {
     static mut JVM: Option<Arc<JavaVM>> = None;
-    static INIT: Once = ONCE_INIT;
+    static INIT: Once = Once::new();
 
     INIT.call_once(|| {
         let jvm_args = InitArgsBuilder::new()


### PR DESCRIPTION
## Overview

Use Once::new instead of deprecated ONCE_INIT, causing build
failures with beta rustc.


### Definition of Done

- [ ] There are no TODOs left in the code
- [ ] Change is covered by automated [tests](https://github.com/jni-rs/jni-rs/blob/master/CONTRIBUTING.md#tests)
- [ ] The [coding guidelines](https://github.com/jni-rs/jni-rs/blob/master/CONTRIBUTING.md#the-code-style) are followed
- [ ] Public API has documentation
- [ ] This change is not breaking **or** mentioned in the Changelog
- [ ] The [continuous integration build](https://www.travis-ci.org/jni-rs/jni-rs) passes
