### PR TITLE
Add method to define a class using an AutoByteArray

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - `JavaStr::from_raw()` which takes ownership of a raw string pointer to create a `JavaStr` ([#374](https://github.com/jni-rs/jni-rs/pull/374))
 - `JNIEnv::get_string_unchecked` is a cheaper, `unsafe` alternative to `get_string` that doesn't check the given object is a `java.lang.String` instance. ([#328](https://github.com/jni-rs/jni-rs/issues/328))
 - `WeakRef` and `JNIEnv#new_weak_ref`. ([#304](https://github.com/jni-rs/jni-rs/pull/304))
+- `define_class_bytearray` method that takes an `AutoArray<jbyte>` rather than a `&[u8]`
 
 ### Changed
 - `JNIEnv::get_string` checks that the given object is a `java.lang.String` instance to avoid undefined behaviour from the JNI implementation potentially aborting the program. ([#328](https://github.com/jni-rs/jni-rs/issues/328))

--- a/src/wrapper/jnienv.rs
+++ b/src/wrapper/jnienv.rs
@@ -143,6 +143,29 @@ impl<'a> JNIEnv<'a> {
         Ok(unsafe { JClass::from_raw(class) })
     }
 
+    /// Load a class from a buffer of raw class data. The name of the class must match the name
+    /// encoded within the class file data.
+    pub fn define_class_bytearray<S>(
+        &self,
+        name: S,
+        loader: JObject<'a>,
+        buf: AutoArray<'_, jbyte>,
+    ) -> Result<JClass<'a>>
+    where
+        S: Into<JNIString>,
+    {
+        let name = name.into();
+        let class = jni_non_null_call!(
+            self.internal,
+            DefineClass,
+            name.as_ptr(),
+            loader.into_raw(),
+            buf.as_ptr(),
+            buf.size()?
+        );
+        Ok(unsafe { JClass::from_raw(class) })
+    }
+
     /// Look up a class by name.
     ///
     /// # Example


### PR DESCRIPTION
## Overview

1. Adds `len` method to `AutoByteArray`
2. Adds `define_class_bytearr` method that takes an `AutoByteArray` rather than a `&[u8]`

I was struggling working out how to feed defineClass a `jbyteArray` and this seemed like the best way to do it.
Im new to rust, so please let me know if this is a dumb change/there is a better way to do it.

### Definition of Done

- [*] There are no TODOs left in the code
- [*] Change is covered by automated [tests](https://github.com/jni-rs/jni-rs/blob/master/CONTRIBUTING.md#tests)
- [*] The [coding guidelines](https://github.com/jni-rs/jni-rs/blob/master/CONTRIBUTING.md#the-code-style) are followed
- [*] Public API has documentation
- [*] This change is not breaking **or** mentioned in the Changelog
- [ ] The [continuous integration build](https://www.travis-ci.org/jni-rs/jni-rs) passes
