### PR TITLE
Remove logging facilities from jni-rs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,6 @@ edition = "2018"
 cesu8 = "1.1.0"
 combine = "4.1.0"
 jni-sys = "0.3.0"
-log = "0.4.4"
 
 [build-dependencies]
 walkdir = "2"

--- a/src/wrapper/jnienv.rs
+++ b/src/wrapper/jnienv.rs
@@ -6,8 +6,6 @@ use std::{
     sync::{Mutex, MutexGuard},
 };
 
-use log::warn;
-
 use crate::{
     descriptors::Desc,
     errors::*,
@@ -2160,13 +2158,9 @@ pub struct MonitorGuard<'a> {
 
 impl<'a> Drop for MonitorGuard<'a> {
     fn drop(&mut self) {
-        let res: Result<()> = catch!({
+        let _: Result<()> = catch!({
             jni_unchecked!(self.env, MonitorExit, self.obj);
             Ok(())
         });
-
-        if let Err(e) = res {
-            warn!("error releasing java monitor: {}", e)
-        }
     }
 }

--- a/src/wrapper/macros.rs
+++ b/src/wrapper/macros.rs
@@ -57,9 +57,7 @@ macro_rules! jni_method {
     ( $jnienv:expr, $name:tt ) => {{
         let env = $jnienv;
         match deref!(deref!(env, "JNIEnv"), "*JNIEnv").$name {
-            Some(method) => {
-                method
-            }
+            Some(method) => method,
             None => {
                 return Err($crate::errors::Error::from(
                     $crate::errors::ErrorKind::JNIEnvMethodNotFound(stringify!($name)),
@@ -100,9 +98,7 @@ macro_rules! java_vm_method {
     ( $jnienv:expr, $name:tt ) => {{
         let env = $jnienv;
         match deref!(deref!(env, "JavaVM"), "*JavaVM").$name {
-            Some(meth) => {
-                meth
-            }
+            Some(meth) => meth,
             None => {
                 return Err($crate::errors::Error::from(
                     $crate::errors::ErrorKind::JavaVMMethodNotFound(stringify!($name)),

--- a/src/wrapper/objects/auto_byte_array.rs
+++ b/src/wrapper/objects/auto_byte_array.rs
@@ -1,6 +1,4 @@
 use crate::sys::{jbyte, JNI_ABORT};
-use log::debug;
-
 use crate::{errors::*, objects::JObject, JNIEnv};
 use std::ptr::NonNull;
 
@@ -65,7 +63,7 @@ impl<'a, 'b> AutoByteArray<'a, 'b> {
             .commit_byte_array_elements(*self.obj, unsafe { self.ptr.as_mut() });
         match res {
             Ok(()) => {}
-            Err(e) => debug!("error committing byte array: {:#?}", e),
+            Err(e) => panic!("error committing byte array: {:#?}", e),
         }
     }
 
@@ -84,7 +82,7 @@ impl<'a, 'b> Drop for AutoByteArray<'a, 'b> {
         );
         match res {
             Ok(()) => {}
-            Err(e) => debug!("error releasing byte array: {:#?}", e),
+            Err(e) => panic!("error releasing byte array: {:#?}", e),
         }
     }
 }

--- a/src/wrapper/objects/auto_local.rs
+++ b/src/wrapper/objects/auto_local.rs
@@ -1,7 +1,5 @@
 use std::mem;
 
-use log::debug;
-
 use crate::{objects::JObject, JNIEnv};
 
 /// Auto-delete wrapper for local refs.
@@ -65,11 +63,7 @@ impl<'a, 'b> AutoLocal<'a, 'b> {
 
 impl<'a, 'b> Drop for AutoLocal<'a, 'b> {
     fn drop(&mut self) {
-        let res = self.env.delete_local_ref(self.obj);
-        match res {
-            Ok(()) => {}
-            Err(e) => debug!("error dropping global ref: {:#?}", e),
-        }
+        let _ = self.env.delete_local_ref(self.obj);
     }
 }
 

--- a/src/wrapper/objects/auto_primitive_array.rs
+++ b/src/wrapper/objects/auto_primitive_array.rs
@@ -1,5 +1,3 @@
-use log::debug;
-
 use crate::wrapper::objects::ReleaseMode;
 use crate::{errors::*, objects::JObject, JNIEnv};
 use std::os::raw::c_void;
@@ -53,7 +51,7 @@ impl<'a, 'b> AutoPrimitiveArray<'a, 'b> {
             .commit_primitive_array_critical(*self.obj, unsafe { self.ptr.as_mut() });
         match res {
             Ok(()) => {}
-            Err(e) => debug!("error committing primitive array: {:#?}", e),
+            Err(e) => panic!("error committing primitive array: {:#?}", e),
         }
     }
 
@@ -72,7 +70,7 @@ impl<'a, 'b> Drop for AutoPrimitiveArray<'a, 'b> {
         );
         match res {
             Ok(()) => {}
-            Err(e) => debug!("error releasing primitive array: {:#?}", e),
+            Err(e) => panic!("error releasing primitive array: {:#?}", e),
         }
     }
 }

--- a/src/wrapper/objects/global_ref.rs
+++ b/src/wrapper/objects/global_ref.rs
@@ -89,11 +89,10 @@ impl Drop for GlobalRefGuard {
 
         let _ = match self.vm.get_env() {
             Ok(env) => drop_impl(&env, self.as_obj()),
-            Err(_) => {
-                self.vm
-                    .attach_current_thread()
-                    .and_then(|env| drop_impl(&env, self.as_obj()))
-            }
+            Err(_) => self
+                .vm
+                .attach_current_thread()
+                .and_then(|env| drop_impl(&env, self.as_obj())),
         };
     }
 }

--- a/src/wrapper/objects/global_ref.rs
+++ b/src/wrapper/objects/global_ref.rs
@@ -1,7 +1,5 @@
 use std::{convert::From, sync::Arc};
 
-use log::{debug, warn};
-
 use crate::{errors::Result, objects::JObject, sys, JNIEnv, JavaVM};
 
 /// A global JVM reference. These are "pinned" by the garbage collector and are
@@ -89,18 +87,13 @@ impl Drop for GlobalRefGuard {
             Ok(())
         }
 
-        let res = match self.vm.get_env() {
+        let _ = match self.vm.get_env() {
             Ok(env) => drop_impl(&env, self.as_obj()),
             Err(_) => {
-                warn!("Dropping a GlobalRef in a detached thread. Fix your code if this message appears frequently (see the GlobalRef docs).");
                 self.vm
                     .attach_current_thread()
                     .and_then(|env| drop_impl(&env, self.as_obj()))
             }
         };
-
-        if let Err(err) = res {
-            debug!("error dropping global ref: {:#?}", err);
-        }
     }
 }

--- a/src/wrapper/objects/jvalue.rs
+++ b/src/wrapper/objects/jvalue.rs
@@ -1,7 +1,5 @@
 use std::mem::transmute;
 
-use log::trace;
-
 use crate::{errors::*, objects::JObject, signature::Primitive, sys::*};
 
 /// Rusty version of the JNI C `jvalue` enum. Used in Java method call arguments
@@ -46,9 +44,6 @@ impl<'a> JValue<'a> {
                 l: ::std::ptr::null_mut(),
             },
         };
-        trace!("converted {:?} to jvalue {:?}", self, unsafe {
-            ::std::mem::transmute::<_, u64>(val)
-        });
         val
     }
 

--- a/src/wrapper/strings/ffi_str.rs
+++ b/src/wrapper/strings/ffi_str.rs
@@ -5,7 +5,6 @@ use std::{
 };
 
 use cesu8::{from_java_cesu8, to_java_cesu8};
-use log::debug;
 
 use crate::wrapper::strings::ffi_str;
 
@@ -55,10 +54,7 @@ impl<'a> From<&'a JNIStr> for Cow<'a, str> {
         let bytes = other.to_bytes();
         match from_java_cesu8(bytes) {
             Ok(s) => s,
-            Err(e) => {
-                debug!("error decoding java cesu8: {:#?}", e);
-                String::from_utf8_lossy(bytes)
-            }
+            Err(_) => String::from_utf8_lossy(bytes),
         }
     }
 }

--- a/src/wrapper/strings/java_str.rs
+++ b/src/wrapper/strings/java_str.rs
@@ -61,6 +61,6 @@ impl<'a: 'b, 'b> From<JavaStr<'a, 'b>> for String {
 
 impl<'a: 'b, 'b> Drop for JavaStr<'a, 'b> {
     fn drop(&mut self) {
-        let _ = self.env.release_string_utf_chars(self.obj, self.internal); 
+        let _ = self.env.release_string_utf_chars(self.obj, self.internal);
     }
 }

--- a/src/wrapper/strings/java_str.rs
+++ b/src/wrapper/strings/java_str.rs
@@ -1,7 +1,5 @@
 use std::{borrow::Cow, os::raw::c_char};
 
-use log::warn;
-
 use crate::{errors::*, objects::JString, strings::JNIStr, JNIEnv};
 
 /// Reference to a string in the JVM. Holds a pointer to the array
@@ -63,9 +61,6 @@ impl<'a: 'b, 'b> From<JavaStr<'a, 'b>> for String {
 
 impl<'a: 'b, 'b> Drop for JavaStr<'a, 'b> {
     fn drop(&mut self) {
-        match self.env.release_string_utf_chars(self.obj, self.internal) {
-            Ok(()) => {}
-            Err(e) => warn!("error dropping java str: {}", e),
-        }
+        let _ = self.env.release_string_utf_chars(self.obj, self.internal); 
     }
 }


### PR DESCRIPTION
## Overview

I'm not sure if this commit is _exactly_ ready to be merged, but I'd like to put it here to pose the question.
I do believe that logging should be removed from jni-rs. It's not a great way to report information, and pollutes logs.
However I can see it being useful for conveying drop errors. Maybe the more sensible solution is to gate logging behind a feature flag?

Anyway, here is my branch for anyone that does not want jni-rs to log. cheers. 