### PR TITLE
Support `registerNatives`

### DIFF
--- a/src/wrapper/jnienv.rs
+++ b/src/wrapper/jnienv.rs
@@ -20,7 +20,7 @@ use crate::{
     sys::{
         self, jarray, jboolean, jbooleanArray, jbyte, jbyteArray, jchar, jcharArray, jdouble,
         jdoubleArray, jfloat, jfloatArray, jint, jintArray, jlong, jlongArray, jobjectArray,
-        jshort, jshortArray, jsize, jvalue,
+        jshort, jshortArray, jsize, jvalue, JNINativeMethod
     },
     JNIVersion, JavaVM,
 };
@@ -1845,6 +1845,45 @@ impl<'a> JNIEnv<'a> {
         jni_void_call!(self.internal, EnsureLocalCapacity, capacity);
         Ok(())
     }
+
+    /// Bind function pointers to native methods of class
+    /// according to method name and signature
+    /// for details see [documentation](https://docs.oracle.com/javase/8/docs/technotes/guides/jni/spec/functions.html#RegisterNatives)
+    pub fn register_native_methods<'c, T>(&self, class: T, methods: Vec<NativeMethod>) -> Result<()>
+    where
+        T: Desc<'a, JClass<'c>>
+    {
+        let class = class.lookup(self)?;
+        let jni_native_methods: Vec<JNINativeMethod> = methods.iter().map(|nm| {
+            JNINativeMethod {
+                name: nm.name.as_ptr() as *mut c_char,
+                signature: nm.sig.as_ptr() as *mut c_char,
+                fnPtr: nm.fn_ptr
+            }
+        }).collect();
+        let res = jni_non_void_call!(self.internal, RegisterNatives, class.into_inner(), jni_native_methods.as_ptr(), jni_native_methods.len() as jint).into();
+        jni_error_code_to_result(res)
+    }
+
+    /// Unbind all native methods of class
+    pub fn unregister_native_methods<'c, T>(&self, class: T) -> Result<()>
+    where
+        T: Desc<'a, JClass<'c>>
+    {
+        let class = class.lookup(self)?;
+        let res = jni_non_void_call!(self.internal, UnregisterNatives, class.into_inner());
+        jni_error_code_to_result(res)
+    }
+}
+
+/// Native method descriptor
+pub struct NativeMethod {
+    /// Name of method
+    pub name: JNIString,
+    /// Method signature
+    pub sig: JNIString,
+    /// Pointer to native function with appropriate signature
+    pub fn_ptr: *mut c_void
 }
 
 /// Guard for a lock on a java object. This gets returned from the `lock_obj`

--- a/src/wrapper/jnienv.rs
+++ b/src/wrapper/jnienv.rs
@@ -1868,8 +1868,7 @@ impl<'a> JNIEnv<'a> {
             class.into_inner(),
             jni_native_methods.as_ptr(),
             jni_native_methods.len() as jint
-        )
-        .into();
+        );
         jni_error_code_to_result(res)
     }
 

