### PR TITLE
Add lifetime to result of `get_static_field`

### DIFF
--- a/src/wrapper/jnienv.rs
+++ b/src/wrapper/jnienv.rs
@@ -1693,7 +1693,7 @@ impl<'a> JNIEnv<'a> {
 
     /// Get a static field. Requires a class lookup and a field id lookup
     /// internally.
-    pub fn get_static_field<T, U, V>(&self, class: T, field: U, sig: V) -> Result<JValue>
+    pub fn get_static_field<T, U, V>(&self, class: T, field: U, sig: V) -> Result<JValue<'a>>
     where
         T: Desc<'a, JClass<'a>>,
         U: Into<JNIString>,


### PR DESCRIPTION
## Overview

This fixes a small typo where the lifetime of the resulting type was using the inferred lifetime from `&self` instead of the `'a` lifetime.

I didn't add any tests because it would just be a compile check test, and I don't think there are any tests of this type for other functions that also return `JValue<'a>`. I also didn't update the changelog because AFAICT it shouldn't break any existing code since in `&'b JNIEnv<'a>` there should be an implicit constraint `'a: 'b`.

### Definition of Done

- [x] There are no TODOs left in the code
- [ ] Change is covered by automated [tests](https://github.com/jni-rs/jni-rs/blob/master/CONTRIBUTING.md#tests)
- [x] The [coding guidelines](https://github.com/jni-rs/jni-rs/blob/master/CONTRIBUTING.md#the-code-style) are followed
- [x] Public API has documentation
- [x] This change is not breaking **or** mentioned in the Changelog
- [x] The [continuous integration build](https://www.travis-ci.org/jni-rs/jni-rs) passes
