### PR TITLE
Use appropriate macros for GetArrayXElements and Release:

### DIFF
--- a/src/wrapper/jnienv.rs
+++ b/src/wrapper/jnienv.rs
@@ -2105,8 +2105,8 @@ impl<'a> JNIEnv<'a> {
         // Even though this method may throw OoME, use `jni_unchecked`
         // instead of `jni_non_null_call` to remove (a slight) overhead
         // of exception checking. An error will still be detected as a `null`
-        // result inside AutoPrimitiveArray ctor; and, as this method is likely
-        // not to create a copy, an OoME is not very likely.
+        // result inside AutoPrimitiveArray ctor; and, as this method is unlikely
+        // to create a copy, an OoME is highly unlikely.
         let ptr = jni_unchecked!(
             self.internal,
             GetPrimitiveArrayCritical,

--- a/src/wrapper/jnienv.rs
+++ b/src/wrapper/jnienv.rs
@@ -2102,7 +2102,7 @@ impl<'a> JNIEnv<'a> {
     ) -> Result<AutoPrimitiveArray> {
         non_null!(array, "get_primitive_array_critical array argument");
         let mut is_copy: jboolean = 0xff;
-        let ptr = jni_unchecked!(
+        let ptr = jni_non_null_call!(
             self.internal,
             GetPrimitiveArrayCritical,
             array,

--- a/src/wrapper/jnienv.rs
+++ b/src/wrapper/jnienv.rs
@@ -2106,7 +2106,7 @@ impl<'a> JNIEnv<'a> {
         // instead of `jni_non_null_call` to remove (a slight) overhead
         // of exception checking. An error will still be detected as a `null`
         // result inside AutoPrimitiveArray ctor; and, as this method is likely
-        // not to perform a copy, an OoME is not very likely.
+        // not to create a copy, an OoME is not very likely.
         let ptr = jni_unchecked!(
             self.internal,
             GetPrimitiveArrayCritical,

--- a/src/wrapper/jnienv.rs
+++ b/src/wrapper/jnienv.rs
@@ -2094,7 +2094,7 @@ impl<'a> JNIEnv<'a> {
     ///
     /// If the given array is `null`, an `Error::NullPtr` is returned.
     ///
-    /// See also [`get_byte_array_elements`](struct.JNIEnv.html#method.get_byte_array_elements)
+    /// See also [`get_byte_array_elements`](struct.JNIEnv.html#method.get_array_elements)
     pub fn get_primitive_array_critical(
         &self,
         array: jarray,
@@ -2102,7 +2102,12 @@ impl<'a> JNIEnv<'a> {
     ) -> Result<AutoPrimitiveArray> {
         non_null!(array, "get_primitive_array_critical array argument");
         let mut is_copy: jboolean = 0xff;
-        let ptr = jni_non_null_call!(
+        // Even though this method may throw OoME, use `jni_unchecked`
+        // instead of `jni_non_null_call` to remove (a slight) overhead
+        // of exception checking. An error will still be detected as a `null`
+        // result inside AutoPrimitiveArray ctor; and, as this method is likely
+        // not to perform a copy, an OoME is not very likely.
+        let ptr = jni_unchecked!(
             self.internal,
             GetPrimitiveArrayCritical,
             array,

--- a/src/wrapper/objects/auto_array.rs
+++ b/src/wrapper/objects/auto_array.rs
@@ -24,7 +24,13 @@ macro_rules! type_array {
             /// Get Java $jni_type array
             fn get(env: &JNIEnv, obj: JObject, is_copy: &mut jboolean) -> Result<*mut Self> {
                 let internal = env.get_native_interface();
-                let res = jni_non_null_call!(internal, $jni_get, *obj, is_copy);
+                // Even though this method may throw OoME, use `jni_unchecked`
+                // instead of `jni_non_null_call` to remove (a slight) overhead
+                // of exception checking. An error will still be detected as a `null`
+                // result inside AutoArray ctor. Also, modern Hotspot in case of lack
+                // of memory will return null and won't throw an exception:
+                // https://sourcegraph.com/github.com/openjdk/jdk/-/blob/src/hotspot/share/memory/allocation.hpp#L488-489
+                let res = jni_unchecked!(internal, $jni_get, *obj, is_copy);
                 Ok(res)
             }
 

--- a/src/wrapper/objects/auto_array.rs
+++ b/src/wrapper/objects/auto_array.rs
@@ -24,14 +24,14 @@ macro_rules! type_array {
             /// Get Java $jni_type array
             fn get(env: &JNIEnv, obj: JObject, is_copy: &mut jboolean) -> Result<*mut Self> {
                 let internal = env.get_native_interface();
-                let res = jni_unchecked!(internal, $jni_get, *obj, is_copy);
+                let res = jni_non_null_call!(internal, $jni_get, *obj, is_copy);
                 Ok(res)
             }
 
             /// Release Java $jni_type array
             fn release(env: &JNIEnv, obj: JObject, ptr: NonNull<Self>, mode: i32) -> Result<()> {
                 let internal = env.get_native_interface();
-                jni_void_call!(internal, $jni_release, *obj, ptr.as_ptr(), mode as i32);
+                jni_unchecked!(internal, $jni_release, *obj, ptr.as_ptr(), mode as i32);
                 Ok(())
             }
         }

--- a/src/wrapper/objects/auto_primitive_array.rs
+++ b/src/wrapper/objects/auto_primitive_array.rs
@@ -48,7 +48,7 @@ impl<'a, 'b> AutoPrimitiveArray<'a, 'b> {
     }
 
     fn release_primitive_array_critical(&mut self, mode: i32) -> Result<()> {
-        jni_void_call!(
+        jni_unchecked!(
             self.env.get_native_interface(),
             ReleasePrimitiveArrayCritical,
             *self.obj,


### PR DESCRIPTION
As Get can throw OOME (also returning null), use
`jni_non_null_call` macro.

As Release never throws, use `jni_unchecked`. This also
resolves the check:jni warning from using a JNI method
between GetCritical and ReleaseCritical.

See the spec:
- https://docs.oracle.com/en/java/javase/11/docs/specs/jni/functions.html#getprimitivetypearrayelements-routines

## Overview

<!-- Please describe your changes here and list any open questions you might have. -->

### Definition of Done

- [ ] There are no TODOs left in the code
- [ ] Change is covered by [automated tests](https://github.com/jni-rs/jni-rs/blob/master/CONTRIBUTING.md#tests)
- [ ] The [coding guidelines](https://github.com/jni-rs/jni-rs/blob/master/CONTRIBUTING.md#the-code-style) are followed
- [ ] Public API has documentation
- [ ] User-visible changes are mentioned in the Changelog
- [ ] The continuous integration build passes
