### PR TITLE
Call into libjli.dylib instead of libjvm.dylib for MacOS

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -23,7 +23,7 @@ const EXPECTED_JVM_FILENAME: &str = "jvm.dll";
 #[cfg(target_os = "linux")]
 const EXPECTED_JVM_FILENAME: &str = "libjvm.so";
 #[cfg(target_os = "macos")]
-const EXPECTED_JVM_FILENAME: &str = "libjvm.dylib";
+const EXPECTED_JVM_FILENAME: &str = "libjli.dylib";
 
 fn main() {
     if cfg!(feature = "invocation") {
@@ -48,7 +48,15 @@ fn main() {
         }
 
         println!("cargo:rerun-if-env-changed=JAVA_HOME");
-        println!("cargo:rustc-link-lib=dylib=jvm");
+
+        // On MacOS, we need to link to libjli instead of libjvm as a workaround
+        // to a Java8 bug. See here for more information:
+        // https://bugs.openjdk.java.net/browse/JDK-7131356
+        if cfg!(target_os = "macos") {
+            println!("cargo:rustc-link-lib=dylib=jli");
+        } else {
+            println!("cargo:rustc-link-lib=dylib=jvm");
+        }
     }
 }
 


### PR DESCRIPTION
## Overview

This is a workaround for the legacy Java SE6 popup on MacOS.

If you don't have the legacy Java6 installed then the call to
`JNI_CreateJavaVM()` will result in a popup requesting you to install it
and abort, even if you call the `libjvm.dylib` that's included as part of
JDK8.

According to jpype-project/jpype#160 and
https://bugs.openjdk.java.net/browse/JDK-7131356 this is a Java8 bug and
the recommended fix is to call into `libjli.dylib` instead.

This PR fixes #220 and fixes #229. 

### See Also

- https://bugs.openjdk.java.net/browse/JDK-8064542?focusedCommentId=13624328&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-13624328 
- https://bugs.openjdk.java.net/browse/JDK-7131356

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Change is covered by automated [tests](https://github.com/jni-rs/jni-rs/blob/master/CONTRIBUTING.md#tests)
- [x] The [coding guidelines](https://github.com/jni-rs/jni-rs/blob/master/CONTRIBUTING.md#the-code-style) are followed
- [x] Public API has documentation
- [x] This change is not breaking **or** mentioned in the Changelog
- [x] The [continuous integration build](https://www.travis-ci.org/jni-rs/jni-rs) passes
