### PR TITLE
Release 0.15

### DIFF
--- a/.travis/run_travis_job.sh
+++ b/.travis/run_travis_job.sh
@@ -6,13 +6,13 @@ set -eu -o pipefail
 # Echo commands so that the progress can be seen in CI server logs.
 set -x
 
-# Detect installed Java
-export JAVA_HOME="$(java -XshowSettings:properties -version \
-    2>&1 > /dev/null |\
-    grep 'java.home' |\
-    awk '{print $3}')"
+# Check the shell scripts
+shellcheck .travis/run_travis_job.sh
+shellcheck test_profile
 
-export LD_LIBRARY_PATH="$(find -L ${JAVA_HOME} -type f -name libjvm.* | xargs -n1 dirname)"
+# Setup LD_LIBRARY_PATH for ITs
+# shellcheck source=/dev/null
+source test_profile
 
 # Install clippy
 if [[ ${TRAVIS_RUST_VERSION} == "nightly" ]];

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [0.15.0] — 2020-02-28
+
 ### Added
 - Ability to pass object wrappers that are convertible to `JObject` as arguments to the majority
  of JNIEnv methods without explicit conversion (#213)
@@ -174,8 +176,9 @@ to call if there is a pending exception (#124):
 ## [0.10.1]
 - No changes has been made to the Changelog until this release.
 
-[Unreleased]: https://github.com/jni-rs/jni-rs/compare/v0.14.0...HEAD
-[0.14.0]: https://github.com/jni-rs/jni-rs/compare/v0.13.1...0.14.0
+[Unreleased]: https://github.com/jni-rs/jni-rs/compare/v0.15.0...HEAD
+[0.15.0]: https://github.com/jni-rs/jni-rs/compare/v0.14.0...v0.15.0
+[0.14.0]: https://github.com/jni-rs/jni-rs/compare/v0.13.1...v0.14.0
 [0.13.1]: https://github.com/jni-rs/jni-rs/compare/v0.13.0...v0.13.1
 [0.13.0]: https://github.com/jni-rs/jni-rs/compare/v0.12.3...v0.13.0
 [0.12.3]: https://github.com/jni-rs/jni-rs/compare/v0.12.2...v0.12.3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Ability to pass object wrappers that are convertible to `JObject` as arguments to the majority
  of JNIEnv methods without explicit conversion (#213)
 - `JNIEnv#is_same_object` implementation (#213)
+- `JNIEnv#register_native_methods` (#214)
+- Conversion from `Into<JObject>` to `JValue::Object`
 
 ### Fixed
 - Passing `null` as class loader to `define_class` method now allowed according

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -81,13 +81,7 @@ to use to `LD_LIBRARY_PATH` on Linux/Mac or `PATH` environment variable on Windo
 On Linux/Mac, you can use the following script for this purpose:
 
 ```$sh
-JAVA_HOME="${JAVA_HOME:-$(java -XshowSettings:properties -version \
-    2>&1 > /dev/null |\
-    grep 'java.home' |\
-    awk '{print $3}')}"
-LIBJVM_PATH="$(find ${JAVA_HOME} -type f -name libjvm.* | xargs -n1 dirname)"
-
-export LD_LIBRARY_PATH="${LIBJVM_PATH}"
+source test_profile
 ```
 
 #### Run Tests

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -107,7 +107,7 @@ They might help you to see the performance differences between
 two [API flavours][checked-unchecked]: checked and unchecked, and
 pick the right one for your application.
 
-[checked-unchecked]: https://docs.rs/jni/0.14.0/jni/struct.JNIEnv.html#checked-and-unchecked-methods
+[checked-unchecked]: https://docs.rs/jni/0.15.0/jni/struct.JNIEnv.html#checked-and-unchecked-methods
 
 ## The Code Style
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ license = "MIT/Apache-2.0"
 name = "jni"
 repository = "https://github.com/jni-rs/jni-rs"
 # ¡When bumping version please also update it in examples and documentation!
-version = "0.14.0"
+version = "0.15.0"
 edition = "2018"
 
 [dependencies]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -82,7 +82,7 @@
 //! `mylib` that has everything needed to build an basic crate with `cargo`. We
 //! need to make a couple of changes to `Cargo.toml` before we do anything else.
 //!
-//! * Under `[dependencies]`, add `jni = "0.14.0"`
+//! * Under `[dependencies]`, add `jni = "0.15.0"`
 //! * Add a new `[lib]` section and under it, `crate_type = ["cdylib"]`.
 //!
 //! Now, if you run `cargo build` from inside the crate directory, you should

--- a/src/wrapper/java_vm/vm.rs
+++ b/src/wrapper/java_vm/vm.rs
@@ -58,7 +58,7 @@ use crate::InitArgs;
 /// in the Cargo.toml:
 ///
 /// ```toml
-/// jni = { version = "0.14.0", features = ["invocation"] }
+/// jni = { version = "0.15.0", features = ["invocation"] }
 /// ```
 ///
 /// The application will require linking to the dynamic `jvm` library, which is distributed

--- a/test_profile
+++ b/test_profile
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+# Sets the LD_LIBRARY_PATH required for running ITs dependent on libjvm.
+# See CONTRIBUTING.md for details.
+
+JAVA_HOME="${JAVA_HOME:-$(java -XshowSettings:properties -version \
+    2>&1 > /dev/null |\
+    grep 'java.home' |\
+    awk '{print $3}')}"
+
+# As JDK 8 and 9+ use different relative paths for libjvm, find the library:
+LIBJVM_PATH="$(find "${JAVA_HOME}" -type f -name 'libjvm.*' -print0 | xargs -0 -n1 dirname)"
+
+export LD_LIBRARY_PATH="${LIBJVM_PATH}"


### PR DESCRIPTION
## Overview

Bump version to 0.15.

Move the script from instructions to a file.

Add shellcheck for Bash scripts in the project.

### Definition of Done

- [ ] There are no TODOs left in the code
- [ ] Change is covered by automated [tests](https://github.com/jni-rs/jni-rs/blob/master/CONTRIBUTING.md#tests)
- [ ] The [coding guidelines](https://github.com/jni-rs/jni-rs/blob/master/CONTRIBUTING.md#the-code-style) are followed
- [ ] Public API has documentation
- [ ] This change is not breaking **or** mentioned in the Changelog
- [ ] The [continuous integration build](https://www.travis-ci.org/jni-rs/jni-rs) passes
