### PR TITLE
[DOC] Correct extension of build artifact for OSX

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -86,7 +86,7 @@
 //! * Add a new `[lib]` section and under it, `crate_type = ["cdylib"]`.
 //!
 //! Now, if you run `cargo build` from inside the crate directory, you should
-//! see a `libmylib.so` (if you're on linux/OSX) in the `target/debug`
+//! see a `libmylib.so` (if you're on linux) or a `libmylib.dylib` (if you are on OSX) in the `target/debug`
 //! directory.
 //!
 //! The last thing we need to do is to define our exported method. Add this to


### PR DESCRIPTION
## Overview

Current documentation lists `libmylib.so` as the artifact generated by `cargo build` for both Linux and OSX. Changed this to note that `libmylib.dylib` is the generated artifact in OSX.

### Definition of Done

- [x] There are no TODOs left in the code
- [x] The [coding guidelines](https://github.com/jni-rs/jni-rs/blob/master/CONTRIBUTING.md#the-code-style) are followed
- [x] This change is not breaking **or** mentioned in the Changelog
- [x] The [continuous integration build](https://www.travis-ci.org/jni-rs/jni-rs) passes
