### PR TITLE
 Switch from error-chain to thiserror 

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -12,4 +12,4 @@ install:
 build: false
 
 test_script:
-  - cargo test --features invocation,backtrace
+  - cargo test --features invocation

--- a/.travis/run_travis_job.sh
+++ b/.travis/run_travis_job.sh
@@ -42,4 +42,4 @@ if [[ ${TRAVIS_RUST_VERSION} == "stable" ]]; then
 fi
 
 # Run all tests with invocation feature (enables JavaVM ITs)
-cargo test --features=backtrace,invocation
+cargo test --features=invocation

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+
+- Switch from `error-chain` to `thiserror`, making all errors `Send`. Also, support all JNI errors
+  in the `jni_error_code_to_result` function and add more information to the `InvalidArgList`
+  error. ([#242](https://github.com/jni-rs/jni-rs/pull/242))
+
 ## [0.17.0] — 2020-06-30
 
 ### Added
@@ -23,7 +29,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [0.16.0] — 2020-02-28
 
 ### Fixed
-- Java VM instantiation with some MacOS configurations. (#220, #229, #230). 
+- Java VM instantiation with some MacOS configurations. (#220, #229, #230).
 
 ## [0.15.0] — 2020-02-28
 
@@ -40,7 +46,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [0.14.0] — 2019-10-31
 
-- Relaxed some lifetime restrictions in JNIEnv to support the case when 
+- Relaxed some lifetime restrictions in JNIEnv to support the case when
   method, field ids; and global references to classes
   have a different (larger) lifetime than JNIEnv (#209)
 
@@ -59,23 +65,23 @@ improvements and fixes.
 of [JavaVM](https://docs.rs/jni/0.13.0/jni/struct.JavaVM.html) to learn about the new features!
 
 ### Added
-- `JavaVM::attach_current_thread_permanently` method, which attaches the current 
-  thread and detaches it when the thread finishes. Daemon threads attached 
+- `JavaVM::attach_current_thread_permanently` method, which attaches the current
+  thread and detaches it when the thread finishes. Daemon threads attached
   with `JavaVM::attach_current_thread_as_daemon` also automatically detach themselves
   when finished. The number of currently attached threads may be acquired using
   `JavaVM::threads_attached` method. (#179, #180)
 - `Executor` — a simple thread attachment manager which helps to safely
-  execute a closure in attached thread context and to automatically free 
+  execute a closure in attached thread context and to automatically free
   created local references at closure exit. (#186)
 
 ### Changed
 - The default JNI API version in `InitArgsBuilder` from V1 to V8. (#178)
 - Extended the lifetimes of `AutoLocal` to make it more flexible. (#190)
 - Default exception type from checked `java.lang.Exception` to unchecked `java.lang.RuntimeException`.
-  It is used implicitly when `JNIEnv#throw` is invoked with exception message: 
-  `env.throw("Exception message")`; however, for efficiency reasons, it is recommended 
-  to specify the exception type explicitly *and* use `throw_new`: 
-  `env.throw_new(exception_type, "Exception message")`. (#194) 
+  It is used implicitly when `JNIEnv#throw` is invoked with exception message:
+  `env.throw("Exception message")`; however, for efficiency reasons, it is recommended
+  to specify the exception type explicitly *and* use `throw_new`:
+  `env.throw_new(exception_type, "Exception message")`. (#194)
 
 ### Fixed
 - Native threads attached with `JavaVM::attach_current_thread_as_daemon` now automatically detach
@@ -112,12 +118,12 @@ This release does not bring code changes.
 
 ### Highlights
 This release brings various improvements and fixes, outlined below. The most notable changes are:
-- `null` is no longer represented as an `Err` with error kind `NullPtr` if it is a value of some 
+- `null` is no longer represented as an `Err` with error kind `NullPtr` if it is a value of some
   nullable Java reference (not an indication of an error). Related issues: #136, #148, #163.
 - `unsafe` methods, providing a low-level API similar to JNI, has been marked safe and renamed
   to have `_unchecked` suffix. Such methods can be used to implement caching of class references
   and method IDs to improve performance in loops and frequently called Java callbacks.
-  If you have such, check out [the docs][unchecked-docs] and [one of early usages][cache-exonum] 
+  If you have such, check out [the docs][unchecked-docs] and [one of early usages][cache-exonum]
   of this feature.
 
 [unchecked-docs]: https://docs.rs/jni/0.11.0/jni/struct.JNIEnv.html
@@ -141,7 +147,7 @@ to call if there is a pending exception (#124):
   to be non-null.
   - Rename `jni_non_null_call` (which may return nulls) to `jni_non_void_call`.
 
-- A lot of public methods of `JNIEnv` have been marked as safe, all unsafe code 
+- A lot of public methods of `JNIEnv` have been marked as safe, all unsafe code
   has been isolated inside internal macros. Methods with `_unsafe` suffixes have
   been renamed and now have `_unchecked` suffixes (#140)
 
@@ -151,11 +157,11 @@ to call if there is a pending exception (#124):
 - Implemented Sync for GlobalRef (#102).
 
 - Improvements in macro usage for JNI methods calls (#136):
-  - `call_static_method_unchecked` and `get_static_field_unchecked` methods are 
+  - `call_static_method_unchecked` and `get_static_field_unchecked` methods are
   allowed to return NULL object
-  - Added checking for pending exception to the `call_static_method_unchecked` 
+  - Added checking for pending exception to the `call_static_method_unchecked`
   method (eliminated WARNING messages in log)
-  
+
 - Further improvements in macro usage for JNI method calls (#150):
   - The new_global_ref() and new_local_ref() functions are allowed to work with NULL objects according to specification.
   - Fixed the family of functions new_direct_byte_buffer(), get_direct_buffer_address() and get_direct_buffer_capacity()
@@ -165,7 +171,7 @@ to call if there is a pending exception (#124):
 - Implemented Clone for JNIEnv (#147).
 
 - The get_superclass(), get_field_unchecked() and get_object_array_element() are allowed to return NULL object according
- to the specification (#163). 
+ to the specification (#163).
 
 ### Fixed
 - The issue with early detaching of a thread by nested AttachGuard. (#139)
@@ -182,7 +188,7 @@ to call if there is a pending exception (#124):
 - Improved project documents (#107)
 
 ### Fixed
-- Crate type of a shared library with native methods 
+- Crate type of a shared library with native methods
   must be `cdylib` (#100)
 
 ## [0.10.1]

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,21 +1,23 @@
 # Jni-rs Contribution Guide
 
-Jni-rs is open to any contributions, whether 
+Jni-rs is open to any contributions, whether
 it is a feedback on existing features, a request for a new one, a bug report
-or a pull request. This document describes how to work with this project: 
-  * how to [build](#how-to-build) it
-  * how to [test](#tests) it
-  * the [code style guidelines](#the-code-style)
-  * how to [submit an issue](#submitting-issues)
-  * how to [submit a PR](#submitting-pull-requests).
+or a pull request. This document describes how to work with this project:
+
+* how to [build](#how-to-build) it
+* how to [test](#tests) it
+* the [code style guidelines](#the-code-style)
+* how to [submit an issue](#submitting-issues)
+* how to [submit a PR](#submitting-pull-requests).
 
 ## How to Build
 
 ### System Dependencies
 
 You need to install the following dependencies:
-  * [JDK 1.8+](http://jdk.java.net/10/).
-  * [Rust (latest stable)](https://www.rust-lang.org/).
+
+* [JDK 1.8+](http://jdk.java.net/10/).
+* [Rust (latest stable)](https://www.rust-lang.org/).
 
 ### Building
 
@@ -35,40 +37,42 @@ adding `--release` flag.
 * Unit tests are typically placed at the bottom of their module file.
   E.g. [unit tests of signature module](src/wrapper/signature.rs). Tests are wrapped
   in private module with `test` attribute:
-  
+
   ```rust
   #[cfg(test)]
   mod test {
     use super::*;
-    
+
     #[test]
     fn first_test() { /* ... */ }
-    
+
     // More tests...
   }
   ```
-* Integration tests are in [tests directory](tests). They use the same pattern as 
+
+* Integration tests are in [tests directory](tests). They use the same pattern as
   unit tests, but split into several files instead of private modules.
-  Integration tests use `jni-rs` as every other Rust application — by importing 
+  Integration tests use `jni-rs` as every other Rust application — by importing
   library using `extern crate` keyword.
-  
+
   ```rust
     extern crate jni;
     use jni::*;
   ```
-  Integration tests typically require running a JVM, so you should add 
+
+  Integration tests typically require running a JVM, so you should add
   `#![cfg(feature = "invocation")]` at the top of the file. You can use helper
   methods from [util module](tests/util/mod.rs) to run JVM.
-  
+
   Keep in mind, that only one JVM can be run per process. Therefore, tests that
-  need to launch it with different parameters have to be placed in different 
+  need to launch it with different parameters have to be placed in different
   source files. `Cargo` runs tests from different modules in parallel.
 
 * Benchmarks are in [benches](benches) directory. As integration tests, they
   require launching a JVM from native.
 
 * Doc tests are rarely used, but they allow to efficiently test some functionality
-  by providing an example of its usage. Consult 
+  by providing an example of its usage. Consult
   [Rust documentation](https://doc.rust-lang.org/beta/rustdoc/documentation-tests.html)
   for more info about writing these tests.
 
@@ -89,7 +93,7 @@ source test_profile
 To run all tests, execute the following command:
 
 ```$sh
-cargo test --features=backtrace,invocation
+cargo test --features=invocation
 ```
 
 This command will run all tests, including unit, integration and documentation
@@ -115,12 +119,13 @@ Rust code follows the [Rust style guide](https://github.com/rust-lang-nursery/fm
 [`rustfmt`](https://github.com/rust-lang-nursery/rustfmt) enforces the code style.
 
 After installation, you can run it with
+
 ```$sh
 cargo fmt --all -- --check
 ```
 
 Every public entry of the API must be thoroughly documented and covered with tests if it is possible.
-You can use [JNI specification](https://docs.oracle.com/javase/10/docs/specs/jni/index.html) as 
+You can use [JNI specification](https://docs.oracle.com/javase/10/docs/specs/jni/index.html) as
 a reference for how to write detailed documentation.
 
 Do not forget to update project guides and tutorials along with documentation.
@@ -132,10 +137,11 @@ cargo doc --open
 ```
 
 ## Submitting Issues
-Use Github Issues to submit an issue, whether it is a question, some feedback, a bug or a feature request:
-https://github.com/jni-rs/jni-rs/issues/new
+
+Use Github Issues to submit an issue, whether it is a question, some feedback, a bug or a feature request: <https://github.com/jni-rs/jni-rs/issues/new>
 
 ## Submitting Pull Requests
+
 Before starting to work on a PR, please submit an issue describing the intended changes.
 Chances are — we are already working on something similar. If not — we can then offer some
 help with the requirements, design, implementation or documentation.
@@ -143,13 +149,16 @@ help with the requirements, design, implementation or documentation.
 It’s fine to open a PR as soon as you need any feedback — ask any questions in the description.
 
 ## License
+
 Licensed under either of
 
- * Apache License, Version 2.0 ([LICENSE-APACHE](LICENSE-APACHE) or http://www.apache.org/licenses/LICENSE-2.0)
- * MIT license ([LICENSE-MIT](LICENSE-MIT) or http://opensource.org/licenses/MIT)
-at your option.
+* Apache License, Version 2.0 ([LICENSE-APACHE](LICENSE-APACHE) or
+  <http://www.apache.org/licenses/LICENSE-2.0>)
+* MIT license ([LICENSE-MIT](LICENSE-MIT) or <http://opensource.org/licenses/MIT>)
+  at your option.
 
 ### Contributor License Agreement
+
 Unless you explicitly state otherwise, any contribution intentionally
 submitted for inclusion is the work by you, as defined in the
 Apache-2.0 license, shall be dual licensed as above, without any

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,13 +21,10 @@ cesu8 = "1.1.0"
 combine = "4.1.0"
 jni-sys = "0.3.0"
 log = "0.4.4"
+thiserror = "1.0.20"
 
 [build-dependencies]
 walkdir = "2"
-
-[dependencies.error-chain]
-default-features = false
-version = "0.12.0"
 
 [dev-dependencies]
 lazy_static = "1"
@@ -35,8 +32,7 @@ lazy_static = "1"
 
 [features]
 invocation = []
-backtrace = ["error-chain/backtrace"]
-default = ["backtrace"]
+default = []
 
 [package.metadata.docs.rs]
 features = ["invocation"]

--- a/src/wrapper/errors.rs
+++ b/src/wrapper/errors.rs
@@ -3,6 +3,7 @@
 use thiserror::Error;
 
 use crate::sys;
+use crate::wrapper::signature::TypeSignature;
 
 pub type Result<T> = std::result::Result<T, Error>;
 
@@ -12,8 +13,8 @@ pub enum Error {
     WrongJValueType(&'static str, &'static str),
     #[error("Invalid constructor return type (must be void)")]
     InvalidCtorReturn,
-    #[error("Invalid number of arguments passed to java method")]
-    InvalidArgList,
+    #[error("Invalid number of arguments passed to java method: {0}")]
+    InvalidArgList(TypeSignature),
     #[error("Method not found: {name} {sig}")]
     MethodNotFound { name: String, sig: String },
     #[error("Field not found: {name} {sig}")]

--- a/src/wrapper/errors.rs
+++ b/src/wrapper/errors.rs
@@ -1,84 +1,58 @@
 #![allow(missing_docs)]
 
-use error_chain::*;
+use thiserror::Error;
 
 use crate::sys;
 
-error_chain! {
-    foreign_links {
-    }
+pub type Result<T> = std::result::Result<T, Error>;
 
-    errors {
-        WrongJValueType(cast: &'static str, actual: &'static str) {
-            description("Invalid JValue type cast")
-            display("Invalid JValue type cast: {}. Actual type: {}",
-                    cast,
-                    actual)
-        }
-        InvalidCtorReturn {
-            description("Invalid constructor return type (must be void)")
-            display("Invalid constructor return type (must be void)")
-        }
-        InvalidArgList {
-            description("Invalid number of arguments passed to java method")
-            display("Invalid number of arguments passed to java method")
-        }
-        MethodNotFound(name: String, sig: String) {
-            description("Method not found")
-            display("Method not found: {} {}", name, sig)
-        }
-        FieldNotFound(name: String, ty: String) {
-            description("Field not found")
-            display("Field not found: {} {}", name, ty)
-        }
-        JavaException {
-            description("Java exception was thrown")
-            display("Java exception was thrown")
-        }
-        JNIEnvMethodNotFound(name: &'static str) {
-            description("Method pointer null in JNIEnv")
-            display("JNIEnv null method pointer for {}", name)
-        }
-        NullPtr(context: &'static str) {
-            description("null pointer")
-            display("null pointer in {}", context)
-        }
-        NullDeref(context: &'static str) {
-            description("null pointer deref")
-            display("null pointer deref in {}", context)
-        }
-        TryLock {
-            description("mutex already locked")
-            display("mutex already locked")
-        }
-        JavaVMMethodNotFound(name: &'static str) {
-            description("Method pointer null in JavaVM")
-            display("JavaVM null method pointer for {}", name)
-        }
-        ThreadDetached {
-            description("Current thread is not attached to the java VM")
-            display("Current thread is not attached to the java VM")
-        }
-        Other(error: sys::jint) {
-            description("JNI error")
-            display("JNI error: {}", error)
-        }
-    }
+#[derive(Debug, Error)]
+pub enum Error {
+    #[error("Invalid JValue type cast: {0}. Actual type: {1}")]
+    WrongJValueType(&'static str, &'static str),
+    #[error("Invalid constructor return type (must be void)")]
+    InvalidCtorReturn,
+    #[error("Invalid number of arguments passed to java method")]
+    InvalidArgList,
+    #[error("Method not found: {name} {sig}")]
+    MethodNotFound { name: String, sig: String },
+    #[error("Field not found: {name} {sig}")]
+    FieldNotFound { name: String, sig: String },
+    #[error("Java exception was thrown")]
+    JavaException,
+    #[error("JNIEnv null method pointer for {0}")]
+    JNIEnvMethodNotFound(&'static str),
+    #[error("Null pointer in {0}")]
+    NullPtr(&'static str),
+    #[error("Null pointer deref in {0}")]
+    NullDeref(&'static str),
+    #[error("Mutex already locked")]
+    TryLock,
+    #[error("JavaVM null method pointer for {0}")]
+    JavaVMMethodNotFound(&'static str),
+    #[error("Current thread is not attached to the java VM")]
+    ThreadDetached,
+    #[error("Field already set: {0}")]
+    FieldAlreadySet(String),
+    #[error("Throw failed with error code {0}")]
+    ThrowFailed(i32),
+    #[error("Parse failed for input: {1}")]
+    ParseFailed(#[source] combine::error::StringStreamError, String),
+    #[error("JNI error: {0}")]
+    Other(sys::jint),
 }
-
-unsafe impl Sync for Error {}
 
 impl<T> From<::std::sync::TryLockError<T>> for Error {
     fn from(_: ::std::sync::TryLockError<T>) -> Self {
-        ErrorKind::TryLock.into()
+        Error::TryLock
     }
 }
 
 pub fn jni_error_code_to_result(code: sys::jint) -> Result<()> {
     match code {
         sys::JNI_OK => Ok(()),
-        sys::JNI_EDETACHED => Err(Error::from(ErrorKind::ThreadDetached)),
-        _ => Err(Error::from(ErrorKind::Other(code))),
+        sys::JNI_EDETACHED => Err(Error::ThreadDetached),
+        _ => Err(Error::Other(code)),
     }
 }
 

--- a/src/wrapper/errors.rs
+++ b/src/wrapper/errors.rs
@@ -30,8 +30,18 @@ pub enum Error {
     TryLock,
     #[error("JavaVM null method pointer for {0}")]
     JavaVMMethodNotFound(&'static str),
-    #[error("Current thread is not attached to the java VM")]
+    #[error("Unknown error")]
+    Unknown,
+    #[error("Current thread is not attached to the Java VM")]
     ThreadDetached,
+    #[error("Problem due to JNI version mismatch")]
+    WrongVersion,
+    #[error("Not enough memory available")]
+    NoMemory,
+    #[error("Java VM already created")]
+    AlreadyCreated,
+    #[error("Invalid arguments provided")]
+    InvalidArguments,
     #[error("Field already set: {0}")]
     FieldAlreadySet(String),
     #[error("Throw failed with error code {0}")]
@@ -51,7 +61,12 @@ impl<T> From<::std::sync::TryLockError<T>> for Error {
 pub fn jni_error_code_to_result(code: sys::jint) -> Result<()> {
     match code {
         sys::JNI_OK => Ok(()),
+        sys::JNI_ERR => Err(Error::Unknown),
         sys::JNI_EDETACHED => Err(Error::ThreadDetached),
+        sys::JNI_EVERSION => Err(Error::WrongVersion),
+        sys::JNI_ENOMEM => Err(Error::NoMemory),
+        sys::JNI_EEXIST => Err(Error::AlreadyCreated),
+        sys::JNI_EINVAL => Err(Error::InvalidArguments),
         _ => Err(Error::Other(code)),
     }
 }

--- a/src/wrapper/errors.rs
+++ b/src/wrapper/errors.rs
@@ -45,7 +45,7 @@ pub enum Error {
 pub enum JniError {
     #[error("Unknown error")]
     Unknown,
-    #[error("Thread was detached from the VM")]
+    #[error("Current thread is not attached to the Java VM")]
     ThreadDetached,
     #[error("JNI version error")]
     WrongVersion,

--- a/src/wrapper/jnienv.rs
+++ b/src/wrapper/jnienv.rs
@@ -311,7 +311,7 @@ impl<'a> JNIEnv<'a> {
     pub fn get_direct_buffer_capacity(&self, buf: JByteBuffer) -> Result<jlong> {
         let capacity = jni_unchecked!(self.internal, GetDirectBufferCapacity, buf.into_inner());
         match capacity {
-            -1 => Err(Error::Other(sys::JNI_ERR)),
+            -1 => Err(Error::JniCall(JniError::Unknown)),
             _ => Ok(capacity),
         }
     }

--- a/src/wrapper/jnienv.rs
+++ b/src/wrapper/jnienv.rs
@@ -844,7 +844,7 @@ impl<'a> JNIEnv<'a> {
         // parse the signature
         let parsed = TypeSignature::from_str(sig.as_ref())?;
         if parsed.args.len() != args.len() {
-            return Err(Error::InvalidArgList);
+            return Err(Error::InvalidArgList(parsed));
         }
 
         let class = self.auto_local(self.get_object_class(obj)?);
@@ -877,7 +877,7 @@ impl<'a> JNIEnv<'a> {
     {
         let parsed = TypeSignature::from_str(&sig)?;
         if parsed.args.len() != args.len() {
-            return Err(Error::InvalidArgList);
+            return Err(Error::InvalidArgList(parsed));
         }
 
         // go ahead and look up the class since it's already Copy,
@@ -903,7 +903,7 @@ impl<'a> JNIEnv<'a> {
         let parsed = TypeSignature::from_str(&ctor_sig)?;
 
         if parsed.args.len() != ctor_args.len() {
-            return Err(Error::InvalidArgList);
+            return Err(Error::InvalidArgList(parsed));
         }
 
         if parsed.ret != JavaType::Primitive(Primitive::Void) {

--- a/src/wrapper/macros.rs
+++ b/src/wrapper/macros.rs
@@ -26,7 +26,7 @@ macro_rules! jni_non_void_call {
 macro_rules! non_null {
     ( $obj:expr, $ctx:expr ) => {
         if $obj.is_null() {
-            return Err($crate::errors::ErrorKind::NullPtr($ctx).into());
+            return Err($crate::errors::Error::NullPtr($ctx));
         } else {
             $obj
         }
@@ -70,10 +70,9 @@ macro_rules! jni_method {
             }
             None => {
                 log::trace!("jnienv method not defined, returning error");
-                return Err($crate::errors::Error::from(
-                    $crate::errors::ErrorKind::JNIEnvMethodNotFound(stringify!($name)),
-                )
-                .into());
+                return Err($crate::errors::Error::JNIEnvMethodNotFound(stringify!(
+                    $name
+                )));
             }
         }
     }};
@@ -85,9 +84,7 @@ macro_rules! check_exception {
         let check = { jni_unchecked!($jnienv, ExceptionCheck) } == $crate::sys::JNI_TRUE;
         if check {
             log::trace!("exception found, returning error");
-            return Err(
-                $crate::errors::Error::from($crate::errors::ErrorKind::JavaException).into(),
-            );
+            return Err($crate::errors::Error::JavaException);
         }
         log::trace!("no exception found");
     };
@@ -120,10 +117,9 @@ macro_rules! java_vm_method {
             }
             None => {
                 log::trace!("JavaVM method not defined, returning error");
-                return Err($crate::errors::Error::from(
-                    $crate::errors::ErrorKind::JavaVMMethodNotFound(stringify!($name)),
-                )
-                .into());
+                return Err($crate::errors::Error::JavaVMMethodNotFound(stringify!(
+                    $name
+                )));
             }
         }
     }};
@@ -132,7 +128,7 @@ macro_rules! java_vm_method {
 macro_rules! deref {
     ( $obj:expr, $ctx:expr ) => {
         if $obj.is_null() {
-            return Err($crate::errors::ErrorKind::NullDeref($ctx).into());
+            return Err($crate::errors::Error::NullDeref($ctx));
         } else {
             #[allow(unused_unsafe)]
             unsafe {

--- a/src/wrapper/objects/auto_byte_array.rs
+++ b/src/wrapper/objects/auto_byte_array.rs
@@ -46,7 +46,7 @@ impl<'a, 'b> AutoByteArray<'a, 'b> {
     ) -> Result<Self> {
         Ok(AutoByteArray {
             obj,
-            ptr: NonNull::new(ptr).ok_or_else(|| ErrorKind::NullPtr("Non-null ptr expected"))?,
+            ptr: NonNull::new(ptr).ok_or_else(|| Error::NullPtr("Non-null ptr expected"))?,
             mode,
             is_copy,
             env,

--- a/src/wrapper/objects/auto_primitive_array.rs
+++ b/src/wrapper/objects/auto_primitive_array.rs
@@ -34,7 +34,7 @@ impl<'a, 'b> AutoPrimitiveArray<'a, 'b> {
     ) -> Result<Self> {
         Ok(AutoPrimitiveArray {
             obj,
-            ptr: NonNull::new(ptr).ok_or_else(|| ErrorKind::NullPtr("Non-null ptr expected"))?,
+            ptr: NonNull::new(ptr).ok_or_else(|| Error::NullPtr("Non-null ptr expected"))?,
             mode,
             is_copy,
             env,

--- a/src/wrapper/objects/jlist.rs
+++ b/src/wrapper/objects/jlist.rs
@@ -71,8 +71,8 @@ impl<'a: 'b, 'b> JList<'a, 'b> {
 
         match result {
             Ok(val) => Ok(Some(val.l()?)),
-            Err(e) => match *e.kind() {
-                ErrorKind::NullPtr(_) => Ok(None),
+            Err(e) => match e {
+                Error::NullPtr(_) => Ok(None),
                 _ => Err(e),
             },
         }
@@ -115,8 +115,8 @@ impl<'a: 'b, 'b> JList<'a, 'b> {
 
         match result {
             Ok(val) => Ok(Some(val.l()?)),
-            Err(e) => match *e.kind() {
-                ErrorKind::NullPtr(_) => Ok(None),
+            Err(e) => match e {
+                Error::NullPtr(_) => Ok(None),
                 _ => Err(e),
             },
         }
@@ -152,8 +152,8 @@ impl<'a: 'b, 'b> JList<'a, 'b> {
 
         match result {
             Ok(val) => Ok(Some(val.l()?)),
-            Err(e) => match *e.kind() {
-                ErrorKind::NullPtr(_) => Ok(None),
+            Err(e) => match e {
+                Error::NullPtr(_) => Ok(None),
                 _ => Err(e),
             },
         }

--- a/src/wrapper/objects/jmap.rs
+++ b/src/wrapper/objects/jmap.rs
@@ -73,8 +73,8 @@ impl<'a: 'b, 'b> JMap<'a, 'b> {
 
         match result {
             Ok(val) => Ok(Some(val.l()?)),
-            Err(e) => match *e.kind() {
-                ErrorKind::NullPtr(_) => Ok(None),
+            Err(e) => match e {
+                Error::NullPtr(_) => Ok(None),
                 _ => Err(e),
             },
         }
@@ -92,8 +92,8 @@ impl<'a: 'b, 'b> JMap<'a, 'b> {
 
         match result {
             Ok(val) => Ok(Some(val.l()?)),
-            Err(e) => match *e.kind() {
-                ErrorKind::NullPtr(_) => Ok(None),
+            Err(e) => match e {
+                Error::NullPtr(_) => Ok(None),
                 _ => Err(e),
             },
         }
@@ -111,8 +111,8 @@ impl<'a: 'b, 'b> JMap<'a, 'b> {
 
         match result {
             Ok(val) => Ok(Some(val.l()?)),
-            Err(e) => match *e.kind() {
-                ErrorKind::NullPtr(_) => Ok(None),
+            Err(e) => match e {
+                Error::NullPtr(_) => Ok(None),
                 _ => Err(e),
             },
         }

--- a/src/wrapper/objects/jvalue.rs
+++ b/src/wrapper/objects/jvalue.rs
@@ -89,7 +89,7 @@ impl<'a> JValue<'a> {
     pub fn l(self) -> Result<JObject<'a>> {
         match self {
             JValue::Object(obj) => Ok(obj),
-            _ => Err(ErrorKind::WrongJValueType("object", self.type_name()).into()),
+            _ => Err(Error::WrongJValueType("object", self.type_name())),
         }
     }
 
@@ -97,7 +97,7 @@ impl<'a> JValue<'a> {
     pub fn z(self) -> Result<bool> {
         match self {
             JValue::Bool(b) => Ok(b == JNI_TRUE),
-            _ => Err(ErrorKind::WrongJValueType("bool", self.type_name()).into()),
+            _ => Err(Error::WrongJValueType("bool", self.type_name())),
         }
     }
 
@@ -105,7 +105,7 @@ impl<'a> JValue<'a> {
     pub fn b(self) -> Result<jbyte> {
         match self {
             JValue::Byte(b) => Ok(b),
-            _ => Err(ErrorKind::WrongJValueType("jbyte", self.type_name()).into()),
+            _ => Err(Error::WrongJValueType("jbyte", self.type_name())),
         }
     }
 
@@ -113,7 +113,7 @@ impl<'a> JValue<'a> {
     pub fn c(self) -> Result<jchar> {
         match self {
             JValue::Char(b) => Ok(b),
-            _ => Err(ErrorKind::WrongJValueType("jchar", self.type_name()).into()),
+            _ => Err(Error::WrongJValueType("jchar", self.type_name())),
         }
     }
 
@@ -121,7 +121,7 @@ impl<'a> JValue<'a> {
     pub fn d(self) -> Result<jdouble> {
         match self {
             JValue::Double(b) => Ok(b),
-            _ => Err(ErrorKind::WrongJValueType("jdouble", self.type_name()).into()),
+            _ => Err(Error::WrongJValueType("jdouble", self.type_name())),
         }
     }
 
@@ -129,7 +129,7 @@ impl<'a> JValue<'a> {
     pub fn f(self) -> Result<jfloat> {
         match self {
             JValue::Float(b) => Ok(b),
-            _ => Err(ErrorKind::WrongJValueType("jfloat", self.type_name()).into()),
+            _ => Err(Error::WrongJValueType("jfloat", self.type_name())),
         }
     }
 
@@ -137,7 +137,7 @@ impl<'a> JValue<'a> {
     pub fn i(self) -> Result<jint> {
         match self {
             JValue::Int(b) => Ok(b),
-            _ => Err(ErrorKind::WrongJValueType("jint", self.type_name()).into()),
+            _ => Err(Error::WrongJValueType("jint", self.type_name())),
         }
     }
 
@@ -145,7 +145,7 @@ impl<'a> JValue<'a> {
     pub fn j(self) -> Result<jlong> {
         match self {
             JValue::Long(b) => Ok(b),
-            _ => Err(ErrorKind::WrongJValueType("jlong", self.type_name()).into()),
+            _ => Err(Error::WrongJValueType("jlong", self.type_name())),
         }
     }
 
@@ -153,7 +153,7 @@ impl<'a> JValue<'a> {
     pub fn s(self) -> Result<jshort> {
         match self {
             JValue::Short(b) => Ok(b),
-            _ => Err(ErrorKind::WrongJValueType("jshort", self.type_name()).into()),
+            _ => Err(Error::WrongJValueType("jshort", self.type_name())),
         }
     }
 
@@ -161,7 +161,7 @@ impl<'a> JValue<'a> {
     pub fn v(self) -> Result<()> {
         match self {
             JValue::Void => Ok(()),
-            _ => Err(ErrorKind::WrongJValueType("void", self.type_name()).into()),
+            _ => Err(Error::WrongJValueType("void", self.type_name())),
         }
     }
 }

--- a/tests/executor_nested_attach.rs
+++ b/tests/executor_nested_attach.rs
@@ -2,7 +2,10 @@
 
 use std::{sync::Arc, thread::spawn};
 
-use jni::{errors::Error, Executor, JavaVM};
+use jni::{
+    errors::{Error, JniError},
+    Executor, JavaVM,
+};
 
 mod util;
 use util::jvm;
@@ -52,7 +55,7 @@ fn is_attached(vm: &JavaVM) -> bool {
     vm.get_env()
         .map(|_| true)
         .or_else(|jni_err| match jni_err {
-            Error::ThreadDetached => Ok(false),
+            Error::JniCall(JniError::ThreadDetached) => Ok(false),
             _ => Err(jni_err),
         })
         .expect("An unexpected JNI error occurred")

--- a/tests/executor_nested_attach.rs
+++ b/tests/executor_nested_attach.rs
@@ -2,7 +2,7 @@
 
 use std::{sync::Arc, thread::spawn};
 
-use jni::{errors::ErrorKind, Executor, JavaVM};
+use jni::{errors::Error, Executor, JavaVM};
 
 mod util;
 use util::jvm;
@@ -51,8 +51,8 @@ fn check_detached(vm: &JavaVM) {
 fn is_attached(vm: &JavaVM) -> bool {
     vm.get_env()
         .map(|_| true)
-        .or_else(|jni_err| match jni_err.0 {
-            ErrorKind::ThreadDetached => Ok(false),
+        .or_else(|jni_err| match jni_err {
+            Error::ThreadDetached => Ok(false),
             _ => Err(jni_err),
         })
         .expect("An unexpected JNI error occurred")

--- a/tests/java_integers.rs
+++ b/tests/java_integers.rs
@@ -1,6 +1,5 @@
 #![cfg(feature = "invocation")]
 
-use error_chain::ChainedError;
 use jni::{objects::JObject, objects::JValue};
 
 mod util;
@@ -38,7 +37,7 @@ fn test_java_integers() {
         })
         .unwrap_or_else(|e| {
             print_exception(&env);
-            panic!(e.display_chain().to_string());
+            panic!("{:#?}", e);
         });
     }
 }

--- a/tests/jni_api.rs
+++ b/tests/jni_api.rs
@@ -5,7 +5,7 @@ use std::str::FromStr;
 
 use jni::{
     descriptors::Desc,
-    errors::{Error, ErrorKind},
+    errors::Error,
     objects::{AutoLocal, JByteBuffer, JList, JObject, JString, JThrowable, JValue},
     signature::JavaType,
     strings::JNIString,
@@ -272,8 +272,8 @@ pub fn call_static_method_throws() {
             MATH_TO_INT_SIGNATURE,
             &[x],
         )
-        .map_err(|error| match error.0 {
-            ErrorKind::JavaException => true,
+        .map_err(|error| match error {
+            Error::JavaException => true,
             _ => false,
         })
         .expect_err("JNIEnv#call_static_method_unsafe should return error");
@@ -523,8 +523,8 @@ pub fn get_object_class_null_arg() {
     let null_obj = JObject::null();
     let result = env
         .get_object_class(null_obj)
-        .map_err(|error| match *error.kind() {
-            ErrorKind::NullPtr(_) => true,
+        .map_err(|error| match error {
+            Error::NullPtr(_) => true,
             _ => false,
         })
         .expect_err("JNIEnv#get_object_class should return error for null argument");
@@ -850,8 +850,8 @@ where
 fn assert_exception(res: Result<jobject, Error>, expect_message: &str) {
     assert!(res.is_err());
     assert!(res
-        .map_err(|error| match *error.kind() {
-            ErrorKind::JavaException => true,
+        .map_err(|error| match error {
+            Error::JavaException => true,
             _ => false,
         })
         .expect_err(expect_message));

--- a/tests/util/mod.rs
+++ b/tests/util/mod.rs
@@ -1,6 +1,5 @@
 use std::sync::{Arc, Once};
 
-use error_chain::ChainedError;
 use jni::{
     errors::Result, objects::JValue, sys::jint, AttachGuard, InitArgsBuilder, JNIEnv, JNIVersion,
     JavaVM,
@@ -18,10 +17,9 @@ pub fn jvm() -> &'static Arc<JavaVM> {
             .version(JNIVersion::V8)
             .option("-Xcheck:jni")
             .build()
-            .unwrap_or_else(|e| panic!("{}", e.display_chain().to_string()));
+            .unwrap_or_else(|e| panic!("{:#?}", e));
 
-        let jvm =
-            JavaVM::new(jvm_args).unwrap_or_else(|e| panic!("{}", e.display_chain().to_string()));
+        let jvm = JavaVM::new(jvm_args).unwrap_or_else(|e| panic!("{:#?}", e));
 
         unsafe {
             JVM = Some(Arc::new(jvm));
@@ -82,6 +80,6 @@ pub fn print_exception(env: &JNIEnv) {
 pub fn unwrap<T>(env: &JNIEnv, res: Result<T>) -> T {
     res.unwrap_or_else(|e| {
         print_exception(&env);
-        panic!("{}", e.display_chain().to_string());
+        panic!("{:#?}", e);
     })
 }


### PR DESCRIPTION
## Overview

I ran into a similar problem as in #233 as `error-chain` errors are all `!Sync` which makes using it in `anyhow` difficult. Therefore, I took the time to convert the errors to `thiserror` versions.

I noticed issues #166 and #86 which were very simple so I fixed them along the way as separate commits.

This fixes #233, fixes #166 and fixes #86.

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Change is covered by automated [tests](https://github.com/jni-rs/jni-rs/blob/master/CONTRIBUTING.md#tests)
- [x] The [coding guidelines](https://github.com/jni-rs/jni-rs/blob/master/CONTRIBUTING.md#the-code-style) are followed
- [x] Public API has documentation
- [x] This change is not breaking **or** mentioned in the Changelog
- [x] The [continuous integration build](https://www.travis-ci.org/jni-rs/jni-rs) passes
