### PR TITLE
Allow `deprecated` warning in CI build

### DIFF
--- a/.travis/run_travis_job.sh
+++ b/.travis/run_travis_job.sh
@@ -34,7 +34,7 @@ echo 'Performing checks over the rust code'
 cargo fmt --all -- --check
 
 # Run clippy static analysis.
-cargo clippy --all --tests --all-features -- -D warnings
+cargo clippy --all --tests --all-features -- -D warnings -A deprecated
 
 # Run tests with default features (stable-only)
 if [[ ${TRAVIS_RUST_VERSION} == "stable" ]]; then

--- a/tests/jni_api.rs
+++ b/tests/jni_api.rs
@@ -508,7 +508,7 @@ pub fn get_auto_long_array_elements_commit() {
     assert_eq!(res[1], 2);
     assert_eq!(res[2], 3);
 
-    auto_ptr.commit();
+    let _ = auto_ptr.commit();
 
     // Confirm modification of original Java array
     env.get_long_array_region(java_array, 0, &mut res).unwrap();


### PR DESCRIPTION
Manual methods for handling byte arrays are being deprecated in https://github.com/jni-rs/jni-rs/pull/276 but are used in tests, which is considered a warning by clippy and leads to a failing CI build.
