### PR TITLE
Introduce WeakGlobalRef

### DIFF
--- a/src/wrapper/jnienv.rs
+++ b/src/wrapper/jnienv.rs
@@ -375,7 +375,7 @@ impl<'a> JNIEnv<'a> {
         )
         .into();
 
-        let weak_global = unsafe { GlobalRef::from_raw(self.get_java_vm()?, new_ref.into_inner()) };
+        let global = unsafe { GlobalRef::from_raw(self.get_java_vm()?, new_ref.into_inner()) };
         Ok(weak_global)
     }
 

--- a/src/wrapper/jnienv.rs
+++ b/src/wrapper/jnienv.rs
@@ -376,7 +376,7 @@ impl<'a> JNIEnv<'a> {
         .into();
 
         let global = unsafe { GlobalRef::from_raw(self.get_java_vm()?, new_ref.into_inner()) };
-        Ok(weak_global)
+        Ok(global)
     }
 
     /// Create a new local ref to an object.

--- a/src/wrapper/objects/jweak.rs
+++ b/src/wrapper/objects/jweak.rs
@@ -1,0 +1,45 @@
+use std::marker::PhantomData;
+
+use crate::sys::jweak;
+
+/// Wrapper around `sys::jweak` that adds a lifetime. This prevents it from
+/// outliving the context in which it was acquired. It matches C's representation
+/// of the raw pointer, so it can be used in any of the extern function argument
+/// positions that would take a `jweak`.
+///
+/// See also: [WeakGlobalRef](./struct.WeakGlobalRef.html)
+#[repr(transparent)]
+#[derive(Clone, Copy, Debug)]
+pub struct JWeak<'a> {
+    internal: jweak,
+    lifetime: PhantomData<&'a ()>,
+}
+
+impl<'a> From<jweak> for JWeak<'a> {
+    fn from(other: jweak) -> Self {
+        Self {
+            internal: other,
+            lifetime: PhantomData,
+        }
+    }
+}
+
+impl<'a> ::std::ops::Deref for JWeak<'a> {
+    type Target = jweak;
+
+    fn deref(&self) -> &Self::Target {
+        &self.internal
+    }
+}
+
+impl<'a> JWeak<'a> {
+    /// Unwrap to the internal jni type.
+    pub fn into_inner(self) -> jweak {
+        self.internal
+    }
+
+    /// Creates a new null object
+    pub fn null() -> Self {
+        (::std::ptr::null_mut() as jweak).into()
+    }
+}

--- a/src/wrapper/objects/mod.rs
+++ b/src/wrapper/objects/mod.rs
@@ -50,3 +50,9 @@ pub use self::auto_byte_array::*;
 // For automatic pointer-based primitive array deletion
 mod auto_primitive_array;
 pub use self::auto_primitive_array::*;
+
+mod jweak;
+pub use self::jweak::*;
+
+mod weak_global_ref;
+pub use self::weak_global_ref::*;

--- a/src/wrapper/objects/weak_global_ref.rs
+++ b/src/wrapper/objects/weak_global_ref.rs
@@ -4,7 +4,7 @@ use log::{debug, warn};
 
 use crate::{errors::Result, objects::JWeak, sys, JNIEnv, JavaVM};
 
-/// A weak global JVM reference. **It doesn't protect underlaying object from been
+/// A weak global JVM reference. **It doesn't protect the underlying object from being
 /// garbage collected.** Still, `WeakGlobalRef` is allowed to outlive the `JNIEnv` that
 /// it came from and can be used in other threads.
 ///

--- a/src/wrapper/objects/weak_global_ref.rs
+++ b/src/wrapper/objects/weak_global_ref.rs
@@ -8,7 +8,7 @@ use crate::{errors::Result, objects::JWeak, sys, JNIEnv, JavaVM};
 /// garbage collected.** Still, `WeakGlobalRef` is allowed to outlive the `JNIEnv` that
 /// it came from and can be used in other threads.
 ///
