### PR TITLE
Add changelog section to the 0.14.0 version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,10 +41,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 - Ability to pass object wrappers that are convertible to `JObject` as arguments to the majority
- of JNIEnv methods without explicit conversion (#213)
-- `JNIEnv#is_same_object` implementation (#213)
-- `JNIEnv#register_native_methods` (#214)
-- Conversion from `Into<JObject>` to `JValue::Object`
+ of JNIEnv methods without explicit conversion. (#213)
+- `JNIEnv#is_same_object` implementation. (#213)
+- `JNIEnv#register_native_methods`. (#214)
+- Conversion from `Into<JObject>` to `JValue::Object`.
 
 ### Fixed
 - Passing `null` as class loader to `define_class` method now allowed according
@@ -52,9 +52,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [0.14.0] — 2019-10-31
 
+### Changed
 - Relaxed some lifetime restrictions in JNIEnv to support the case when
   method, field ids; and global references to classes
-  have a different (larger) lifetime than JNIEnv (#209)
+  have a different (larger) lifetime than JNIEnv. (#209)
 
 ## [0.13.1] — 2019-08-22
 


### PR DESCRIPTION
## Overview

During publishing release notes for missing releases  (#267) I have noticed some changelog inconsistencies.

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Change is covered by automated [tests](https://github.com/jni-rs/jni-rs/blob/master/CONTRIBUTING.md#tests)
- [x] The [coding guidelines](https://github.com/jni-rs/jni-rs/blob/master/CONTRIBUTING.md#the-code-style) are followed
- [x] Public API has documentation
- [x] This change is not breaking **or** mentioned in the Changelog
- [x] The [continuous integration build](https://www.travis-ci.org/jni-rs/jni-rs) passes
