### PR TITLE
add wrappers for java.io.{OutputStream, InputStream}

### DIFF
--- a/src/wrapper/objects/jinputstream.rs
+++ b/src/wrapper/objects/jinputstream.rs
@@ -1,0 +1,86 @@
+use crate::{
+    errors::Result,
+    objects::{AutoLocal, JMethodID, JObject},
+    signature::{JavaType, Primitive},
+    sys::jsize,
+    JNIEnv,
+};
+use std::io;
+
+const DEFAULT_BUF_SIZE: usize = 8 * 1024; // same as std::io
+
+/// Wrapper for JObjects that implement `java.io.InputStream`.
+pub struct JInputStream<'a: 'b, 'b> {
+    internal: JObject<'a>,
+    buffer: AutoLocal<'a, 'b>,
+    read: JMethodID<'a>,
+    env: &'b JNIEnv<'a>,
+}
+
+impl<'a: 'b, 'b> std::ops::Deref for JInputStream<'a, 'b> {
+    type Target = JObject<'a>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.internal
+    }
+}
+
+impl<'a: 'b, 'b> From<JInputStream<'a, 'b>> for JObject<'a> {
+    fn from(other: JInputStream<'a, 'b>) -> JObject<'a> {
+        other.internal
+    }
+}
+
+impl<'a: 'b, 'b> JInputStream<'a, 'b> {
+    /// Wrap an environment and an object that implements
+    /// `java.io.InputStream`, specifying the capacity of the internal
+    /// buffer.
+    pub fn from_env_with_capacity(
+        capacity: usize,
+        env: &'b JNIEnv<'a>,
+        obj: JObject<'a>,
+    ) -> Result<JInputStream<'a, 'b>> {
+        let class = env.auto_local(env.find_class("java/io/InputStream")?);
+
+        let read = env.get_method_id(&class, "read", "([B)I")?;
+
+        let buffer = env.auto_local(env.new_byte_array(capacity as jsize)?);
+
+        Ok(JInputStream {
+            internal: obj,
+            buffer,
+            read,
+            env,
+        })
+    }
+    /// Wrap an environment and an object that implements `java.io.InputStream`.
+    pub fn from_env(env: &'b JNIEnv<'a>, obj: JObject<'a>) -> Result<JInputStream<'a, 'b>> {
+        Self::from_env_with_capacity(DEFAULT_BUF_SIZE, env, obj)
+    }
+}
+
+impl<'a: 'b, 'b> io::Read for JInputStream<'a, 'b> {
+    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        self.env
+            .call_method_unchecked(
+                self.internal,
+                self.read,
+                JavaType::Primitive(Primitive::Int),
+                &[self.buffer.as_obj().into()],
+            )
+            .and_then(|count| {
+                let count = count.i().unwrap();
+                if count == -1 {
+                    // EOF - signalled by a count of -1 in Java and 0 in Rust
+                    Ok(0)
+                } else {
+                    let count = count as usize;
+                    let buf = unsafe { &mut *(buf as *mut [u8] as *mut [i8]) };
+                    self.env
+                        .get_byte_array_region(*self.buffer.as_obj(), 0, &mut buf[..count])?;
+                    Ok(count)
+                }
+            })
+            .map_err(|e| io::Error::new(io::ErrorKind::Other, e))
+    }
+}

