### PR TITLE
Add conversion JvmError into Error

### DIFF
--- a/src/wrapper/errors.rs
+++ b/src/wrapper/errors.rs
@@ -37,6 +37,8 @@ pub enum Error {
     ThrowFailed(i32),
     #[error("Parse failed for input: {1}")]
     ParseFailed(#[source] combine::error::StringStreamError, String),
+    #[error("Error occurred in JavaVM: {0}")]
+    JvmError(String),
     #[error("JNI call failed")]
     JniCall(#[source] JniError),
 }

--- a/src/wrapper/java_vm/init_args.rs
+++ b/src/wrapper/java_vm/init_args.rs
@@ -3,6 +3,7 @@ use std::{ffi::CString, os::raw::c_void};
 use thiserror::Error;
 
 use crate::{
+    errors::Error as JniError,
     sys::{JavaVMInitArgs, JavaVMOption},
     JNIVersion,
 };
@@ -14,6 +15,12 @@ pub enum JvmError {
     /// An internal `0` byte was found when constructing a string.
     #[error("internal null in option: {0}")]
     NullOptString(String),
+}
+
+impl From<JvmError> for JniError {
+    fn from(e: JvmError) -> Self {
+        JniError::JvmError(format!("{}", e))
+    }
 }
 
 /// Builder for JavaVM InitArgs.


### PR DESCRIPTION
## Overview

It would be convenient to make such conversions in user's code.

### Definition of Done

- [ ] There are no TODOs left in the code
- [ ] Change is covered by automated [tests](https://github.com/jni-rs/jni-rs/blob/master/CONTRIBUTING.md#tests)
- [ ] The [coding guidelines](https://github.com/jni-rs/jni-rs/blob/master/CONTRIBUTING.md#the-code-style) are followed
- [ ] Public API has documentation
- [ ] This change is not breaking **or** mentioned in the Changelog
- [ ] The [continuous integration build](https://www.travis-ci.org/jni-rs/jni-rs) passes