-/// `WeakGloablRef` may be created via
+/// `WeakGlobalRef` can be created via
 /// [JNIEnv::new_weak_global_ref](../struct.JNIEnv.html#method.new_weak_global_ref).
 ///
 /// `WeakGloablRef` doesn't allow access to the underlying object but may be

--- a/src/wrapper/objects/weak_global_ref.rs
+++ b/src/wrapper/objects/weak_global_ref.rs
@@ -1,0 +1,97 @@
+use std::{convert::From, sync::Arc};
+
+use log::{debug, warn};
+
+use crate::{errors::Result, objects::JWeak, sys, JNIEnv, JavaVM};
+
+/// A weak global JVM reference. **It doesn't protect underlaying object from been
+/// garbage collected.** Still, `WeakGlobalRef` is allowed to outlive the `JNIEnv` that
+/// it came from and can be used in other threads.
+///
+/// `WeakGloablRef` may be created via
+/// [JNIEnv::new_weak_global_ref](../struct.JNIEnv.html#method.new_weak_global_ref).
+///
+/// `WeakGloablRef` doesn't allow access to the underlying object but may be
+/// upgraded into _potentially null_ [GlobalRef](struct.GlobalRef.html) via
+/// [JNIEnv::upgrade_weak_global_ref](../struct.JNIEnv.html#method.upgrade_weak_global_ref).
+///
+/// `WeakGlobalRef` can be cloned to use weak global reference in different contexts.
+///
+/// Underlying weak global reference will be dropped, when the last instance
+/// of `WeakGlobalRef` leaves its scope.
+///
+/// It is _recommended_ that a native thread that drops the global reference is attached
+/// to the Java thread (i.e., has an instance of `JNIEnv`). If the native thread is *not* attached,
+/// the `WeakGlobalRef::drop` will print a warning and implicitly `attach` and `detach` the thread,
+/// which significantly affects performance.
+#[derive(Clone)]
+pub struct WeakGlobalRef {
+    inner: Arc<WeakGlobalRefGuard>,
+}
+
+struct WeakGlobalRefGuard {
+    obj: JWeak<'static>,
+    vm: JavaVM,
+}
+
+unsafe impl Send for WeakGlobalRefGuard {}
+unsafe impl Sync for WeakGlobalRefGuard {}
+
+impl WeakGlobalRef {
+    /// Creates a new wrapper for a global reference.
+    ///
+    /// # Safety
+    ///
+    /// Expects a valid raw global reference that should be created with `NewWeakGlobalRef` JNI function.
+    pub(crate) unsafe fn from_raw(vm: JavaVM, raw_weak_global_ref: sys::jweak) -> Self {
+        Self {
+            inner: Arc::new(WeakGlobalRefGuard::from_raw(vm, raw_weak_global_ref)),
+        }
+    }
+
+    /// Get the underlying JWeak object
+    pub fn as_weak(&self) -> JWeak {
+        self.inner.as_weak()
+    }
+}
+
+impl WeakGlobalRefGuard {
+    /// Creates a new global reference guard. This assumes that `NewWeakGlobalRef`
+    /// has already been called.
+    unsafe fn from_raw(vm: JavaVM, obj: sys::jweak) -> Self {
+        WeakGlobalRefGuard {
+            obj: JWeak::from(obj),
+            vm,
+        }
+    }
+
+    /// Get the underlying JWeak object
+    pub fn as_weak(&self) -> JWeak {
+        self.obj
+    }
+}
+
+impl Drop for WeakGlobalRefGuard {
+    fn drop(&mut self) {
+        fn drop_impl(env: &JNIEnv, weak_global_ref: JWeak) -> Result<()> {
+            let internal = env.get_native_interface();
+            // This method is safe to call in case of pending exceptions (see chapter 2 of the spec)
+            jni_unchecked!(internal, DeleteWeakGlobalRef, weak_global_ref.into_inner());
+            Ok(())
+        }
+
+        let res = match self.vm.get_env() {
+            Ok(env) => drop_impl(&env, self.obj),
+            Err(_) => {
+                warn!("Dropping a WeakGlobalRef in a detached thread. Fix your code if this message appears frequently (see the WeakGlobalRef docs).");
+                self.vm
+                    .attach_current_thread()
+                    .and_then(|env| drop_impl(&env, self.obj))
+            }
+        };
+
+        if let Err(err) = res {
+            debug!("error dropping weak global ref: {:#?}", err);
+        }
+    }
+}

