### PR TITLE
Fix: ReleaseMode struct / methods (#283)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,14 +16,15 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 
 ### Added
-- `discard()` method to `AutoByteArray` and `AutoPrimitiveArray`. (#275)
 - Added `AutoLongArray`. (#276)
+- Added `CopyBackNoFree` mode to `ReleaseMode` enum. (#283)
+- Added `get/set_release_mode()` to `Auto*Array`. (#283)
 
 ### Changed
-- `AutoByte/PrimitiveArray.commit()` now returns `Result`. (#275)
 - Removed methods get/release/commit_byte/primitive_array_{elements|critical}. (#281)
 - Renamed methods get_auto_byte/long/primitive_array_{elements|critical} to
 	get_byte/long/primitive_array_{elements|critical}. (#281)
+- Removed buggy `AutoByte/PrimitiveArray.commit()`. (#283)
 
 ## [0.18.0] — 2020-09-23
 

--- a/src/wrapper/objects/auto_long_array.rs
+++ b/src/wrapper/objects/auto_long_array.rs
@@ -4,7 +4,7 @@ use log::error;
 
 use crate::objects::release_mode::ReleaseMode;
 use crate::sys::jlong;
-use crate::{errors::*, objects::JObject, sys, JNIEnv};
+use crate::{errors::*, objects::JObject, JNIEnv};
 
 /// Auto-release wrapper for pointer-based long arrays.
 ///
@@ -39,39 +39,38 @@ impl<'a, 'b> AutoLongArray<'a, 'b> {
         self.ptr.as_ptr()
     }
 
-    /// Commits the result of the array, if it is a copy
-    pub fn commit(&mut self) -> Result<()> {
-        self.release_long_array_elements(sys::JNI_COMMIT)
+    /// Get the release mode
+    /// See [`ReleaseMode`](objects/enum.ReleaseMode.html) for details.
+    pub fn get_release_mode(&self) -> ReleaseMode {
+        self.mode
     }
 
-    fn release_long_array_elements(&mut self, mode: i32) -> Result<()> {
-        jni_void_call!(
-            self.env.get_native_interface(),
-            ReleaseLongArrayElements,
-            *self.obj,
-            self.ptr.as_mut(),
-            mode
-        );
-        Ok(())
-    }
-
-    /// Don't commit the changes to the array on release (if it is a copy).
-    /// This has no effect if the array is not a copy.
-    /// This method is useful to change the release mode of an array originally created
-    /// with `ReleaseMode::CopyBack`.
-    pub fn discard(&mut self) {
-        self.mode = ReleaseMode::NoCopyBack;
+    /// Set/Change the release mode
+    /// See [`ReleaseMode`](objects/enum.ReleaseMode.html) for details.
+    pub fn set_release_mode(&mut self, mode: ReleaseMode) {
+        self.mode = mode;
     }
 
     /// Indicates if the array is a copy or not
     pub fn is_copy(&self) -> bool {
         self.is_copy
     }
+
+    fn release_long_array_elements(&self) -> Result<()> {
+        jni_void_call!(
+            self.env.get_native_interface(),
+            ReleaseLongArrayElements,
+            *self.obj,
+            self.ptr.as_ptr(),
+            self.mode as i32
+        );
+        Ok(())
+    }
 }
 
 impl<'a, 'b> Drop for AutoLongArray<'a, 'b> {
     fn drop(&mut self) {
-        let res = self.release_long_array_elements(self.mode as i32);
+        let res = self.release_long_array_elements();
         match res {
             Ok(()) => {}
             Err(e) => error!("error releasing long array: {:#?}", e),

--- a/src/wrapper/objects/auto_primitive_array.rs
+++ b/src/wrapper/objects/auto_primitive_array.rs
@@ -1,7 +1,7 @@
 use log::debug;
 
 use crate::wrapper::objects::ReleaseMode;
-use crate::{errors::*, objects::JObject, sys, JNIEnv};
+use crate::{errors::*, objects::JObject, JNIEnv};
 use std::os::raw::c_void;
 use std::ptr::NonNull;
 
@@ -46,39 +46,38 @@ impl<'a, 'b> AutoPrimitiveArray<'a, 'b> {
         self.ptr.as_ptr()
     }
 
-    /// Commits the changes to the array, if it is a copy
-    pub fn commit(&mut self) -> Result<()> {
-        self.release_primitive_array_critical(sys::JNI_COMMIT)
+    /// Get the release mode
+    /// See [`ReleaseMode`](objects/enum.ReleaseMode.html) for details.
+    pub fn get_release_mode(&self) -> ReleaseMode {
+        self.mode
     }
 
-    fn release_primitive_array_critical(&mut self, mode: i32) -> Result<()> {
-        jni_void_call!(
-            self.env.get_native_interface(),
-            ReleasePrimitiveArrayCritical,
-            *self.obj,
-            self.ptr.as_mut(),
-            mode
-        );
-        Ok(())
-    }
-
-    /// Don't commit the changes to the array on release (if it is a copy).
-    /// This has no effect if the array is not a copy.
-    /// This method is useful to change the release mode of an array originally created
-    /// with `ReleaseMode::CopyBack`.
-    pub fn discard(&mut self) {
-        self.mode = ReleaseMode::NoCopyBack;
+    /// Set/Change the release mode
+    /// See [`ReleaseMode`](objects/enum.ReleaseMode.html) for details.
+    pub fn set_release_mode(&mut self, mode: ReleaseMode) {
+        self.mode = mode;
     }
 
     /// Indicates if the array is a copy or not
     pub fn is_copy(&self) -> bool {
         self.is_copy
     }
+
+    fn release_primitive_array_critical(&self) -> Result<()> {
+        jni_void_call!(
+            self.env.get_native_interface(),
+            ReleasePrimitiveArrayCritical,
+            *self.obj,
+            self.ptr.as_ptr(),
+            self.mode as i32
+        );
+        Ok(())
+    }
 }
 
 impl<'a, 'b> Drop for AutoPrimitiveArray<'a, 'b> {
     fn drop(&mut self) {
-        let res = self.release_primitive_array_critical(self.mode as i32);
+        let res = self.release_primitive_array_critical();
         match res {
             Ok(()) => {}
             Err(e) => debug!("error releasing primitive array: {:#?}", e),

--- a/src/wrapper/objects/release_mode.rs
+++ b/src/wrapper/objects/release_mode.rs
@@ -1,14 +1,15 @@
-use crate::sys::JNI_ABORT;
+use crate::sys::{JNI_ABORT, JNI_COMMIT};
 
 /// ReleaseMode
 ///
-/// This defines the release mode of Auto*Array (and AutoPrimitiveArray) resources, and
-/// related release array functions.
+/// This defines the release mode of Auto*Array (and AutoPrimitiveArray) resources.
 #[derive(Clone, Copy)]
 #[repr(i32)]
 pub enum ReleaseMode {
-    /// Copy back the content and free the elems buffer.
+    /// Copy back the content and free the native buffer.
     CopyBack = 0,
-    /// Free the buffer without copying back the possible changes.
+    /// Copy back the content and don't free the native buffer.
+    CopyBackNoFree = JNI_COMMIT,
+    /// Free the native buffer without copying back the possible changes.
     NoCopyBack = JNI_ABORT,
 }

--- a/tests/jni_api.rs
+++ b/tests/jni_api.rs
@@ -453,6 +453,7 @@ pub fn get_long_array_elements_commit() {
         *ptr.offset(0) += 1;
         *ptr.offset(1) += 1;
         *ptr.offset(2) += 1;
+        assert_eq!(ptr.read(), 2);
     }
 
     // Check that original Java array is unmodified
@@ -474,7 +475,12 @@ pub fn get_long_array_elements_commit() {
     assert_eq!(res[1], 3);
     assert_eq!(res[2], 4);
 
-    // Native buffer automatically released here anyway
+    // Confirm original pointer contents are not valid anymore
+    unsafe {
+        let val = ptr.read();
+        assert_ne!(val, 2);
+        println!("*ptr: {:?}", val);
+    }
 }
 
 #[test]


### PR DESCRIPTION
## Overview

Fixes #283. Sorry for the confusion regarding release modes. I think it's OK now; please review.

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Change is covered by [automated tests](https://github.com/jni-rs/jni-rs/blob/master/CONTRIBUTING.md#tests)
- [x] The [coding guidelines](https://github.com/jni-rs/jni-rs/blob/master/CONTRIBUTING.md#the-code-style) are followed
- [x] Public API has documentation
- [x] User-visible changes are mentioned in the Changelog
- [x] The continuous integration build passes
