### PR TITLE
Search right library name on MacOS in test_profile

### DIFF
--- a/test_profile
+++ b/test_profile
@@ -8,7 +8,13 @@ JAVA_HOME="${JAVA_HOME:-$(java -XshowSettings:properties -version \
     grep 'java.home' |\
     awk '{print $3}')}"
 
+if [[ "$(uname -s)" == "Darwin" ]]; then
+    LIB_NAME="libjli"
+else
+    LIB_NAME="libjvm"
+fi
+
 # As JDK 8 and 9+ use different relative paths for libjvm, find the library:
-LIBJVM_PATH="$(find "${JAVA_HOME}" -type f -name 'libjvm.*' -print0 | xargs -0 -n1 dirname)"
+LIBJVM_PATH="$(find "${JAVA_HOME}" -type f -name "${LIB_NAME}.*" -print0 | xargs -0 -n1 dirname)"
 
 export LD_LIBRARY_PATH="${LIBJVM_PATH}"


### PR DESCRIPTION
## Overview

When working on another PR I noticed that the `test_profile` script couldn't find the right library on my Mac when trying to run the integration tests.

This PR adds a switch to use `libjli` instead of `libjvm` for MacOS similar to how it's done in the `build.rs` file.

It's nothing related to the actual functionality of the crate so I didn't add any entry to the changelog.

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Change is covered by automated [tests](https://github.com/jni-rs/jni-rs/blob/master/CONTRIBUTING.md#tests)
- [x] The [coding guidelines](https://github.com/jni-rs/jni-rs/blob/master/CONTRIBUTING.md#the-code-style) are followed
- [x] Public API has documentation
- [x] This change is not breaking **or** mentioned in the Changelog
- [x] The [continuous integration build](https://www.travis-ci.org/jni-rs/jni-rs) passes
