### PR TITLE
Clarify which changes go to the changelog

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,12 +1,12 @@
 ## Overview
 
-Please describe your changes here and list any open questions you might have.
+<!-- Please describe your changes here and list any open questions you might have. -->
 
 ### Definition of Done
 
 - [ ] There are no TODOs left in the code
-- [ ] Change is covered by automated [tests](https://github.com/jni-rs/jni-rs/blob/master/CONTRIBUTING.md#tests)
+- [ ] Change is covered by [automated tests](https://github.com/jni-rs/jni-rs/blob/master/CONTRIBUTING.md#tests)
 - [ ] The [coding guidelines](https://github.com/jni-rs/jni-rs/blob/master/CONTRIBUTING.md#the-code-style) are followed
 - [ ] Public API has documentation
-- [ ] This change is not breaking **or** mentioned in the Changelog
-- [ ] The [continuous integration build](https://www.travis-ci.org/jni-rs/jni-rs) passes
+- [ ] User-visible changes are mentioned in the Changelog
+- [ ] The continuous integration build passes


### PR DESCRIPTION
## Overview

We strive to put not just "breaking" but any significant changes visible to the end-user.

Also, removed the link to not presently working travis, and made the link to our testing guide more visible.

