### PR TITLE
Get/release byte array elements. Get/release primitive array critical

### DIFF
--- a/src/wrapper/jnienv.rs
+++ b/src/wrapper/jnienv.rs
@@ -2020,8 +2020,7 @@ impl<'a> JNIEnv<'a> {
         mode: ReleaseMode,
     ) -> Result<AutoByteArray> {
         let (ptr, is_copy) = self.get_byte_array_elements(array)?;
-        let res = AutoByteArray::new(self, array.into(), ptr, mode, is_copy);
-        Ok(res)
+        AutoByteArray::new(self, array.into(), ptr, mode, is_copy)
     }
 
     /// Return a tuple with a pointer to elements of the given Java primitive array as first
@@ -2133,8 +2132,7 @@ impl<'a> JNIEnv<'a> {
         mode: ReleaseMode,
     ) -> Result<AutoPrimitiveArray> {
         let (ptr, is_copy) = self.get_primitive_array_critical(array)?;
-        let res = AutoPrimitiveArray::new(self, array.into(), ptr, mode, is_copy);
-        Ok(res)
+        AutoPrimitiveArray::new(self, array.into(), ptr, mode, is_copy)
     }
 }
 

--- a/src/wrapper/jnienv.rs
+++ b/src/wrapper/jnienv.rs
@@ -2135,11 +2135,20 @@ impl<'a> JNIEnv<'a> {
     /// The result is valid until the corresponding AutoPrimitiveArray object goes out of scope,
     /// when the release happens automatically according to the mode parameter.
     ///
+    /// Given that Critical sections must be as short as possible, and that they come with a
+    /// number of important restrictions (see get_primitive_array_critical), use this
+    /// wrapper wisely, to avoid holding the array longer that strictly necessary.
+    /// In any case, you can:
+    ///  - Use the manual variants instead (i.e. get/release_primitive_array_critical).
+    ///  - Use std::mem::drop explicitly, to force / anticipate resource release.
+    ///  - Use a nested scope, to release the array at the nested scope's exit.
+    ///
     /// Since the returned array may be a copy of the Java array, changes made to the
     /// returned array will not necessarily be reflected in the original array until
-    /// release_primitive_array_critical() is called.
-    /// AutoPrimitiveArray has a commit() method, to force a copy of the array if needed (and
-    /// without releasing it).
+    /// release_primitive_array_critical() is called, which happens at AutoPrimitiveArray
+    /// destruction.
+    /// AutoPrimitiveArray has a commit() method, to force a copy of the array if needed (without
+    /// releasing it).
     ///
     /// See also [`get_primitive_array_critical`](struct.JNIEnv.html#method.get_primitive_array_critical)
     pub fn get_primitive_array_critical_auto(

--- a/src/wrapper/jnienv.rs
+++ b/src/wrapper/jnienv.rs
@@ -2019,7 +2019,7 @@ impl<'a> JNIEnv<'a> {
         array: jbyteArray,
         mode: ReleaseMode,
     ) -> Result<AutoByteArray> {
-        let (ptr, is_copy) = self.get_byte_array_elements(array).unwrap();
+        let (ptr, is_copy) = self.get_byte_array_elements(array)?;
         let res = AutoByteArray::new(self, array.into(), ptr, mode, is_copy);
         Ok(res)
     }

--- a/src/wrapper/jnienv.rs
+++ b/src/wrapper/jnienv.rs
@@ -2132,7 +2132,7 @@ impl<'a> JNIEnv<'a> {
         array: jarray,
         mode: ReleaseMode,
     ) -> Result<AutoPrimitiveArray> {
-        let (ptr, is_copy) = self.get_primitive_array_critical(array).unwrap();
+        let (ptr, is_copy) = self.get_primitive_array_critical(array)?;
         let res = AutoPrimitiveArray::new(self, array.into(), ptr, mode, is_copy);
         Ok(res)
     }

--- a/src/wrapper/jnienv.rs
+++ b/src/wrapper/jnienv.rs
@@ -1940,12 +1940,11 @@ impl<'a> JNIEnv<'a> {
     /// returned array will not necessarily be reflected in the original array until
     /// release_array_elements() is called.
     ///
-    /// If is_copy is not null, then *is_copy is set to JNI_TRUE if a copy is made; or it is set to
-    /// JNI_FALSE if no copy is made.
+    /// is_copy is set to JNI_TRUE if a copy is made; or it is set to JNI_FALSE if no copy is made.
     pub fn get_byte_array_elements(
         &self,
         array: jbyteArray,
-        is_copy: *mut jboolean,
+        is_copy: &mut jboolean,
     ) -> Result<*mut jbyte> {
         non_null!(array, "get_byte_array_elements array argument");
         let res = jni_non_void_call!(self.internal, GetByteArrayElements, array, is_copy);
@@ -1971,7 +1970,7 @@ impl<'a> JNIEnv<'a> {
     pub fn release_byte_array_elements(
         &self,
         array: jbyteArray,
-        elems: *mut jbyte,
+        elems: &mut jbyte,
         mode: jint,
     ) -> Result<()> {
         non_null!(array, "release_byte_array_elements array argument");
@@ -2004,7 +2003,7 @@ impl<'a> JNIEnv<'a> {
     pub fn get_primitive_array_critical(
         &self,
         array: jarray,
-        is_copy: *mut jboolean,
+        is_copy: &mut jboolean,
     ) -> Result<*mut c_void> {
         non_null!(array, "get_primitive_array_critical array argument");
         let res = jni_non_void_call!(self.internal, GetPrimitiveArrayCritical, array, is_copy);
@@ -2017,7 +2016,7 @@ impl<'a> JNIEnv<'a> {
     pub fn release_primitive_array_critical(
         &self,
         array: jarray,
-        elems: *mut c_void,
+        elems: &mut c_void,
         mode: jint,
     ) -> Result<()> {
         non_null!(array, "release_primitive_array_critical array argument");

--- a/src/wrapper/jnienv.rs
+++ b/src/wrapper/jnienv.rs
@@ -8,14 +8,13 @@ use std::{
 
 use log::warn;
 
-use crate::wrapper::objects::ReleaseMode;
 use crate::{
     descriptors::Desc,
     errors::*,
     objects::{
         AutoByteArray, AutoLocal, AutoPrimitiveArray, GlobalRef, JByteBuffer, JClass, JFieldID,
         JList, JMap, JMethodID, JObject, JStaticFieldID, JStaticMethodID, JString, JThrowable,
-        JValue,
+        JValue, ReleaseMode,
     },
     signature::{JavaType, Primitive, TypeSignature},
     strings::{JNIString, JavaStr},
@@ -438,38 +437,6 @@ impl<'a> JNIEnv<'a> {
             AllocObject,
             class.into_inner()
         ))
-    }
-
-    /// Creates a new auto-released byte array.
-    ///
-    /// See also [`get_byte_array_elements_auto`](struct.JNIEnv.html#method.get_byte_array_elements_auto)
-    fn auto_byte_array<'b, O>(
-        &'b self,
-        obj: O,
-        ptr: *mut jbyte,
-        mode: ReleaseMode,
-        is_copy: bool,
-    ) -> AutoByteArray<'a, 'b>
-    where
-        O: Into<JObject<'a>>,
-    {
-        AutoByteArray::new(self, obj.into(), ptr, mode, is_copy)
-    }
-
-    /// Creates a new auto-released primitive array.
-    ///
-    /// See also [`get_primitive_array_critical_auto`](struct.JNIEnv.html#method.get_primitive_array_critical_auto)
-    fn auto_primitive_array<'b, O>(
-        &'b self,
-        obj: O,
-        ptr: *mut c_void,
-        mode: ReleaseMode,
-        is_copy: bool,
-    ) -> AutoPrimitiveArray<'a, 'b>
-    where
-        O: Into<JObject<'a>>,
-    {
-        AutoPrimitiveArray::new(self, obj.into(), ptr, mode, is_copy)
     }
 
     /// Common functionality for finding methods.
@@ -2048,14 +2015,14 @@ impl<'a> JNIEnv<'a> {
     /// releasing it).
     ///
     /// See also [`get_byte_array_elements`](struct.JNIEnv.html#method.get_byte_array_elements)
-    pub fn get_byte_array_elements_auto(
+    pub fn get_auto_byte_array_elements(
         &self,
         array: jbyteArray,
         mode: ReleaseMode,
     ) -> Result<AutoByteArray> {
         let mut is_copy: jboolean = 0xff;
         let ptr = self.get_byte_array_elements(array, &mut is_copy).unwrap();
-        let res = self.auto_byte_array(array, ptr, mode, is_copy != JNI_FALSE);
+        let res = AutoByteArray::new(self, array.into(), ptr, mode, is_copy != JNI_FALSE);
         Ok(res)
     }
 
@@ -2151,7 +2118,7 @@ impl<'a> JNIEnv<'a> {
     /// releasing it).
     ///
     /// See also [`get_primitive_array_critical`](struct.JNIEnv.html#method.get_primitive_array_critical)
-    pub fn get_primitive_array_critical_auto(
+    pub fn get_auto_primitive_array_critical(
         &self,
         array: jarray,
         mode: ReleaseMode,
@@ -2160,7 +2127,7 @@ impl<'a> JNIEnv<'a> {
         let ptr = self
             .get_primitive_array_critical(array, &mut is_copy)
             .unwrap();
-        let res = self.auto_primitive_array(array, ptr, mode, is_copy != JNI_FALSE);
+        let res = AutoPrimitiveArray::new(self, array.into(), ptr, mode, is_copy != JNI_FALSE);
         Ok(res)
     }
 }

--- a/src/wrapper/jnienv.rs
+++ b/src/wrapper/jnienv.rs
@@ -1948,12 +1948,7 @@ impl<'a> JNIEnv<'a> {
         is_copy: *mut jboolean,
     ) -> Result<*mut jbyte> {
         non_null!(array, "get_byte_array_elements array argument");
-        let res = jni_non_void_call!(
-            self.internal,
-            GetByteArrayElements,
-            array,
-            is_copy
-        );
+        let res = jni_non_void_call!(self.internal, GetByteArrayElements, array, is_copy);
         Ok(res)
     }
 
@@ -1977,16 +1972,10 @@ impl<'a> JNIEnv<'a> {
         &self,
         array: jbyteArray,
         elems: *mut jbyte,
-        mode: jint
+        mode: jint,
     ) -> Result<()> {
         non_null!(array, "release_byte_array_elements array argument");
-        jni_void_call!(
-            self.internal,
-            ReleaseByteArrayElements,
-            array,
-            elems,
-            mode
-        );
+        jni_void_call!(self.internal, ReleaseByteArrayElements, array, elems, mode);
         Ok(())
     }
 
@@ -2018,12 +2007,7 @@ impl<'a> JNIEnv<'a> {
         is_copy: *mut jboolean,
     ) -> Result<*mut c_void> {
         non_null!(array, "get_primitive_array_critical array argument");
-        let res = jni_non_void_call!(
-            self.internal,
-            GetPrimitiveArrayCritical,
-            array,
-            is_copy
-        );
+        let res = jni_non_void_call!(self.internal, GetPrimitiveArrayCritical, array, is_copy);
         Ok(res)
     }
 
@@ -2034,7 +2018,7 @@ impl<'a> JNIEnv<'a> {
         &self,
         array: jarray,
         elems: *mut c_void,
-        mode: jint
+        mode: jint,
     ) -> Result<()> {
         non_null!(array, "release_primitive_array_critical array argument");
         jni_void_call!(

--- a/src/wrapper/jnienv.rs
+++ b/src/wrapper/jnienv.rs
@@ -1932,6 +1932,63 @@ impl<'a> JNIEnv<'a> {
         let res = jni_non_void_call!(self.internal, UnregisterNatives, class.into_inner());
         jni_error_code_to_result(res)
     }
+
+    /// Return elements of the given Java byte array.
+    ///
+    /// The result is valid until the corresponding release_byte_array_elements() function is
+    /// called. Since the returned array may be a copy of the Java array, changes made to the
+    /// returned array will not necessarily be reflected in the original array until
+    /// release_array_elements() is called.
+    ///
+    /// If is_copy is not null, then *is_copy is set to JNI_TRUE if a copy is made; or it is set to
+    /// JNI_FALSE if no copy is made.
+    pub fn get_byte_array_elements(
+        &self,
+        array: jbyteArray,
+        is_copy: *mut jboolean,
+    ) -> Result<*mut jbyte> {
+        non_null!(array, "get_byte_array_elements array argument");
+        let res = jni_non_void_call!(
+            self.internal,
+            GetByteArrayElements,
+            array,
+            is_copy
+        );
+        Ok(res)
+    }
+
+    /// Release elements of the given byte array.
+    ///
+    /// Informs the VM that the native code no longer needs access to elems. The elems argument
+    /// is a pointer derived from array using the corresponding get_byte_array_elements() function.
+    /// If necessary, this function copies back all changes made to elems to the original array.
+    ///
+    /// The mode argument provides information on how the array buffer should be released. mode
+    /// has no effect if elems is not a copy of the elements in array. Otherwise, mode has the
+    /// following impact:
+    /// 0: Copy back the content and free the elems buffer.
+    /// JNI_COMMIT: Copy back the content but do not free the elems buffer.
+    /// JNI_ABORT: Free the buffer without copying back the possible changes.
+    ///
+    /// In most cases, programmers pass “0” to the mode argument to ensure consistent behavior
+    /// for both pinned and copied arrays. The other options give the programmer more control
+    /// over memory management, and should be used with extreme care.
+    pub fn release_byte_array_elements(
+        &self,
+        array: jbyteArray,
+        elems: *mut jbyte,
+        mode: jint
+    ) -> Result<()> {
+        non_null!(array, "release_byte_array_elements array argument");
+        jni_void_call!(
+            self.internal,
+            ReleaseByteArrayElements,
+            array,
+            elems,
+            mode
+        );
+        Ok(())
+    }
 }
 
 /// Native method descriptor.

--- a/src/wrapper/objects/auto_byte_array.rs
+++ b/src/wrapper/objects/auto_byte_array.rs
@@ -1,7 +1,7 @@
 use crate::sys::{jbyte, JNI_ABORT};
 use log::debug;
 
-use crate::{objects::JObject, JNIEnv};
+use crate::{errors::*, objects::JObject, JNIEnv};
 use std::ptr::NonNull;
 
 /// ReleaseMode
@@ -43,14 +43,14 @@ impl<'a, 'b> AutoByteArray<'a, 'b> {
         ptr: *mut jbyte,
         mode: ReleaseMode,
         is_copy: bool,
-    ) -> Self {
-        AutoByteArray {
+    ) -> Result<Self> {
+        Ok(AutoByteArray {
             obj,
-            ptr: NonNull::new(ptr).expect("Non-null pointer expected"),
+            ptr: NonNull::new(ptr).ok_or_else(|| ErrorKind::NullPtr("Non-null ptr expected"))?,
             mode,
             is_copy,
             env,
-        }
+        })
     }
 
     /// Get a reference to the wrapped pointer

--- a/src/wrapper/objects/auto_byte_array.rs
+++ b/src/wrapper/objects/auto_byte_array.rs
@@ -1,4 +1,4 @@
-use jni_sys::{jbyte, JNI_ABORT};
+use crate::sys::{jbyte, JNI_ABORT};
 use log::debug;
 
 use crate::{objects::JObject, JNIEnv};
@@ -11,9 +11,9 @@ use crate::{objects::JObject, JNIEnv};
 #[repr(i32)]
 pub enum ReleaseMode {
     /// Copy back the content and free the elems buffer.
-    Copy = 0,
+    CopyBack = 0,
     /// Free the buffer without copying back the possible changes.
-    NoCopy = JNI_ABORT,
+    NoCopyBack = JNI_ABORT,
 }
 
 /// Auto-release wrapper for pointer-based byte arrays.

--- a/src/wrapper/objects/auto_byte_array.rs
+++ b/src/wrapper/objects/auto_byte_array.rs
@@ -1,5 +1,3 @@
-use std::mem;
-
 use jni_sys::{jbyte, JNI_ABORT};
 use log::debug;
 
@@ -36,7 +34,7 @@ impl<'a, 'b> AutoByteArray<'a, 'b> {
     ///
     /// Once this wrapper goes out of scope, `release_byte_array_elements` will be
     /// called on the object. While wrapped, the object can be accessed via
-    /// the `Deref` impl.
+    /// the `From` impl.
     pub fn new(
         env: &'b JNIEnv<'a>,
         obj: JObject<'a>,
@@ -53,32 +51,13 @@ impl<'a, 'b> AutoByteArray<'a, 'b> {
         }
     }
 
-    /// Forget the wrapper, returning the original pointer.
-    ///
-    /// This prevents `release_byte_array_elements` from being called when the `AutoArray`
-    /// gets dropped. You must remember to release the array manually.
-    pub fn forget(self) -> *mut jbyte {
-        let ptr = self.ptr;
-        mem::forget(self);
-        ptr
-    }
-
     /// Get a reference to the wrapped pointer
-    ///
-    /// Unlike `forget`, this ensures the wrapper from being dropped while the
-    /// returned `JObject` is still live.
-    pub fn as_ptr<'c>(&self) -> *mut jbyte
-    where
-        'a: 'c,
-    {
+    pub fn as_ptr(&self) -> *mut jbyte {
         self.ptr
     }
 
     /// Commits the result of the array, if it is a copy
     pub fn commit(&self) {
-        if !self.is_copy {
-            return;
-        }
         let res = self
             .env
             .commit_byte_array_elements(*self.obj, unsafe { self.ptr.as_mut() }.unwrap());
@@ -88,7 +67,7 @@ impl<'a, 'b> AutoByteArray<'a, 'b> {
         }
     }
 
-    /// Indicates the array is a copy or not
+    /// Indicates if the array is a copy or not
     pub fn is_copy(&self) -> bool {
         self.is_copy
     }

--- a/src/wrapper/objects/auto_byte_array.rs
+++ b/src/wrapper/objects/auto_byte_array.rs
@@ -8,11 +8,12 @@ use crate::{objects::JObject, JNIEnv};
 /// This defines the release mode of AutoByteArray (and AutoPrimitiveArray) resources, and
 /// related release array functions.
 #[derive(Clone, Copy)]
+#[repr(i32)]
 pub enum ReleaseMode {
     /// Copy back the content and free the elems buffer.
     Copy = 0,
     /// Free the buffer without copying back the possible changes.
-    NoCopy = JNI_ABORT as isize,
+    NoCopy = JNI_ABORT,
 }
 
 /// Auto-release wrapper for pointer-based byte arrays.

--- a/src/wrapper/objects/auto_byte_array.rs
+++ b/src/wrapper/objects/auto_byte_array.rs
@@ -1,0 +1,115 @@
+use std::mem;
+
+use jni_sys::{jbyte, JNI_ABORT};
+use log::debug;
+
+use crate::{objects::JObject, JNIEnv};
+
+/// ReleaseMode
+///
+/// This defines the release mode of AutoByteArray (and AutoPrimitiveArray) resources, and
+/// related release array functions.
+#[derive(Clone, Copy)]
+pub enum ReleaseMode {
+    /// Copy back the content and free the elems buffer.
+    Copy = 0,
+    /// Free the buffer without copying back the possible changes.
+    NoCopy = JNI_ABORT as isize,
+}
+
+/// Auto-release wrapper for pointer-based byte arrays.
+///
+/// This wrapper is used to wrap pointers returned by get_byte_array_elements.
+///
+/// These arrays need to be released through a call to release_byte_array_elements.
+/// This wrapper provides automatic array release when it goes out of scope.
+pub struct AutoByteArray<'a: 'b, 'b> {
+    obj: JObject<'a>,
+    ptr: *mut jbyte,
+    mode: ReleaseMode,
+    is_copy: bool,
+    env: &'b JNIEnv<'a>,
+}
+
+impl<'a, 'b> AutoByteArray<'a, 'b> {
+    /// Creates a new auto-release wrapper for a pointer-based byte array
+    ///
+    /// Once this wrapper goes out of scope, `release_byte_array_elements` will be
+    /// called on the object. While wrapped, the object can be accessed via
+    /// the `Deref` impl.
+    pub fn new(
+        env: &'b JNIEnv<'a>,
+        obj: JObject<'a>,
+        ptr: *mut jbyte,
+        mode: ReleaseMode,
+        is_copy: bool,
+    ) -> Self {
+        AutoByteArray {
+            obj,
+            ptr,
+            mode,
+            is_copy,
+            env,
+        }
+    }
+
+    /// Forget the wrapper, returning the original pointer.
+    ///
+    /// This prevents `release_byte_array_elements` from being called when the `AutoArray`
+    /// gets dropped. You must remember to release the array manually.
+    pub fn forget(self) -> *mut jbyte {
+        let ptr = self.ptr;
+        mem::forget(self);
+        ptr
+    }
+
+    /// Get a reference to the wrapped pointer
+    ///
+    /// Unlike `forget`, this ensures the wrapper from being dropped while the
+    /// returned `JObject` is still live.
+    pub fn as_ptr<'c>(&self) -> *mut jbyte
+    where
+        'a: 'c,
+    {
+        self.ptr
+    }
+
+    /// Commits the result of the array, if it is a copy
+    pub fn commit(&self) {
+        if !self.is_copy {
+            return;
+        }
+        let res = self
+            .env
+            .commit_byte_array_elements(*self.obj, unsafe { self.ptr.as_mut() }.unwrap());
+        match res {
+            Ok(()) => {}
+            Err(e) => debug!("error committing byte array: {:#?}", e),
+        }
+    }
+
+    /// Indicates the array is a copy or not
+    pub fn is_copy(&self) -> bool {
+        self.is_copy
+    }
+}
+
+impl<'a, 'b> Drop for AutoByteArray<'a, 'b> {
+    fn drop(&mut self) {
+        let res = self.env.release_byte_array_elements(
+            *self.obj,
+            unsafe { self.ptr.as_mut() }.unwrap(),
+            self.mode,
+        );
+        match res {
+            Ok(()) => {}
+            Err(e) => debug!("error releasing byte array: {:#?}", e),
+        }
+    }
+}
+
+impl<'a> From<&'a AutoByteArray<'a, '_>> for *mut jbyte {
+    fn from(other: &'a AutoByteArray) -> *mut jbyte {
+        other.as_ptr()
+    }
+}

--- a/src/wrapper/objects/auto_primitive_array.rs
+++ b/src/wrapper/objects/auto_primitive_array.rs
@@ -1,0 +1,105 @@
+use std::mem;
+
+use log::debug;
+
+use crate::wrapper::objects::ReleaseMode;
+use crate::{objects::JObject, JNIEnv};
+use std::os::raw::c_void;
+
+/// Auto-release wrapper for pointer-based primitive arrays.
+///
+/// This wrapper is used to wrap pointers returned by get_primitive_array_critical.
+///
+/// These pointers normally need to be released manually, through a call to
+/// release_primitive_array_critical.
+/// This wrapper provides automatic pointer-based array release when it goes out of scope.
+pub struct AutoPrimitiveArray<'a: 'b, 'b> {
+    obj: JObject<'a>,
+    ptr: *mut c_void,
+    mode: ReleaseMode,
+    is_copy: bool,
+    env: &'b JNIEnv<'a>,
+}
+
+impl<'a, 'b> AutoPrimitiveArray<'a, 'b> {
+    /// Creates a new auto-release wrapper for a pointer-based primitive array.
+    ///
+    /// Once this wrapper goes out of scope, `release_primitive_array_critical` will be
+    /// called on the object. While wrapped, the object can be accessed via the `Deref` impl.
+    pub fn new(
+        env: &'b JNIEnv<'a>,
+        obj: JObject<'a>,
+        ptr: *mut c_void,
+        mode: ReleaseMode,
+        is_copy: bool,
+    ) -> Self {
+        AutoPrimitiveArray {
+            obj,
+            ptr,
+            mode,
+            is_copy,
+            env,
+        }
+    }
+
+    /// Forget the wrapper, returning the original pointer.
+    ///
+    /// This prevents `release_primitive_array_critical` from being called when the
+    /// `AutoArrayCritical` gets dropped. You must remember to release the primitive array
+    /// manually.
+    pub fn forget(self) -> *mut c_void {
+        let ptr = self.ptr;
+        mem::forget(self);
+        ptr
+    }
+
+    /// Get a reference to the wrapped pointer
+    ///
+    /// Unlike `forget`, this ensures the wrapper from being dropped while the
+    /// returned `JObject` is still live.
+    pub fn as_ptr<'c>(&self) -> *mut c_void
+    where
+        'a: 'c,
+    {
+        self.ptr
+    }
+
+    /// Commits the result of the array, if it is a copy
+    pub fn commit(&self) {
+        if !self.is_copy {
+            return;
+        }
+        let res = self
+            .env
+            .commit_primitive_array_critical(*self.obj, unsafe { self.ptr.as_mut() }.unwrap());
+        match res {
+            Ok(()) => {}
+            Err(e) => debug!("error committing primitive array: {:#?}", e),
+        }
+    }
+
+    /// Indicates the array is a copy or not
+    pub fn is_copy(&self) -> bool {
+        self.is_copy
+    }
+}
+
+impl<'a, 'b> Drop for AutoPrimitiveArray<'a, 'b> {
+    fn drop(&mut self) {
+        let res = self.env.release_primitive_array_critical(
+            *self.obj,
+            unsafe { self.ptr.as_mut() }.unwrap(),
+            self.mode,
+        );
+        match res {
+            Ok(()) => {}
+            Err(e) => debug!("error releasing primitive array: {:#?}", e),
+        }
+    }
+}
+
+impl<'a> From<&'a AutoPrimitiveArray<'a, '_>> for *mut c_void {
+    fn from(other: &'a AutoPrimitiveArray) -> *mut c_void {
+        other.as_ptr()
+    }
+}

--- a/src/wrapper/objects/auto_primitive_array.rs
+++ b/src/wrapper/objects/auto_primitive_array.rs
@@ -1,7 +1,7 @@
 use log::debug;
 
 use crate::wrapper::objects::ReleaseMode;
-use crate::{objects::JObject, JNIEnv};
+use crate::{errors::*, objects::JObject, JNIEnv};
 use std::os::raw::c_void;
 use std::ptr::NonNull;
 
@@ -31,14 +31,14 @@ impl<'a, 'b> AutoPrimitiveArray<'a, 'b> {
         ptr: *mut c_void,
         mode: ReleaseMode,
         is_copy: bool,
-    ) -> Self {
-        AutoPrimitiveArray {
+    ) -> Result<Self> {
+        Ok(AutoPrimitiveArray {
             obj,
-            ptr: NonNull::new(ptr).expect("Non-null pointer expected"),
+            ptr: NonNull::new(ptr).ok_or_else(|| ErrorKind::NullPtr("Non-null ptr expected"))?,
             mode,
             is_copy,
             env,
-        }
+        })
     }
 
     /// Get a reference to the wrapped pointer

--- a/src/wrapper/objects/mod.rs
+++ b/src/wrapper/objects/mod.rs
@@ -42,3 +42,11 @@ pub use self::global_ref::*;
 // For automatic local ref deletion
 mod auto_local;
 pub use self::auto_local::*;
+
+// For automatic pointer-based byte array deletion
+mod auto_byte_array;
+pub use self::auto_byte_array::*;
+
+// For automatic pointer-based primitive array deletion
+mod auto_primitive_array;
+pub use self::auto_primitive_array::*;

--- a/tests/jni_api.rs
+++ b/tests/jni_api.rs
@@ -1,8 +1,8 @@
 #![cfg(feature = "invocation")]
 
-use std::str::FromStr;
 use jni::sys;
 use jni_sys::jboolean;
+use std::str::FromStr;
 
 use jni::{
     descriptors::Desc,
@@ -325,18 +325,20 @@ pub fn java_get_byte_array_elements() {
     // Create original Java array
     let buf: &[u8] = &[1, 2, 3];
     let java_array = env
-      .byte_array_from_slice(buf)
-      .expect("JNIEnv#byte_array_from_slice must create a java array from slice");
+        .byte_array_from_slice(buf)
+        .expect("JNIEnv#byte_array_from_slice must create a java array from slice");
 
     // Get array elements
     let mut is_copy: jboolean = 0xff;
-    let ptr = env.get_byte_array_elements(java_array, &mut is_copy).unwrap();
+    let ptr = env
+        .get_byte_array_elements(java_array, &mut is_copy)
+        .unwrap();
 
     // Check
     assert!(is_copy == sys::JNI_FALSE || is_copy == sys::JNI_TRUE);
-    assert_eq!(unsafe {*ptr.offset(0)}, 1);
-    assert_eq!(unsafe {*ptr.offset(1)}, 2);
-    assert_eq!(unsafe {*ptr.offset(2)}, 3);
+    assert_eq!(unsafe { *ptr.offset(0) }, 1);
+    assert_eq!(unsafe { *ptr.offset(1) }, 2);
+    assert_eq!(unsafe { *ptr.offset(2) }, 3);
 
     // Modify
     unsafe {
@@ -347,7 +349,7 @@ pub fn java_get_byte_array_elements() {
 
     // Release
     env.release_byte_array_elements(java_array, ptr, 0)
-      .expect("JNIEnv#release_byte_array_elements must release Java array");
+        .expect("JNIEnv#release_byte_array_elements must release Java array");
 
     // Confirm modification of original Java array
     let mut res: [i8; 3] = [0; 3];
@@ -364,18 +366,18 @@ pub fn java_get_primitive_array_critical() {
     // Create original Java array
     let buf: &[u8] = &[1, 2, 3];
     let java_array = env
-      .byte_array_from_slice(buf)
-      .expect("JNIEnv#byte_array_from_slice must create a java array from slice");
+        .byte_array_from_slice(buf)
+        .expect("JNIEnv#byte_array_from_slice must create a java array from slice");
 
     // Get array elements
     let mut is_copy: jboolean = 0xff;
-    let ptr = env.get_primitive_array_critical(java_array, &mut is_copy).unwrap();
+    let ptr = env
+        .get_primitive_array_critical(java_array, &mut is_copy)
+        .unwrap();
 
     // Convert void pointer to an unsigned byte array, without copy
     let mut vec;
-    unsafe {
-        vec = Vec::from_raw_parts(ptr as *mut u8, 3, 3)
-    }
+    unsafe { vec = Vec::from_raw_parts(ptr as *mut u8, 3, 3) }
 
     // Check
     assert!(is_copy == sys::JNI_FALSE || is_copy == sys::JNI_TRUE);
@@ -394,7 +396,7 @@ pub fn java_get_primitive_array_critical() {
     std::mem::ManuallyDrop::new(vec);
 
     env.release_primitive_array_critical(java_array, ptr, 0)
-      .expect("JNIEnv#release_primitive_array_critical must release Java array");
+        .expect("JNIEnv#release_primitive_array_critical must release Java array");
 
     // Confirm modification of original Java array
     let mut res: [i8; 3] = [0; 3];

--- a/tests/jni_api.rs
+++ b/tests/jni_api.rs
@@ -348,7 +348,7 @@ pub fn java_get_byte_array_elements() {
     }
 
     // Release
-    env.release_byte_array_elements(java_array, ptr, 0)
+    env.release_byte_array_elements(java_array, unsafe { ptr.as_mut().unwrap() }, 0)
         .expect("JNIEnv#release_byte_array_elements must release Java array");
 
     // Confirm modification of original Java array
@@ -395,7 +395,7 @@ pub fn java_get_primitive_array_critical() {
     // of scope (so release_primitive_array_critical() can properly free it)
     std::mem::ManuallyDrop::new(vec);
 
-    env.release_primitive_array_critical(java_array, ptr, 0)
+    env.release_primitive_array_critical(java_array, unsafe { ptr.as_mut().unwrap() }, 0)
         .expect("JNIEnv#release_primitive_array_critical must release Java array");
 
     // Confirm modification of original Java array

--- a/tests/jni_api.rs
+++ b/tests/jni_api.rs
@@ -1,7 +1,6 @@
 #![cfg(feature = "invocation")]
 
-use jni::sys;
-use jni_sys::{jboolean, jbyte};
+use jni_sys::jbyte;
 use std::str::FromStr;
 
 use jni::{
@@ -330,13 +329,9 @@ pub fn java_get_byte_array_elements() {
         .expect("JNIEnv#byte_array_from_slice must create a java array from slice");
 
     // Get array elements
-    let mut is_copy: jboolean = 0xff;
-    let ptr = env
-        .get_byte_array_elements(java_array, &mut is_copy)
-        .unwrap();
+    let (ptr, _is_copy) = env.get_byte_array_elements(java_array).unwrap();
 
     // Check
-    assert!(is_copy == sys::JNI_FALSE || is_copy == sys::JNI_TRUE);
     assert_eq!(unsafe { *ptr.offset(0) }, 1);
     assert_eq!(unsafe { *ptr.offset(1) }, 2);
     assert_eq!(unsafe { *ptr.offset(2) }, 3);
@@ -429,17 +424,13 @@ pub fn java_get_primitive_array_critical() {
         .expect("JNIEnv#byte_array_from_slice must create a java array from slice");
 
     // Get array elements
-    let mut is_copy: jboolean = 0xff;
-    let ptr = env
-        .get_primitive_array_critical(java_array, &mut is_copy)
-        .unwrap();
+    let (ptr, _is_copy) = env.get_primitive_array_critical(java_array).unwrap();
 
     // Convert void pointer to an unsigned byte array, without copy
     let mut vec;
     unsafe { vec = Vec::from_raw_parts(ptr as *mut u8, 3, 3) }
 
     // Check
-    assert!(is_copy == sys::JNI_FALSE || is_copy == sys::JNI_TRUE);
     assert_eq!(vec[0], 1);
     assert_eq!(vec[1], 2);
     assert_eq!(vec[2], 3);

--- a/tests/jni_api.rs
+++ b/tests/jni_api.rs
@@ -15,6 +15,7 @@ use jni::{
 };
 
 mod util;
+use jni::objects::ReleaseMode::Copy;
 use util::{attach_current_thread, unwrap};
 
 static ARRAYLIST_CLASS: &str = "java/util/ArrayList";
@@ -348,7 +349,7 @@ pub fn java_get_byte_array_elements() {
     }
 
     // Release
-    env.release_byte_array_elements(java_array, unsafe { ptr.as_mut().unwrap() }, 0)
+    env.release_byte_array_elements(java_array, unsafe { ptr.as_mut().unwrap() }, Copy)
         .expect("JNIEnv#release_byte_array_elements must release Java array");
 
     // Confirm modification of original Java array
@@ -395,7 +396,7 @@ pub fn java_get_primitive_array_critical() {
     // of scope (so release_primitive_array_critical() can properly free it)
     std::mem::ManuallyDrop::new(vec);
 
-    env.release_primitive_array_critical(java_array, unsafe { ptr.as_mut().unwrap() }, 0)
+    env.release_primitive_array_critical(java_array, unsafe { ptr.as_mut().unwrap() }, Copy)
         .expect("JNIEnv#release_primitive_array_critical must release Java array");
 
     // Confirm modification of original Java array

--- a/tests/jni_api.rs
+++ b/tests/jni_api.rs
@@ -1,6 +1,8 @@
 #![cfg(feature = "invocation")]
 
 use std::str::FromStr;
+use jni::sys;
+use jni_sys::jboolean;
 
 use jni::{
     descriptors::Desc,
@@ -314,6 +316,45 @@ pub fn java_byte_array_from_slice() {
     assert_eq!(res[0], 1);
     assert_eq!(res[1], 2);
     assert_eq!(res[2], 3);
+}
+
+#[test]
+pub fn java_get_byte_array_elements() {
+    let env = attach_current_thread();
+
+    // Create original Java array
+    let buf: &[u8] = &[1, 2, 3];
+    let java_array = env
+      .byte_array_from_slice(buf)
+      .expect("JNIEnv#byte_array_from_slice must create a java array from slice");
+
+    // Get array elements
+    let mut is_copy: jboolean = 0xff;
+    let ptr = env.get_byte_array_elements(java_array, &mut is_copy).unwrap();
+
+    // Check
+    assert!(is_copy == sys::JNI_FALSE || is_copy == sys::JNI_TRUE);
+    assert_eq!(unsafe {*ptr.offset(0)}, 1);
+    assert_eq!(unsafe {*ptr.offset(1)}, 2);
+    assert_eq!(unsafe {*ptr.offset(2)}, 3);
+
+    // Modify
+    unsafe {
+        *ptr.offset(0) += 1;
+        *ptr.offset(1) += 1;
+        *ptr.offset(2) += 1;
+    }
+
+    // Release
+    env.release_byte_array_elements(java_array, ptr, 0)
+      .expect("JNIEnv#release_byte_array_elements must release Java array");
+
+    // Confirm modification of original Java array
+    let mut res: [i8; 3] = [0; 3];
+    env.get_byte_array_region(java_array, 0, &mut res).unwrap();
+    assert_eq!(res[0], 2);
+    assert_eq!(res[1], 3);
+    assert_eq!(res[2], 4);
 }
 
 #[test]

--- a/tests/jni_api.rs
+++ b/tests/jni_api.rs
@@ -358,6 +358,53 @@ pub fn java_get_byte_array_elements() {
 }
 
 #[test]
+pub fn java_get_primitive_array_critical() {
+    let env = attach_current_thread();
+
+    // Create original Java array
+    let buf: &[u8] = &[1, 2, 3];
+    let java_array = env
+      .byte_array_from_slice(buf)
+      .expect("JNIEnv#byte_array_from_slice must create a java array from slice");
+
+    // Get array elements
+    let mut is_copy: jboolean = 0xff;
+    let ptr = env.get_primitive_array_critical(java_array, &mut is_copy).unwrap();
+
+    // Convert void pointer to an unsigned byte array, without copy
+    let mut vec;
+    unsafe {
+        vec = Vec::from_raw_parts(ptr as *mut u8, 3, 3)
+    }
+
+    // Check
+    assert!(is_copy == sys::JNI_FALSE || is_copy == sys::JNI_TRUE);
+    assert_eq!(vec[0], 1);
+    assert_eq!(vec[1], 2);
+    assert_eq!(vec[2], 3);
+
+    // Modify
+    vec[0] += 1;
+    vec[1] += 1;
+    vec[2] += 1;
+
+    // Release
+    // First, make sure vec's destructor doesn't free the data it thinks it owns when it goes out
+    // of scope (so release_primitive_array_critical() can properly free it)
+    std::mem::ManuallyDrop::new(vec);
+
+    env.release_primitive_array_critical(java_array, ptr, 0)
+      .expect("JNIEnv#release_primitive_array_critical must release Java array");
+
+    // Confirm modification of original Java array
+    let mut res: [i8; 3] = [0; 3];
+    env.get_byte_array_region(java_array, 0, &mut res).unwrap();
+    assert_eq!(res[0], 2);
+    assert_eq!(res[1], 3);
+    assert_eq!(res[2], 4);
+}
+
+#[test]
 pub fn get_object_class() {
     let env = attach_current_thread();
     let string = env.new_string("test").unwrap();


### PR DESCRIPTION
## Overview

Hello,

I've implemented wrappers around [Get/ReleaseByteArrayElements](https://docs.oracle.com/javase/8/docs/technotes/guides/jni/spec/functions.html#Get_PrimitiveType_ArrayElements_routines), and [Get/ReleasePrimitiveArrayCritical](https://docs.oracle.com/javase/8/docs/technotes/guides/jni/spec/functions.html#GetPrimitiveArrayCritical_ReleasePrimitiveArrayCritical).

I understand these functions are `unsafe`, as they return raw pointers. But they can still be convenient for performance reasons, given precautions are taken when allocating / releasing the pointed-to data. There are a couple examples on how to do this in the unit tests.

I have a series of questions regarding these functions:

- Why haven't you implemented these wrappers already?

- Do you know of better ways to use these functions, than the ones documented in the unit tests? With `get_byte_array_elements()` in particular, I haven't been able to avoid copying the array (i.e. `is_copy` always return true). At least with OpenJDK 8, and the default GC. I plan to test other VMs and other GCs, so I can document these eventually.
With `get_primitive_array_critical()`, copy is avoided (i.e. `is_copy` set to false). But the cost overall is relatively high, as it's not recommended to call other JNI functions during critical sections. The current test cases in fact throw a Warning. I suppose, because test cases are running in parallel. Do you know of specific problems if these recommendations are violated? I've been unable to detect them, and in fact all unit tests are still passing, despite the warning.

- Are you interested in these implementations? In particular, there's a family of related functions (`Get<PrimitiveType>ArrayElements`, and `Get/ReleaseStringCritical`) that can still be wrapped up.

- Regarding benchmarks, I've detected a ~15% performance improvement using `get_primitive_array_critical()`, compared to `get_byte_array_region()` (which always copies the array), and depending on array length. I can reflect / document these in the benchmarks if you want.

I've searched the issues for this and found nothing related. If you'd rather I create an issue to follow up on this, say so and I will.

Regards,
Mauro

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Change is covered by automated [tests](https://github.com/jni-rs/jni-rs/blob/master/CONTRIBUTING.md#tests)
- [x] The [coding guidelines](https://github.com/jni-rs/jni-rs/blob/master/CONTRIBUTING.md#the-code-style) are followed
- [x] Public API has documentation
- [x] This change is not breaking **or** mentioned in the Changelog
- [x] The [continuous integration build](https://www.travis-ci.org/jni-rs/jni-rs) passes
