### PR TITLE
Add repr(transparent) attribute to JavaVM struct

### DIFF
--- a/src/wrapper/java_vm/vm.rs
+++ b/src/wrapper/java_vm/vm.rs
@@ -130,6 +130,7 @@ use crate::InitArgs;
 /// [actp]: struct.JavaVM.html#method.attach_current_thread_permanently
 /// [actd]: struct.JavaVM.html#method.attach_current_thread_as_daemon
 /// [spec-references]: https://docs.oracle.com/en/java/javase/12/docs/specs/jni/design.html#referencing-java-objects
+#[repr(transparent)]
 pub struct JavaVM(*mut sys::JavaVM);
 
 unsafe impl Send for JavaVM {}

--- a/src/wrapper/objects/auto_byte_array.rs
+++ b/src/wrapper/objects/auto_byte_array.rs
@@ -46,7 +46,7 @@ impl<'a, 'b> AutoByteArray<'a, 'b> {
     ) -> Result<Self> {
         Ok(AutoByteArray {
             obj,
-            ptr: NonNull::new(ptr).ok_or_else(|| Error::NullPtr("Non-null ptr expected"))?,
+            ptr: NonNull::new(ptr).ok_or(Error::NullPtr("Non-null ptr expected"))?,
             mode,
             is_copy,
             env,

--- a/src/wrapper/objects/auto_primitive_array.rs
+++ b/src/wrapper/objects/auto_primitive_array.rs
@@ -34,7 +34,7 @@ impl<'a, 'b> AutoPrimitiveArray<'a, 'b> {
     ) -> Result<Self> {
         Ok(AutoPrimitiveArray {
             obj,
-            ptr: NonNull::new(ptr).ok_or_else(|| Error::NullPtr("Non-null ptr expected"))?,
+            ptr: NonNull::new(ptr).ok_or(Error::NullPtr("Non-null ptr expected"))?,
             mode,
             is_copy,
             env,

--- a/tests/jni_api.rs
+++ b/tests/jni_api.rs
@@ -628,43 +628,35 @@ pub fn new_primitive_array_wrong() {
     const WRONG_SIZE: jsize = -1;
 
     let result = env.new_boolean_array(WRONG_SIZE);
-    assert!(result.is_err());
-    assert_exception(result, "JNIEnv#new_boolean_array should throw exception");
+    assert_exception(&result, "JNIEnv#new_boolean_array should throw exception");
     assert_pending_java_exception(&env);
 
     let result = env.new_byte_array(WRONG_SIZE);
-    assert!(result.is_err());
-    assert_exception(result, "JNIEnv#new_byte_array should throw exception");
+    assert_exception(&result, "JNIEnv#new_byte_array should throw exception");
     assert_pending_java_exception(&env);
 
     let result = env.new_char_array(WRONG_SIZE);
-    assert!(result.is_err());
-    assert_exception(result, "JNIEnv#new_char_array should throw exception");
+    assert_exception(&result, "JNIEnv#new_char_array should throw exception");
     assert_pending_java_exception(&env);
 
     let result = env.new_short_array(WRONG_SIZE);
-    assert!(result.is_err());
-    assert_exception(result, "JNIEnv#new_short_array should throw exception");
+    assert_exception(&result, "JNIEnv#new_short_array should throw exception");
     assert_pending_java_exception(&env);
 
     let result = env.new_int_array(WRONG_SIZE);
-    assert!(result.is_err());
-    assert_exception(result, "JNIEnv#new_int_array should throw exception");
+    assert_exception(&result, "JNIEnv#new_int_array should throw exception");
     assert_pending_java_exception(&env);
 
     let result = env.new_long_array(WRONG_SIZE);
-    assert!(result.is_err());
-    assert_exception(result, "JNIEnv#new_long_array should throw exception");
+    assert_exception(&result, "JNIEnv#new_long_array should throw exception");
     assert_pending_java_exception(&env);
 
     let result = env.new_float_array(WRONG_SIZE);
-    assert!(result.is_err());
-    assert_exception(result, "JNIEnv#new_float_array should throw exception");
+    assert_exception(&result, "JNIEnv#new_float_array should throw exception");
     assert_pending_java_exception(&env);
 
     let result = env.new_double_array(WRONG_SIZE);
-    assert!(result.is_err());
-    assert_exception(result, "JNIEnv#new_double_array should throw exception");
+    assert_exception(&result, "JNIEnv#new_double_array should throw exception");
     assert_pending_java_exception(&env);
 }
 
@@ -841,9 +833,10 @@ where
 }
 
 // Helper method that asserts that result is Error and the cause is JavaException.
-fn assert_exception(res: Result<jobject, Error>, expect_message: &str) {
+fn assert_exception(res: &Result<jobject, Error>, expect_message: &str) {
     assert!(res.is_err());
     assert!(res
+        .as_ref()
         .map_err(|error| matches!(error, Error::JavaException))
         .expect_err(expect_message));
 }

--- a/tests/jni_api.rs
+++ b/tests/jni_api.rs
@@ -272,10 +272,7 @@ pub fn call_static_method_throws() {
             MATH_TO_INT_SIGNATURE,
             &[x],
         )
-        .map_err(|error| match error {
-            Error::JavaException => true,
-            _ => false,
-        })
+        .map_err(|error| matches!(error, Error::JavaException))
         .expect_err("JNIEnv#call_static_method_unsafe should return error");
 
     assert!(
@@ -523,10 +520,7 @@ pub fn get_object_class_null_arg() {
     let null_obj = JObject::null();
     let result = env
         .get_object_class(null_obj)
-        .map_err(|error| match error {
-            Error::NullPtr(_) => true,
-            _ => false,
-        })
+        .map_err(|error| matches!(error, Error::NullPtr(_)))
         .expect_err("JNIEnv#get_object_class should return error for null argument");
     assert!(result, "ErrorKind::NullPtr expected as error");
 }
@@ -850,10 +844,7 @@ where
 fn assert_exception(res: Result<jobject, Error>, expect_message: &str) {
     assert!(res.is_err());
     assert!(res
-        .map_err(|error| match error {
-            Error::JavaException => true,
-            _ => false,
-        })
+        .map_err(|error| matches!(error, Error::JavaException))
         .expect_err(expect_message));
 }
 

--- a/tests/threads_nested_attach_daemon.rs
+++ b/tests/threads_nested_attach_daemon.rs
@@ -45,7 +45,5 @@ pub fn nested_attaches_should_not_detach_daemon_thread() {
         assert_eq!(jvm().threads_attached(), 1);
     }
     assert_eq!(jvm().threads_attached(), 1);
-
-    drop(env);
     assert_eq!(jvm().threads_attached(), 1);
 }

--- a/tests/threads_nested_attach_daemon.rs
+++ b/tests/threads_nested_attach_daemon.rs
@@ -45,5 +45,4 @@ pub fn nested_attaches_should_not_detach_daemon_thread() {
         assert_eq!(jvm().threads_attached(), 1);
     }
     assert_eq!(jvm().threads_attached(), 1);
-    assert_eq!(jvm().threads_attached(), 1);
 }

--- a/tests/threads_nested_attach_permanently.rs
+++ b/tests/threads_nested_attach_permanently.rs
@@ -47,7 +47,6 @@ pub fn nested_attaches_should_not_detach_permanent_thread() {
     assert_eq!(jvm().threads_attached(), 1);
 
     // Dropping JNIEnv obtained from a permanent attach has no effect on the thread status.
-    drop(env);
     assert_eq!(jvm().threads_attached(), 1);
     assert!(jvm().get_env().is_ok());
 }

--- a/tests/threads_nested_attach_permanently.rs
+++ b/tests/threads_nested_attach_permanently.rs
@@ -45,8 +45,5 @@ pub fn nested_attaches_should_not_detach_permanent_thread() {
         assert_eq!(jvm().threads_attached(), 1);
     }
     assert_eq!(jvm().threads_attached(), 1);
-
-    // Dropping JNIEnv obtained from a permanent attach has no effect on the thread status.
-    assert_eq!(jvm().threads_attached(), 1);
     assert!(jvm().get_env().is_ok());
 }


### PR DESCRIPTION
## Overview

Adding of the attribute makes rust 1.46 compiler happy about issue: `extern` fn uses type `jni::JavaVM`, which is not FFI-safe`
 
```
warning: `extern` fn uses type `jni::JavaVM`, which is not FFI-safe
  --> src/utils/jni_cache.rs:67:39
   |
67 | pub extern "system" fn JNI_OnLoad(vm: JavaVM, _: *mut c_void) -> jint {
   |                                       ^^^^^^ not FFI-safe
   |
   = note: `#[warn(improper_ctypes_definitions)]` on by default
   = help: consider adding a `#[repr(C)]` or `#[repr(transparent)]` attribute to this struct
   = note: this struct has unspecified layout
``` 

### Definition of Done

- [x] There are no TODOs left in the code
- [ ] Change is covered by automated [tests](https://github.com/jni-rs/jni-rs/blob/master/CONTRIBUTING.md#tests)
- [ ] The [coding guidelines](https://github.com/jni-rs/jni-rs/blob/master/CONTRIBUTING.md#the-code-style) are followed
- [ ] Public API has documentation
- [x] This change is not breaking **or** mentioned in the Changelog
- [ ] The [continuous integration build](https://www.travis-ci.org/jni-rs/jni-rs) passes
