### PR TITLE
Fix the let_underscore_lock Clippy lint

### DIFF
--- a/src/wrapper/jnienv.rs
+++ b/src/wrapper/jnienv.rs
@@ -1800,7 +1800,7 @@ impl<'a> JNIEnv<'a> {
             // attempt to acquire the lock. This prevents us from consuming the
             // mutex if there's an outstanding lock. No one else will be able to
             // get a new one as long as we're in the guarded scope.
-            let _ = mbox.try_lock()?;
+            drop(mbox.try_lock()?);
 
             self.set_field_unchecked(
                 obj,


### PR DESCRIPTION
## Overview

Looks like now Clippy doesn't like `let _ = lock()` code.

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Change is covered by automated [tests](https://github.com/jni-rs/jni-rs/blob/master/CONTRIBUTING.md#tests)
- [x] The [coding guidelines](https://github.com/jni-rs/jni-rs/blob/master/CONTRIBUTING.md#the-code-style) are followed
- [x] Public API has documentation
- [x] This change is not breaking **or** mentioned in the Changelog
- [x] The [continuous integration build](https://www.travis-ci.org/jni-rs/jni-rs) passes
