### PR TITLE
Set EXPECTED_JVM_FILENAME on FreeBSD

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -20,7 +20,7 @@ use std::{
 
 #[cfg(target_os = "windows")]
 const EXPECTED_JVM_FILENAME: &str = "jvm.dll";
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", target_os = "freebsd"))]
 const EXPECTED_JVM_FILENAME: &str = "libjvm.so";
 #[cfg(target_os = "macos")]
 const EXPECTED_JVM_FILENAME: &str = "libjli.dylib";


### PR DESCRIPTION
This makes jni-rs compile on FreeBSD.

## Overview

- This is what's needed to get jni-rs to compile on FreeBSD (I've stumbled upon this problem as I was packaging the zkgroup library).
- I am not sure if there is anything else to be done for this PR to be merged.

### Definition of Done

- [x] There are no TODOs left in the code
- [ ] Change is covered by [automated tests](https://github.com/jni-rs/jni-rs/blob/master/CONTRIBUTING.md#tests)
- [x] The [coding guidelines](https://github.com/jni-rs/jni-rs/blob/master/CONTRIBUTING.md#the-code-style) are followed
- [ ] Public API has documentation
- [ ] User-visible changes are mentioned in the Changelog
- [ ] The continuous integration build passes
