### PR TITLE
Deprecate get byte array elements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Switch from `error-chain` to `thiserror`, making all errors `Send`. Also, support all JNI errors
   in the `jni_error_code_to_result` function and add more information to the `InvalidArgList`
   error. ([#242](https://github.com/jni-rs/jni-rs/pull/242))
+- `AutoByte/PrimitiveArray.commit()` now returns `Result`. (#275)
 
 ## [0.17.0] — 2020-06-30
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - `TryFrom<JValue>` for types inside JValue variants (#264).
 - Implemented Copy for JNIEnv (#255).
 - `repr(transparent)` attribute to JavaVM struct (#259)
+- `discard()` method to `AutoByteArray` and `AutoPrimitiveArray`. (#275)
+- deprecation notice for get/release/commit_byte/primitive_array_{elements|critical}. (#275)
 
 ### Changed
 - Switch from `error-chain` to `thiserror`, making all errors `Send`. Also, support all JNI errors

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+- `discard()` method to `AutoByteArray` and `AutoPrimitiveArray`. (#275)
+- deprecation notice for get/release/commit_byte/primitive_array_{elements|critical}. (#275)
+
+### Changed
+- `AutoByte/PrimitiveArray.commit()` now returns `Result`. (#275)
+
 ## [0.18.0] — 2020-09-23
 
 ### Added
@@ -24,14 +31,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - `TryFrom<JValue>` for types inside JValue variants (#264).
 - Implemented Copy for JNIEnv (#255).
 - `repr(transparent)` attribute to JavaVM struct (#259)
-- `discard()` method to `AutoByteArray` and `AutoPrimitiveArray`. (#275)
-- deprecation notice for get/release/commit_byte/primitive_array_{elements|critical}. (#275)
 
 ### Changed
 - Switch from `error-chain` to `thiserror`, making all errors `Send`. Also, support all JNI errors
   in the `jni_error_code_to_result` function and add more information to the `InvalidArgList`
   error. ([#242](https://github.com/jni-rs/jni-rs/pull/242))
-- `AutoByte/PrimitiveArray.commit()` now returns `Result`. (#275)
 
 ## [0.17.0] — 2020-06-30
 

--- a/src/wrapper/jnienv.rs
+++ b/src/wrapper/jnienv.rs
@@ -1983,7 +1983,7 @@ impl<'a> JNIEnv<'a> {
     ///
     /// See also [`release_byte_array_elements`](struct.JNIEnv.html#method.release_byte_array_elements)
     #[deprecated(
-        since = "0.18.0",
+        since = "0.19.0",
         note = "Please use get_auto_byte_array_elements instead"
     )]
     pub fn get_byte_array_elements(&self, array: jbyteArray) -> Result<(*mut jbyte, bool)> {
@@ -2013,7 +2013,7 @@ impl<'a> JNIEnv<'a> {
     ///
     /// See also [`commit_byte_array_elements`](struct.JNIEnv.html#method.commit_byte_array_elements)
     #[deprecated(
-        since = "0.18.0",
+        since = "0.19.0",
         note = "Please use get_auto_byte_array_elements instead"
     )]
     pub fn release_byte_array_elements(
@@ -2038,7 +2038,7 @@ impl<'a> JNIEnv<'a> {
     /// This function has no effect if elems is not a copy of the elements in array. Otherwise,
     /// this function copies back the content of the array (and does not free the elems buffer).
     #[deprecated(
-        since = "0.18.0",
+        since = "0.19.0",
         note = "Please use get_auto_byte_array_elements instead"
     )]
     pub fn commit_byte_array_elements(&self, array: jbyteArray, elems: &mut jbyte) -> Result<()> {
@@ -2103,7 +2103,7 @@ impl<'a> JNIEnv<'a> {
     /// See also [`get_byte_array_elements`](struct.JNIEnv.html#method.get_byte_array_elements)
     /// See also [`release_primitive_array_critical`](struct.JNIEnv.html#method.release_primitive_array_critical)
     #[deprecated(
-        since = "0.18.0",
+        since = "0.19.0",
         note = "Please use get_auto_primitive_array_critical instead"
     )]
     pub fn get_primitive_array_critical(&self, array: jarray) -> Result<(*mut c_void, bool)> {
@@ -2126,7 +2126,7 @@ impl<'a> JNIEnv<'a> {
     /// See also [`get_primitive_array_critical`](struct.JNIEnv.html#method.get_primitive_array_critical)
     /// See also [`commit_primitive_array_critical`](struct.JNIEnv.html#method.commit_primitive_array_critical)
     #[deprecated(
-        since = "0.18.0",
+        since = "0.19.0",
         note = "Please use get_auto_primitive_array_critical instead"
     )]
     pub fn release_primitive_array_critical(
@@ -2151,7 +2151,7 @@ impl<'a> JNIEnv<'a> {
     /// This function has no effect if elems is not a copy of the elements in array. Otherwise,
     /// this function copies back the content of the array (and does not free the elems buffer).
     #[deprecated(
-        since = "0.18.0",
+        since = "0.19.0",
         note = "Please use get_auto_primitive_array_critical instead"
     )]
     pub fn commit_primitive_array_critical(

--- a/src/wrapper/jnienv.rs
+++ b/src/wrapper/jnienv.rs
@@ -2070,8 +2070,10 @@ impl<'a> JNIEnv<'a> {
         array: jbyteArray,
         mode: ReleaseMode,
     ) -> Result<AutoByteArray> {
-        let (ptr, is_copy) = self.get_byte_array_elements(array)?;
-        AutoByteArray::new(self, array.into(), ptr, mode, is_copy)
+        non_null!(array, "get_auto_byte_array_elements array argument");
+        let mut is_copy: jboolean = 0xff;
+        let ptr = jni_non_void_call!(self.internal, GetByteArrayElements, array, &mut is_copy);
+        AutoByteArray::new(self, array.into(), ptr, mode, is_copy == sys::JNI_TRUE)
     }
 
     /// Return a tuple with a pointer to elements of the given Java primitive array as first

--- a/src/wrapper/jnienv.rs
+++ b/src/wrapper/jnienv.rs
@@ -2196,8 +2196,16 @@ impl<'a> JNIEnv<'a> {
         array: jarray,
         mode: ReleaseMode,
     ) -> Result<AutoPrimitiveArray> {
-        let (ptr, is_copy) = self.get_primitive_array_critical(array)?;
-        AutoPrimitiveArray::new(self, array.into(), ptr, mode, is_copy)
+        non_null!(array, "get_auto_primitive_array_critical array argument");
+        let mut is_copy: jboolean = 0xff;
+        let ptr = jni_non_void_call!(
+            self.internal,
+            GetPrimitiveArrayCritical,
+            array,
+            &mut is_copy
+        );
+        non_null!(ptr, "get_primitive_array_critical return value");
+        AutoPrimitiveArray::new(self, array.into(), ptr, mode, is_copy == sys::JNI_TRUE)
     }
 }
 

--- a/src/wrapper/jnienv.rs
+++ b/src/wrapper/jnienv.rs
@@ -1982,6 +1982,10 @@ impl<'a> JNIEnv<'a> {
     /// release_byte_array_elements() is called.
     ///
     /// See also [`release_byte_array_elements`](struct.JNIEnv.html#method.release_byte_array_elements)
+    #[deprecated(
+        since = "0.18.0",
+        note = "Please use get_auto_byte_array_elements instead"
+    )]
     pub fn get_byte_array_elements(&self, array: jbyteArray) -> Result<(*mut jbyte, bool)> {
         non_null!(array, "get_byte_array_elements array argument");
         let mut is_copy: jboolean = 0xff;
@@ -2008,6 +2012,10 @@ impl<'a> JNIEnv<'a> {
     /// control over memory management, and should be used with extreme care.
     ///
     /// See also [`commit_byte_array_elements`](struct.JNIEnv.html#method.commit_byte_array_elements)
+    #[deprecated(
+        since = "0.18.0",
+        note = "Please use get_auto_byte_array_elements instead"
+    )]
     pub fn release_byte_array_elements(
         &self,
         array: jbyteArray,
@@ -2029,6 +2037,10 @@ impl<'a> JNIEnv<'a> {
     ///
     /// This function has no effect if elems is not a copy of the elements in array. Otherwise,
     /// this function copies back the content of the array (and does not free the elems buffer).
+    #[deprecated(
+        since = "0.18.0",
+        note = "Please use get_auto_byte_array_elements instead"
+    )]
     pub fn commit_byte_array_elements(&self, array: jbyteArray, elems: &mut jbyte) -> Result<()> {
         non_null!(array, "commit_byte_array_elements array argument");
         jni_void_call!(
@@ -2088,6 +2100,10 @@ impl<'a> JNIEnv<'a> {
     ///
     /// See also [`get_byte_array_elements`](struct.JNIEnv.html#method.get_byte_array_elements)
     /// See also [`release_primitive_array_critical`](struct.JNIEnv.html#method.release_primitive_array_critical)
+    #[deprecated(
+        since = "0.18.0",
+        note = "Please use get_auto_primitive_array_critical instead"
+    )]
     pub fn get_primitive_array_critical(&self, array: jarray) -> Result<(*mut c_void, bool)> {
         non_null!(array, "get_primitive_array_critical array argument");
         let mut is_copy: jboolean = 0xff;
@@ -2107,6 +2123,10 @@ impl<'a> JNIEnv<'a> {
     ///
     /// See also [`get_primitive_array_critical`](struct.JNIEnv.html#method.get_primitive_array_critical)
     /// See also [`commit_primitive_array_critical`](struct.JNIEnv.html#method.commit_primitive_array_critical)
+    #[deprecated(
+        since = "0.18.0",
+        note = "Please use get_auto_primitive_array_critical instead"
+    )]
     pub fn release_primitive_array_critical(
         &self,
         array: jarray,
@@ -2128,6 +2148,10 @@ impl<'a> JNIEnv<'a> {
     ///
     /// This function has no effect if elems is not a copy of the elements in array. Otherwise,
     /// this function copies back the content of the array (and does not free the elems buffer).
+    #[deprecated(
+        since = "0.18.0",
+        note = "Please use get_auto_primitive_array_critical instead"
+    )]
     pub fn commit_primitive_array_critical(
         &self,
         array: jbyteArray,

--- a/src/wrapper/objects/auto_byte_array.rs
+++ b/src/wrapper/objects/auto_byte_array.rs
@@ -58,7 +58,7 @@ impl<'a, 'b> AutoByteArray<'a, 'b> {
         self.ptr.as_ptr()
     }
 
-    /// Commits the result of the array, if it is a copy
+    /// Commits the changes to the array, if it is a copy
     pub fn commit(&mut self) {
         let res = self
             .env
@@ -67,6 +67,14 @@ impl<'a, 'b> AutoByteArray<'a, 'b> {
             Ok(()) => {}
             Err(e) => debug!("error committing byte array: {:#?}", e),
         }
+    }
+
+    /// Don't commit the changes to the array on release (if it is a copy).
+    /// This has no effect if the array is not a copy.
+    /// This method is useful to change the release mode of an array originally created
+    /// with `ReleaseMode::CopyBack`.
+    pub fn discard(&mut self) {
+        self.mode = ReleaseMode::NoCopyBack;
     }
 
     /// Indicates if the array is a copy or not

--- a/src/wrapper/objects/auto_byte_array.rs
+++ b/src/wrapper/objects/auto_byte_array.rs
@@ -58,6 +58,15 @@ impl<'a, 'b> AutoByteArray<'a, 'b> {
         self.ptr.as_ptr()
     }
 
+    /// Commits the changes to the array, if it is a copy
+    pub fn commit(&mut self) {
+        let res = self.commit_byte_array_elements();
+        match res {
+            Ok(()) => {}
+            Err(e) => debug!("error committing byte array: {:#?}", e),
+        }
+    }
+
     fn commit_byte_array_elements(&mut self) -> Result<()> {
         jni_void_call!(
             self.env.get_native_interface(),
@@ -78,15 +87,6 @@ impl<'a, 'b> AutoByteArray<'a, 'b> {
             self.mode as i32
         );
         Ok(())
-    }
-
-    /// Commits the changes to the array, if it is a copy
-    pub fn commit(&mut self) {
-        let res = self.commit_byte_array_elements();
-        match res {
-            Ok(()) => {}
-            Err(e) => debug!("error committing byte array: {:#?}", e),
-        }
     }
 
     /// Don't commit the changes to the array on release (if it is a copy).

--- a/src/wrapper/objects/auto_byte_array.rs
+++ b/src/wrapper/objects/auto_byte_array.rs
@@ -59,15 +59,7 @@ impl<'a, 'b> AutoByteArray<'a, 'b> {
     }
 
     /// Commits the changes to the array, if it is a copy
-    pub fn commit(&mut self) {
-        let res = self.commit_byte_array_elements();
-        match res {
-            Ok(()) => {}
-            Err(e) => debug!("error committing byte array: {:#?}", e),
-        }
-    }
-
-    fn commit_byte_array_elements(&mut self) -> Result<()> {
+    pub fn commit(&mut self) -> Result<()> {
         jni_void_call!(
             self.env.get_native_interface(),
             ReleaseByteArrayElements,

--- a/src/wrapper/objects/auto_byte_array.rs
+++ b/src/wrapper/objects/auto_byte_array.rs
@@ -60,23 +60,16 @@ impl<'a, 'b> AutoByteArray<'a, 'b> {
 
     /// Commits the changes to the array, if it is a copy
     pub fn commit(&mut self) -> Result<()> {
-        jni_void_call!(
-            self.env.get_native_interface(),
-            ReleaseByteArrayElements,
-            *self.obj,
-            self.ptr.as_mut(),
-            sys::JNI_COMMIT
-        );
-        Ok(())
+        self.release_byte_array_elements(sys::JNI_COMMIT)
     }
 
-    fn release_byte_array_elements(&mut self) -> Result<()> {
+    fn release_byte_array_elements(&mut self, mode: i32) -> Result<()> {
         jni_void_call!(
             self.env.get_native_interface(),
             ReleaseByteArrayElements,
             *self.obj,
             self.ptr.as_mut(),
-            self.mode as i32
+            mode
         );
         Ok(())
     }
@@ -97,7 +90,7 @@ impl<'a, 'b> AutoByteArray<'a, 'b> {
 
 impl<'a, 'b> Drop for AutoByteArray<'a, 'b> {
     fn drop(&mut self) {
-        let res = self.release_byte_array_elements();
+        let res = self.release_byte_array_elements(self.mode as i32);
         match res {
             Ok(()) => {}
             Err(e) => debug!("error releasing byte array: {:#?}", e),

--- a/src/wrapper/objects/auto_primitive_array.rs
+++ b/src/wrapper/objects/auto_primitive_array.rs
@@ -46,7 +46,7 @@ impl<'a, 'b> AutoPrimitiveArray<'a, 'b> {
         self.ptr.as_ptr()
     }
 
-    /// Commits the result of the array, if it is a copy
+    /// Commits the changes to the array, if it is a copy
     pub fn commit(&mut self) {
         let res = self
             .env
@@ -55,6 +55,14 @@ impl<'a, 'b> AutoPrimitiveArray<'a, 'b> {
             Ok(()) => {}
             Err(e) => debug!("error committing primitive array: {:#?}", e),
         }
+    }
+
+    /// Don't commit the changes to the array on release (if it is a copy).
+    /// This has no effect if the array is not a copy.
+    /// This method is useful to change the release mode of an array originally created
+    /// with `ReleaseMode::CopyBack`.
+    pub fn discard(&mut self) {
+        self.mode = ReleaseMode::NoCopyBack;
     }
 
     /// Indicates if the array is a copy or not

--- a/src/wrapper/objects/auto_primitive_array.rs
+++ b/src/wrapper/objects/auto_primitive_array.rs
@@ -46,6 +46,15 @@ impl<'a, 'b> AutoPrimitiveArray<'a, 'b> {
         self.ptr.as_ptr()
     }
 
+    /// Commits the changes to the array, if it is a copy
+    pub fn commit(&mut self) {
+        let res = self.commit_primitive_array_critical();
+        match res {
+            Ok(()) => {}
+            Err(e) => debug!("error committing primitive array: {:#?}", e),
+        }
+    }
+
     fn commit_primitive_array_critical(&mut self) -> Result<()> {
         jni_void_call!(
             self.env.get_native_interface(),
@@ -66,15 +75,6 @@ impl<'a, 'b> AutoPrimitiveArray<'a, 'b> {
             self.mode as i32
         );
         Ok(())
-    }
-
-    /// Commits the changes to the array, if it is a copy
-    pub fn commit(&mut self) {
-        let res = self.commit_primitive_array_critical();
-        match res {
-            Ok(()) => {}
-            Err(e) => debug!("error committing primitive array: {:#?}", e),
-        }
     }
 
     /// Don't commit the changes to the array on release (if it is a copy).

--- a/src/wrapper/objects/auto_primitive_array.rs
+++ b/src/wrapper/objects/auto_primitive_array.rs
@@ -47,15 +47,7 @@ impl<'a, 'b> AutoPrimitiveArray<'a, 'b> {
     }
 
     /// Commits the changes to the array, if it is a copy
-    pub fn commit(&mut self) {
-        let res = self.commit_primitive_array_critical();
-        match res {
-            Ok(()) => {}
-            Err(e) => debug!("error committing primitive array: {:#?}", e),
-        }
-    }
-
-    fn commit_primitive_array_critical(&mut self) -> Result<()> {
+    pub fn commit(&mut self) -> Result<()> {
         jni_void_call!(
             self.env.get_native_interface(),
             ReleasePrimitiveArrayCritical,

--- a/src/wrapper/objects/auto_primitive_array.rs
+++ b/src/wrapper/objects/auto_primitive_array.rs
@@ -48,23 +48,16 @@ impl<'a, 'b> AutoPrimitiveArray<'a, 'b> {
 
     /// Commits the changes to the array, if it is a copy
     pub fn commit(&mut self) -> Result<()> {
-        jni_void_call!(
-            self.env.get_native_interface(),
-            ReleasePrimitiveArrayCritical,
-            *self.obj,
-            self.ptr.as_mut(),
-            sys::JNI_COMMIT
-        );
-        Ok(())
+        self.release_primitive_array_critical(sys::JNI_COMMIT)
     }
 
-    fn release_primitive_array_critical(&mut self) -> Result<()> {
+    fn release_primitive_array_critical(&mut self, mode: i32) -> Result<()> {
         jni_void_call!(
             self.env.get_native_interface(),
             ReleasePrimitiveArrayCritical,
             *self.obj,
             self.ptr.as_mut(),
-            self.mode as i32
+            mode
         );
         Ok(())
     }
@@ -85,7 +78,7 @@ impl<'a, 'b> AutoPrimitiveArray<'a, 'b> {
 
 impl<'a, 'b> Drop for AutoPrimitiveArray<'a, 'b> {
     fn drop(&mut self) {
-        let res = self.release_primitive_array_critical();
+        let res = self.release_primitive_array_critical(self.mode as i32);
         match res {
             Ok(()) => {}
             Err(e) => debug!("error releasing primitive array: {:#?}", e),


### PR DESCRIPTION
## Overview

Closes #275.

Will modify / extend unit tests soon.

**Update**: I think unit tests are fine as they are. The new `discard()` functionality is straightforward. And, we're not currently explicitly testing a call to `commit()` either (which is also straightforward).
In any case, If you want me to add explicit tests for these, I'll do it.
Also, not sure what to do with the tests of the deprecated methods... I guess we keep them, until removing these methods in a future release.

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Change is covered by [automated tests](https://github.com/jni-rs/jni-rs/blob/master/CONTRIBUTING.md#tests)
- [x] The [coding guidelines](https://github.com/jni-rs/jni-rs/blob/master/CONTRIBUTING.md#the-code-style) are followed
- [x] Public API has documentation
- [x] User-visible changes are mentioned in the Changelog
- [x] The continuous integration build passes
