### PR TITLE
Make JNIEnv `Copy`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Switch from `error-chain` to `thiserror`, making all errors `Send`. Also, support all JNI errors
   in the `jni_error_code_to_result` function and add more information to the `InvalidArgList`
   error. ([#242](https://github.com/jni-rs/jni-rs/pull/242))
+- Implemented Copy for JNIEnv (#255).
 
 ## [0.17.0] — 2020-06-30
 

--- a/src/wrapper/jnienv.rs
+++ b/src/wrapper/jnienv.rs
@@ -74,7 +74,7 @@ use crate::{
 ///
 /// Calling unchecked methods with invalid arguments and/or invalid class and
 /// method descriptors may lead to segmentation fault.
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 #[repr(transparent)]
 pub struct JNIEnv<'a> {
     internal: *mut sys::JNIEnv,


### PR DESCRIPTION
## Overview

Currently JNIEnv is `Clone` but not `Copy`, however there seems no difficulty in having it also be `Copy`.

Possibly I've missed or misunderstood something such that this is a bad idea, in which case I look forward to learning the reason. Thank you.

If this is acceptable but needs some additional test or documentation work just let me know.

### Definition of Done

- [x] There are no TODOs left in the code
- [ ] Change is covered by automated [tests](https://github.com/jni-rs/jni-rs/blob/master/CONTRIBUTING.md#tests)
- [x] The [coding guidelines](https://github.com/jni-rs/jni-rs/blob/master/CONTRIBUTING.md#the-code-style) are followed
- [ ] Public API has documentation
- [x] This change is not breaking **or** mentioned in the Changelog
- [ ] The [continuous integration build](https://www.travis-ci.org/jni-rs/jni-rs) passes