--- a/src/wrapper/objects/joutputstream.rs
+++ b/src/wrapper/objects/joutputstream.rs
@@ -1,0 +1,101 @@
+use std::cmp;
+use std::io;
+
+use crate::{
+    errors::Result,
+    objects::{AutoLocal, JMethodID, JObject},
+    signature::{JavaType, Primitive},
+    sys::jsize,
+    JNIEnv,
+};
+
+const DEFAULT_BUF_SIZE: usize = 8 * 1024; // same as std::io
+
+/// Wrapper for JObjects that implement `java.io.OutputStream`.
+pub struct JOutputStream<'a: 'b, 'b> {
+    internal: JObject<'a>,
+    buffer: AutoLocal<'a, 'b>,
+    buffer_len: usize,
+    write: JMethodID<'a>,
+    flush: JMethodID<'a>,
+    env: &'b JNIEnv<'a>,
+}
+
+impl<'a: 'b, 'b> std::ops::Deref for JOutputStream<'a, 'b> {
+    type Target = JObject<'a>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.internal
+    }
+}
+
+impl<'a: 'b, 'b> From<JOutputStream<'a, 'b>> for JObject<'a> {
+    fn from(other: JOutputStream<'a, 'b>) -> JObject<'a> {
+        other.internal
+    }
+}
+
+impl<'a: 'b, 'b> JOutputStream<'a, 'b> {
+    /// Wrap an environment and an object that implements
+    /// `java.io.OutputStream`, specifying the capacity of the internal
+    /// buffer.
+    pub fn from_env_with_capacity(
+        capacity: usize,
+        env: &'b JNIEnv<'a>,
+        obj: JObject<'a>,
+    ) -> Result<JOutputStream<'a, 'b>> {
+        let class = env.auto_local(env.find_class("java/io/OutputStream")?);
+
+        let write = env.get_method_id(&class, "write", "([BII)V")?;
+        let flush = env.get_method_id(&class, "flush", "()V")?;
+
+        let buffer = env.auto_local(env.new_byte_array(capacity as jsize)?);
+
+        Ok(JOutputStream {
+            internal: obj,
+            buffer,
+            buffer_len: capacity,
+            write,
+            flush,
+            env,
+        })
+    }
+    /// Wrap an environment and an object that implements `java.io.OutputStream`.
+    pub fn from_env(env: &'b JNIEnv<'a>, obj: JObject<'a>) -> Result<JOutputStream<'a, 'b>> {
+        Self::from_env_with_capacity(DEFAULT_BUF_SIZE, env, obj)
+    }
+}
+
+impl<'a: 'b, 'b> io::Write for JOutputStream<'a, 'b> {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        let count = cmp::min(self.buffer_len, buf.len());
+        let buf = unsafe { &*(buf as *const [u8] as *const [i8]) };
+        self.env
+            .set_byte_array_region(*self.buffer.as_obj(), 0, &buf[..count])
+            .and_then(|()| {
+                self.env.call_method_unchecked(
+                    self.internal,
+                    self.write,
+                    JavaType::Primitive(Primitive::Void),
+                    &[
+                        self.buffer.as_obj().into(),
+                        0.into(),
+                        (count as jsize).into(),
+                    ],
+                )?;
+                Ok(count)
+            })
+            .map_err(|e| io::Error::new(io::ErrorKind::Other, e))
+    }
+    fn flush(&mut self) -> io::Result<()> {
+        self.env
+            .call_method_unchecked(
+                self.internal,
+                self.flush,
+                JavaType::Primitive(Primitive::Void),
+                &[],
+            )
+            .map_err(|e| io::Error::new(io::ErrorKind::Other, e))?;
+        Ok(())
+    }
+}

--- a/src/wrapper/objects/mod.rs
+++ b/src/wrapper/objects/mod.rs
@@ -26,6 +26,12 @@ pub use self::jclass::*;
 mod jstring;
 pub use self::jstring::*;
 
+mod jinputstream;
+pub use self::jinputstream::*;
+
+mod joutputstream;
+pub use self::joutputstream::*;
+
 mod jmap;
 pub use self::jmap::*;
 

--- a/tests/streams.rs
+++ b/tests/streams.rs
@@ -1,0 +1,52 @@
+#![cfg(feature = "invocation")]
+
+use jni::objects::{JInputStream, JOutputStream};
+use std::io::{Read, Write};
+
+mod util;
+use util::{attach_current_thread, unwrap};
+
+#[test]
+pub fn jinputstream_read() {
+    let env = attach_current_thread();
+    let data = b"this is a long string for testing multiple reads";
+
+    let ba = unwrap(&env, env.byte_array_from_slice(data));
+    let bais = unwrap(
+        &env,
+        env.new_object("java/io/ByteArrayInputStream", "([B)V", &[ba.into()]),
+    );
+
+    // Use a very small capacity to test multiple calls to `read`
+    let mut stream = unwrap(&env, JInputStream::from_env_with_capacity(2, &env, bais));
+
+    let mut buf = Vec::new();
+    stream.read_to_end(&mut buf).unwrap();
+
+    assert_eq!(&buf[..], &data[..]);
+}
+
+#[test]
+pub fn joutputstream_write() {
+    let env = attach_current_thread();
+    let data = b"this is a long string for testing multiple writes";
+
+    let baos = unwrap(
+        &env,
+        env.new_object("java/io/ByteArrayOutputStream", "()V", &[]),
+    );
+
+    // Use a very small capacity to test multiple calls to `write`
+    let mut stream = unwrap(&env, JOutputStream::from_env_with_capacity(2, &env, baos));
+
+    stream.write_all(data).unwrap();
+    stream.flush().unwrap(); // no-op, just to test method call
+
+    let ba = unwrap(&env, env.call_method(baos, "toByteArray", "()[B", &[]))
+        .l()
+        .unwrap();
+
+    let buf = unwrap(&env, env.convert_byte_array(ba.into_inner()));
+
+    assert_eq!(&buf[..], &data[..]);
+}


### PR DESCRIPTION
## Overview

I was thinking this would be nice to have in jni-rs. It's useful to have if you want to use a Rust parsing library on a Java stream, for example. 

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Change is covered by automated [tests](https://github.com/jni-rs/jni-rs/blob/master/CONTRIBUTING.md#tests)
- [x] The [coding guidelines](https://github.com/jni-rs/jni-rs/blob/master/CONTRIBUTING.md#the-code-style) are followed
- [x] Public API has documentation
- [x] This change is not breaking **or** mentioned in the Changelog
- [ ] The [continuous integration build](https://www.travis-ci.org/jni-rs/jni-rs) passes