--- a/src/wrapper/jnienv.rs
+++ b/src/wrapper/jnienv.rs
@@ -1849,7 +1849,7 @@ impl<'a> JNIEnv<'a> {
     /// Bind function pointers to native methods of class
     /// according to method name and signature
     /// for details see [documentation](https://docs.oracle.com/javase/8/docs/technotes/guides/jni/spec/functions.html#RegisterNatives)
-    pub fn register_native_methods<'c, T>(&self, class: T, methods: Vec<NativeMethod>) -> Result<()>
+    pub fn register_native_methods<'c, T>(&self, class: T, methods: &[NativeMethod]) -> Result<()>
     where
         T: Desc<'a, JClass<'c>>,
     {

--- a/src/wrapper/jnienv.rs
+++ b/src/wrapper/jnienv.rs
@@ -1889,7 +1889,8 @@ pub struct NativeMethod {
     pub name: JNIString,
     /// Method signature
     pub sig: JNIString,
-    /// Pointer to native function with appropriate signature
+    /// Pointer to native function with signature
+    /// fn(env: JNIEnv, class: JClass, ...arguments according to `sig`) -> RetType
     pub fn_ptr: *mut c_void,
 }
 

--- a/src/wrapper/jnienv.rs
+++ b/src/wrapper/jnienv.rs
@@ -20,7 +20,7 @@ use crate::{
     sys::{
         self, jarray, jboolean, jbooleanArray, jbyte, jbyteArray, jchar, jcharArray, jdouble,
         jdoubleArray, jfloat, jfloatArray, jint, jintArray, jlong, jlongArray, jobjectArray,
-        jshort, jshortArray, jsize, jvalue, JNINativeMethod
+        jshort, jshortArray, jsize, jvalue, JNINativeMethod,
     },
     JNIVersion, JavaVM,
 };
@@ -1851,24 +1851,32 @@ impl<'a> JNIEnv<'a> {
     /// for details see [documentation](https://docs.oracle.com/javase/8/docs/technotes/guides/jni/spec/functions.html#RegisterNatives)
     pub fn register_native_methods<'c, T>(&self, class: T, methods: Vec<NativeMethod>) -> Result<()>
     where
-        T: Desc<'a, JClass<'c>>
+        T: Desc<'a, JClass<'c>>,
     {
         let class = class.lookup(self)?;
-        let jni_native_methods: Vec<JNINativeMethod> = methods.iter().map(|nm| {
-            JNINativeMethod {
+        let jni_native_methods: Vec<JNINativeMethod> = methods
+            .iter()
+            .map(|nm| JNINativeMethod {
                 name: nm.name.as_ptr() as *mut c_char,
                 signature: nm.sig.as_ptr() as *mut c_char,
-                fnPtr: nm.fn_ptr
-            }
-        }).collect();
-        let res = jni_non_void_call!(self.internal, RegisterNatives, class.into_inner(), jni_native_methods.as_ptr(), jni_native_methods.len() as jint).into();
+                fnPtr: nm.fn_ptr,
+            })
+            .collect();
+        let res = jni_non_void_call!(
+            self.internal,
+            RegisterNatives,
+            class.into_inner(),
+            jni_native_methods.as_ptr(),
+            jni_native_methods.len() as jint
+        )
+        .into();
         jni_error_code_to_result(res)
     }
 
     /// Unbind all native methods of class
     pub fn unregister_native_methods<'c, T>(&self, class: T) -> Result<()>
     where
-        T: Desc<'a, JClass<'c>>
+        T: Desc<'a, JClass<'c>>,
     {
         let class = class.lookup(self)?;
         let res = jni_non_void_call!(self.internal, UnregisterNatives, class.into_inner());
@@ -1883,7 +1891,7 @@ pub struct NativeMethod {
     /// Method signature
     pub sig: JNIString,
     /// Pointer to native function with appropriate signature
-    pub fn_ptr: *mut c_void
+    pub fn_ptr: *mut c_void,
 }
 
 /// Guard for a lock on a java object. This gets returned from the `lock_obj`

--- a/src/wrapper/jnienv.rs
+++ b/src/wrapper/jnienv.rs
@@ -1847,8 +1847,8 @@ impl<'a> JNIEnv<'a> {
     }
 
     /// Bind function pointers to native methods of class
-    /// according to method name and signature
-    /// for details see [documentation](https://docs.oracle.com/javase/8/docs/technotes/guides/jni/spec/functions.html#RegisterNatives)
+    /// according to method name and signature.
+    /// For details see [documentation](https://docs.oracle.com/javase/8/docs/technotes/guides/jni/spec/functions.html#RegisterNatives).
     pub fn register_native_methods<'c, T>(&self, class: T, methods: &[NativeMethod]) -> Result<()>
     where
         T: Desc<'a, JClass<'c>>,
@@ -1872,7 +1872,7 @@ impl<'a> JNIEnv<'a> {
         jni_error_code_to_result(res)
     }
 
-    /// Unbind all native methods of class
+    /// Unbind all native methods of class.
     pub fn unregister_native_methods<'c, T>(&self, class: T) -> Result<()>
     where
         T: Desc<'a, JClass<'c>>,
@@ -1883,14 +1883,17 @@ impl<'a> JNIEnv<'a> {
     }
 }
 
-/// Native method descriptor
+/// Native method descriptor.
 pub struct NativeMethod {
-    /// Name of method
+    /// Name of method.
     pub name: JNIString,
-    /// Method signature
+    /// Method signature.
     pub sig: JNIString,
     /// Pointer to native function with signature
-    /// fn(env: JNIEnv, class: JClass, ...arguments according to `sig`) -> RetType
+    /// `fn(env: JNIEnv, class: JClass, ...arguments according to sig) -> RetType`
+    /// for static methods or
+    /// `fn(env: JNIEnv, object: JObject, ...arguments according to sig) -> RetType`
+    /// for instance methods.
     pub fn_ptr: *mut c_void,
 }
 


### PR DESCRIPTION
## Overview

Support `registerNatives` related to   #92 

### Definition of Done

- [x] There are no TODOs left in the code
- [ ] Change is covered by automated [tests](https://github.com/jni-rs/jni-rs/blob/master/CONTRIBUTING.md#tests)
- [x] The [coding guidelines](https://github.com/jni-rs/jni-rs/blob/master/CONTRIBUTING.md#the-code-style) are followed
- [x] Public API has documentation
- [x] This change is not breaking **or** mentioned in the Changelog
- [x] The [continuous integration build](https://www.travis-ci.org/jni-rs/jni-rs) passes