--- a/tests/jni_weak_refs.rs
+++ b/tests/jni_weak_refs.rs
@@ -1,0 +1,84 @@
+#![cfg(feature = "invocation")]
+
+use std::{
+    sync::{Arc, Barrier},
+    thread::spawn,
+};
+
+use jni::{
+    objects::{AutoLocal, JValue},
+    sys::jint,
+};
+
+mod util;
+use util::{attach_current_thread, unwrap};
+
+#[test]
+pub fn global_ref_works_in_other_threads() {
+    const ITERS_PER_THREAD: usize = 10_000;
+
+    let env = attach_current_thread();
+    let mut join_handlers = Vec::new();
+
+    let atomic_integer = {
+        let local_ref = AutoLocal::new(
+            &env,
+            unwrap(
+                &env,
+                env.new_object(
+                    "java/util/concurrent/atomic/AtomicInteger",
+                    "(I)V",
+                    &[JValue::from(0)],
+                ),
+            ),
+        );
+        unwrap(&env, env.new_global_ref(&local_ref))
+    };
+
+    let weak_atomic_integer = unwrap(&env, env.new_weak_global_ref(&atomic_integer));
+
+    // Test with a different number of threads (from 2 to 8)
+    for thread_num in 2..9 {
+        let barrier = Arc::new(Barrier::new(thread_num));
+
+        for _ in 0..thread_num {
+            let barrier = barrier.clone();
+            let weak_atomic_integer = weak_atomic_integer.clone();
+
+            let jh = spawn(move || {
+                let env = attach_current_thread();
+                barrier.wait();
+                for _ in 0..ITERS_PER_THREAD {
+                    let atomic_integer =
+                        unwrap(&env, env.upgrade_weak_global_ref(&weak_atomic_integer));
+                    unwrap(
+                        &env,
+                        unwrap(
+                            &env,
+                            env.call_method(&atomic_integer, "incrementAndGet", "()I", &[]),
+                        )
+                        .i(),
+                    );
+                }
+            });
+            join_handlers.push(jh);
+        }
+
+        for jh in join_handlers.drain(..) {
+            jh.join().unwrap();
+        }
+
+        let expected = (ITERS_PER_THREAD * thread_num) as jint;
+        assert_eq!(
+            expected,
+            unwrap(
+                &env,
+                unwrap(
+                    &env,
+                    env.call_method(&atomic_integer, "getAndSet", "(I)I", &[JValue::from(0)])
+                )
+                .i()
+            )
+        );
+    }
+}


### PR DESCRIPTION

## Overview
Introduce WeakGlobalRef. Closes #167

* WeakGlobalRef allows user to keep weak reference on the underlying Java object.
* The WeakGlobalRef may be created via JNIEnv::new_weak_global_ref.
* JNIEnv::upgrade_weak_global_ref may be used to obtain GlobalRef and access the underlying object.

### Definition of Done

- [ ] There are no TODOs left in the code
- [ ] Change is covered by automated [tests](https://github.com/jni-rs/jni-rs/blob/master/CONTRIBUTING.md#tests)
- [ ] The [coding guidelines](https://github.com/jni-rs/jni-rs/blob/master/CONTRIBUTING.md#the-code-style) are followed
- [ ] Public API has documentation
- [ ] This change is not breaking **or** mentioned in the Changelog
- [ ] The [continuous integration build](https://www.travis-ci.org/jni-rs/jni-rs) passes
