### PR TITLE
Add (minimal) test of primitive array critical commit()

### DIFF
--- a/src/wrapper/jnienv.rs
+++ b/src/wrapper/jnienv.rs
@@ -2050,7 +2050,7 @@ impl<'a> JNIEnv<'a> {
     ) -> Result<AutoPrimitiveArray> {
         non_null!(array, "get_primitive_array_critical array argument");
         let mut is_copy: jboolean = 0xff;
-        let ptr = jni_non_void_call!(
+        let ptr = jni_unchecked!(
             self.internal,
             GetPrimitiveArrayCritical,
             array,

--- a/src/wrapper/jnienv.rs
+++ b/src/wrapper/jnienv.rs
@@ -1994,7 +1994,7 @@ impl<'a> JNIEnv<'a> {
     ) -> Result<AutoByteArray> {
         non_null!(array, "get_byte_array_elements array argument");
         let mut is_copy: jboolean = 0xff;
-        let ptr = jni_non_void_call!(self.internal, GetByteArrayElements, array, &mut is_copy);
+        let ptr = jni_unchecked!(self.internal, GetByteArrayElements, array, &mut is_copy);
         AutoByteArray::new(self, array.into(), ptr, mode, is_copy == sys::JNI_TRUE)
     }
 
@@ -2017,7 +2017,7 @@ impl<'a> JNIEnv<'a> {
     ) -> Result<AutoLongArray> {
         non_null!(array, "get_long_array_elements array argument");
         let mut is_copy: jboolean = 0xff;
-        let ptr = jni_non_void_call!(self.internal, GetLongArrayElements, array, &mut is_copy);
+        let ptr = jni_unchecked!(self.internal, GetLongArrayElements, array, &mut is_copy);
         AutoLongArray::new(self, array.into(), ptr, mode, is_copy == sys::JNI_TRUE)
     }
 

--- a/src/wrapper/jnienv.rs
+++ b/src/wrapper/jnienv.rs
@@ -2056,7 +2056,6 @@ impl<'a> JNIEnv<'a> {
             array,
             &mut is_copy
         );
-        non_null!(ptr, "get_primitive_array_critical return value");
         AutoPrimitiveArray::new(self, array.into(), ptr, mode, is_copy == sys::JNI_TRUE)
     }
 }

--- a/tests/jni_api.rs
+++ b/tests/jni_api.rs
@@ -433,7 +433,7 @@ pub fn get_long_array_elements() {
 }
 
 #[test]
-#[ignore]
+#[ignore] // Disabled until issue #283 is resolved
 pub fn get_long_array_elements_commit() {
     let env = attach_current_thread();
 
@@ -535,6 +535,7 @@ pub fn get_primitive_array_critical() {
 }
 
 #[test]
+#[ignore] // Disabled until issue #283 is resolved
 pub fn get_primitive_array_critical_commit() {
     let env = attach_current_thread();
 

--- a/tests/jni_api.rs
+++ b/tests/jni_api.rs
@@ -535,6 +535,24 @@ pub fn get_primitive_array_critical() {
 }
 
 #[test]
+pub fn get_primitive_array_critical_commit() {
+    let env = attach_current_thread();
+
+    // Create original Java array
+    let java_array = env
+        .new_long_array(3)
+        .expect("JNIEnv#new_long_array must create a java array with given size");
+
+    // Get primitive array elements auto wrapper
+    let mut auto_ptr = env
+        .get_primitive_array_critical(java_array, ReleaseMode::CopyBack)
+        .unwrap();
+
+    // Call commit
+    auto_ptr.commit().unwrap();
+}
+
+#[test]
 pub fn get_object_class() {
     let env = attach_current_thread();
     let string = env.new_string("test").unwrap();


### PR DESCRIPTION
## Overview

Adding a (minimal) test to confirm that `GetPrimitiveArrayCritical` also errors with a double free when invoked twice (first time with `JNI_COMMIT`) and `-Xcheck:jni` is enabled.

Related to #283.

Looking at the output, both implementations (`ArrayElements` and `ArrayCritical`) seem to be based on the same code. At least when `-Xcheck:jni` is enabled.
The only difference in the error output (besides the pointer addresses) is that the `Critical` version adds a warning:
" Warning: Calling other JNI functions in the scope of Get/ReleasePrimitiveArrayCritical or Get/ReleaseStringCritical"
Interestingly, this warning is emitted even when no other JNI functions seem to be called (the test is minimal to confirm that).

Perhaps we can merge this to master, after disabling the test with `#ignore`, like in the other `commit()` test.

Finally, this bug raises a couple of questions / issues:
- Maybe both settings (`-Xcheck:jni` enabled / present, and `-Xcheck:jni` not present) should be tested.
- What about other JDKs / non HotSpot VMs ? Would it make sense to test against Graal, OpenJ9, etc. for compatibility?

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Change is covered by [automated tests](https://github.com/jni-rs/jni-rs/blob/master/CONTRIBUTING.md#tests)
- [x] The [coding guidelines](https://github.com/jni-rs/jni-rs/blob/master/CONTRIBUTING.md#the-code-style) are followed
- [x] Public API has documentation
- [x] User-visible changes are mentioned in the Changelog
- [x] The continuous integration build passes
