### PR TITLE
Add support for weak references

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - `JavaStr::into_raw()` which drops the `JavaStr` and releases ownership of the raw string pointer ([#374](https://github.com/jni-rs/jni-rs/pull/374))
 - `JavaStr::from_raw()` which takes ownership of a raw string pointer to create a `JavaStr` ([#374](https://github.com/jni-rs/jni-rs/pull/374))
 - `JNIEnv::get_string_unchecked` is a cheaper, `unsafe` alternative to `get_string` that doesn't check the given object is a `java.lang.String` instance. ([#328](https://github.com/jni-rs/jni-rs/issues/328))
+- `WeakRef` and `JNIEnv#new_weak_ref`. ([#304](https://github.com/jni-rs/jni-rs/pull/304))
 
 ### Changed
 - `JNIEnv::get_string` checks that the given object is a `java.lang.String` instance to avoid undefined behaviour from the JNI implementation potentially aborting the program. ([#328](https://github.com/jni-rs/jni-rs/issues/328))

--- a/src/wrapper/objects/mod.rs
+++ b/src/wrapper/objects/mod.rs
@@ -39,6 +39,9 @@ pub use self::jbytebuffer::*;
 mod global_ref;
 pub use self::global_ref::*;
 
+mod weak_ref;
+pub use self::weak_ref::*;
+
 // For automatic local ref deletion
 mod auto_local;
 pub use self::auto_local::*;

--- a/src/wrapper/objects/weak_ref.rs
+++ b/src/wrapper/objects/weak_ref.rs
@@ -1,0 +1,172 @@
+use std::sync::Arc;
+
+use log::{debug, warn};
+
+use crate::{
+    errors::Result,
+    objects::{GlobalRef, JObject},
+    sys, JNIEnv, JavaVM,
+};
+
+/// A *weak* global JVM reference. These are global in scope like
+/// [`GlobalRef`], and may outlive the `JNIEnv` they came from, but are
+/// *not* guaranteed to not get collected until released.
+///
+/// `WeakRef` can be cloned to use _the same_ weak reference in different
+/// contexts. If you want to create yet another weak ref to the same java object, call
+/// [`WeakRef::clone_in_jvm`].
+///
+/// Underlying weak reference will be dropped, when the last instance
+/// of `WeakRef` leaves its scope.
+///
+/// It is _recommended_ that a native thread that drops the weak reference is attached
+/// to the Java thread (i.e., has an instance of `JNIEnv`). If the native thread is *not* attached,
+/// the `WeakRef#drop` will print a warning and implicitly `attach` and `detach` it, which
+/// significantly affects performance.
+
+#[derive(Clone)]
+pub struct WeakRef {
+    inner: Arc<WeakRefGuard>,
+}
+
+struct WeakRefGuard {
+    raw: sys::jweak,
+    vm: JavaVM,
+}
+
+unsafe impl Send for WeakRef {}
+unsafe impl Sync for WeakRef {}
+
+impl WeakRef {
+    /// Creates a new wrapper for a global reference.
+    ///
+    /// # Safety
+    ///
+    /// Expects a valid raw weak global reference that should be created with `NewWeakGlobalRef`
+    /// JNI function.
+    pub(crate) unsafe fn from_raw(vm: JavaVM, raw: sys::jweak) -> Self {
+        WeakRef {
+            inner: Arc::new(WeakRefGuard { raw, vm }),
+        }
+    }
+
+    /// Returns the raw JNI weak reference.
+    pub fn as_raw(&self) -> sys::jweak {
+        self.inner.raw
+    }
+
+    /// Creates a new local reference to this object.
+    ///
+    /// This object may have already been garbage collected by the time this method is called. If
+    /// so, this method returns `Ok(None)`. Otherwise, it returns `Ok(Some(r))` where `r` is the
+    /// new local reference.
+    ///
+    /// If this method returns `Ok(Some(r))`, it is guaranteed that the object will not be garbage
+    /// collected at least until `r` is deleted or becomes invalid.
+    pub fn upgrade_local<'e>(&self, env: &JNIEnv<'e>) -> Result<Option<JObject<'e>>> {
+        let r = env.new_local_ref(unsafe { JObject::from_raw(self.as_raw()) })?;
+
+        // Per JNI spec, `NewLocalRef` will return a null pointer if the object was GC'd.
+        if r.into_raw().is_null() {
+            Ok(None)
+        } else {
+            Ok(Some(r))
+        }
+    }
+
+    /// Creates a new strong global reference to this object.
+    ///
+    /// This object may have already been garbage collected by the time this method is called. If
+    /// so, this method returns `Ok(None)`. Otherwise, it returns `Ok(Some(r))` where `r` is the
+    /// new strong global reference.
+    ///
+    /// If this method returns `Ok(Some(r))`, it is guaranteed that the object will not be garbage
+    /// collected at least until `r` is dropped.
+    pub fn upgrade_global(&self, env: &JNIEnv) -> Result<Option<GlobalRef>> {
+        let r = env.new_global_ref(unsafe { JObject::from_raw(self.as_raw()) })?;
+
+        // Unlike `NewLocalRef`, the JNI spec does *not* guarantee that `NewGlobalRef` will return a
+        // null pointer if the object was GC'd, so we'll have to check.
+        if env.is_same_object(r.as_obj(), JObject::null())? {
+            Ok(None)
+        } else {
+            Ok(Some(r))
+        }
+    }
+
+    /// Checks if the object referred to by this `WeakRef` has been garbage collected.
+    ///
+    /// Note that garbage collection can happen at any moment, so a return of `Ok(true)` from this
+    /// method does not guarantee that [`WeakRef::upgrade_local`] or [`WeakRef::upgrade_global`]
+    /// will succeed.
+    ///
+    /// This is equivalent to
+    /// <code>self.[is_same_object][WeakRef::is_same_object](env, [JObject::null]\())</code>.
+    pub fn is_garbage_collected(&self, env: &JNIEnv) -> Result<bool> {
+        self.is_same_object(env, JObject::null())
+    }
+
+    // The following methods are wrappers around those `JNIEnv` methods that make sense for a weak
+    // reference. These methods exist because they use `JObject::from_raw` on the raw pointer of a
+    // weak reference. Although this usage is sound, it is `unsafe`. It's also confusing because
+    // `JObject` normally represents a strong reference.
+
+    /// Returns true if this weak reference refers to the given object. Otherwise returns false.
+    ///
+    /// If `object` is [null][JObject::null], then this method is equivalent to
+    /// [`WeakRef::is_garbage_collected`]: it returns true if the object referred to by this
+    /// `WeakRef` has been garbage collected, or false if the object has not yet been garbage
+    /// collected.
+    pub fn is_same_object<'a, O>(&self, env: &JNIEnv<'a>, object: O) -> Result<bool>
+    where
+        O: Into<JObject<'a>>,
+    {
+        env.is_same_object(unsafe { JObject::from_raw(self.as_raw()) }, object)
+    }
+
+    /// Returns true if this weak reference refers to the same object as another weak reference.
+    /// Otherwise returns false.
+    ///
+    /// This method will also return true if both weak references refer to an object that has been
+    /// garbage collected.
+    pub fn is_weak_ref_to_same_object(&self, env: &JNIEnv, other: &WeakRef) -> Result<bool> {
+        self.is_same_object(env, unsafe { JObject::from_raw(other.as_raw()) })
+    }
+
+    /// Creates a new weak reference to the same object that this one refers to.
+    ///
+    /// `WeakRef` implements [`Clone`], which should normally be used whenever a new `WeakRef` to
+    /// the same object is needed. However, that only increments an internal reference count and
+    /// does not actually create a new weak reference in the JVM. If you specifically need to have
+    /// the JVM create a new weak reference, use this method instead of `Clone`.
+    ///
+    /// This method returns `Ok(None)` if the object has already been garbage collected.
+    pub fn clone_in_jvm(&self, env: &JNIEnv) -> Result<Option<WeakRef>> {
+        env.new_weak_ref(unsafe { JObject::from_raw(self.as_raw()) })
+    }
+}
+
+impl Drop for WeakRefGuard {
+    fn drop(&mut self) {
+        fn drop_impl(env: &JNIEnv, raw: sys::jweak) -> Result<()> {
+            let internal = env.get_native_interface();
+            // This method is safe to call in case of pending exceptions (see chapter 2 of the spec)
+            jni_unchecked!(internal, DeleteWeakGlobalRef, raw);
+            Ok(())
+        }
+
+        let res = match self.vm.get_env() {
+            Ok(env) => drop_impl(&env, self.raw),
+            Err(_) => {
+                warn!("Dropping a WeakRef in a detached thread. Fix your code if this message appears frequently (see the WeakRef docs).");
+                self.vm
+                    .attach_current_thread()
+                    .and_then(|env| drop_impl(&env, self.raw))
+            }
+        };
+
+        if let Err(err) = res {
+            debug!("error dropping weak ref: {:#?}", err);
+        }
+    }
+}

--- a/tests/jni_api.rs
+++ b/tests/jni_api.rs
@@ -935,6 +935,14 @@ fn new_global_ref_null() {
 }
 
 #[test]
+fn new_weak_ref_null() {
+    let env = attach_current_thread();
+    let null_obj = JObject::null();
+    let result = unwrap(&env, env.new_weak_ref(null_obj));
+    assert!(result.is_none());
+}
+
+#[test]
 fn auto_local_null() {
     let env = attach_current_thread();
     let null_obj = JObject::null();
@@ -1037,6 +1045,11 @@ pub fn test_conversion() {
 
     let global_ref = env.new_global_ref(orig_obj).unwrap();
     let actual = JObject::from(&global_ref);
+    assert!(unwrap(&env, env.is_same_object(orig_obj, actual)));
+
+    let weak_ref = unwrap(&env, env.new_weak_ref(orig_obj)).expect("weak ref should not be null");
+    let actual =
+        unwrap(&env, weak_ref.upgrade_local(&env)).expect("weak ref should not have been GC'd");
     assert!(unwrap(&env, env.is_same_object(orig_obj, actual)));
 
     let auto_local = env.auto_local(orig_obj);

--- a/tests/jni_weak_refs.rs
+++ b/tests/jni_weak_refs.rs
@@ -1,0 +1,192 @@
+#![cfg(feature = "invocation")]
+
+use std::{
+    sync::{Arc, Barrier},
+    thread::spawn,
+};
+
+use jni::{
+    objects::{AutoLocal, JObject, JValue},
+    sys::jint,
+    JNIEnv,
+};
+
+mod util;
+use util::{attach_current_thread, unwrap};
+
+#[test]
+pub fn weak_ref_works_in_other_threads() {
+    const ITERS_PER_THREAD: usize = 10_000;
+
+    let env = attach_current_thread();
+    let mut join_handlers = Vec::new();
+
+    let atomic_integer_local = AutoLocal::new(
+        &env,
+        unwrap(
+            &env,
+            env.new_object(
+                "java/util/concurrent/atomic/AtomicInteger",
+                "(I)V",
+                &[JValue::from(0)],
+            ),
+        ),
+    );
+    let atomic_integer =
+        unwrap(&env, env.new_weak_ref(&atomic_integer_local)).expect("weak ref should not be null");
+
+    // Test with a different number of threads (from 2 to 8)
+    for thread_num in 2..9 {
+        let barrier = Arc::new(Barrier::new(thread_num));
+
+        for _ in 0..thread_num {
+            let barrier = barrier.clone();
+            let atomic_integer = atomic_integer.clone();
+
+            let jh = spawn(move || {
+                let env = attach_current_thread();
+                barrier.wait();
+                for _ in 0..ITERS_PER_THREAD {
+                    let atomic_integer = env.auto_local(
+                        unwrap(&env, atomic_integer.upgrade_local(&env))
+                            .expect("AtomicInteger shouldn't have been GC'd yet"),
+                    );
+                    unwrap(
+                        &env,
+                        unwrap(
+                            &env,
+                            env.call_method(&atomic_integer, "incrementAndGet", "()I", &[]),
+                        )
+                        .i(),
+                    );
+                }
+            });
+            join_handlers.push(jh);
+        }
+
+        for jh in join_handlers.drain(..) {
+            jh.join().unwrap();
+        }
+
+        let expected = (ITERS_PER_THREAD * thread_num) as jint;
+        assert_eq!(
+            expected,
+            unwrap(
+                &env,
+                unwrap(
+                    &env,
+                    env.call_method(
+                        &atomic_integer_local,
+                        "getAndSet",
+                        "(I)I",
+                        &[JValue::from(0)]
+                    )
+                )
+                .i()
+            )
+        );
+    }
+}
+
+#[test]
+fn weak_ref_is_actually_weak() {
+    let env = attach_current_thread();
+
+    // This test uses `with_local_frame` to work around issue #109.
+
+    fn run_gc(env: &JNIEnv) {
+        unwrap(
+            env,
+            env.with_local_frame(1, || {
+                env.call_static_method("java/lang/System", "gc", "()V", &[])?;
+                Ok(JObject::null())
+            }),
+        );
+    }
+
+    for _ in 0..100 {
+        let obj_local = env.auto_local(unwrap(
+            &env,
+            env.with_local_frame(2, || env.new_object("java/lang/Object", "()V", &[])),
+        ));
+
+        let obj_weak =
+            unwrap(&env, env.new_weak_ref(&obj_local)).expect("weak ref should not be null");
+
+        let obj_weak2 =
+            unwrap(&env, obj_weak.clone_in_jvm(&env)).expect("weak ref should not be null");
+
+        run_gc(&env);
+
+        for obj_weak in &[&obj_weak, &obj_weak2] {
+            {
+                let obj_local_from_weak = env.auto_local(
+                    unwrap(&env, obj_weak.upgrade_local(&env))
+                        .expect("object shouldn't have been GC'd yet"),
+                );
+
+                assert!(!obj_local_from_weak.as_obj().is_null());
+                assert!(unwrap(
+                    &env,
+                    env.is_same_object(&obj_local_from_weak, &obj_local)
+                ));
+            }
+
+            {
+                let obj_global_from_weak = unwrap(&env, obj_weak.upgrade_global(&env))
+                    .expect("object shouldn't have been GC'd yet");
+
+                assert!(!obj_global_from_weak.as_obj().is_null());
+                assert!(unwrap(
+                    &env,
+                    env.is_same_object(&obj_global_from_weak, &obj_local)
+                ));
+            }
+
+            assert!(unwrap(&env, obj_weak.is_same_object(&env, &obj_local)));
+
+            assert!(
+                !unwrap(&env, obj_weak.is_garbage_collected(&env)),
+                "`is_garbage_collected` returned incorrect value"
+            );
+        }
+
+        assert!(unwrap(
+            &env,
+            obj_weak.is_weak_ref_to_same_object(&env, &obj_weak2)
+        ));
+
+        drop(obj_local);
+        run_gc(&env);
+
+        for obj_weak in &[&obj_weak, &obj_weak2] {
+            {
+                let obj_local_from_weak = unwrap(&env, obj_weak.upgrade_local(&env));
+
+                assert!(
+                    obj_local_from_weak.is_none(),
+                    "object should have been GC'd"
+                );
+            }
+
+            {
+                let obj_global_from_weak = unwrap(&env, obj_weak.upgrade_global(&env));
+
+                assert!(
+                    obj_global_from_weak.is_none(),
+                    "object should have been GC'd"
+                );
+            }
+
+            assert!(
+                unwrap(&env, obj_weak.is_garbage_collected(&env)),
+                "`is_garbage_collected` returned incorrect value"
+            );
+        }
+
+        assert!(unwrap(
+            &env,
+            obj_weak.is_weak_ref_to_same_object(&env, &obj_weak2)
+        ));
+    }
+}


### PR DESCRIPTION
## Overview

This PR adds a `WeakRef` type and `JNIEnv::new_weak_ref` method, allowing the user to create weak references to Java objects. Fixes #167.

This is an alternative to #266. I wrote this before checking if someone had already implemented weak references for the `jni` crate, but I decided to submit a PR anyway because this is different from #266.

### Differences From #266

* This PR [doesn't introduce][no JWeak comment] a `JWeak` type. It only introduces `WeakRef`.
* `WeakRef` can be upgraded to either a local or global strong reference.
* Upgrading returns `Result<Option<JObject>>` or `Result<Option<GlobalRef>>`, where the `Option` is `None` if the object was garbage collected. Returning `Option` [is debated][Option comment] in #266, but I think it's the right approach because:
	1. It's immediately clear what happens if the reference has been garbage collected.
	2. `std::{rc,sync}::Weak::upgrade` also returns `Option`.
* `JNIEnv::new_weak_ref` returns `Result<Option<WeakRef>>`, where the `Option` is `None` if the original reference is null. That way, there's no [ambiguity between a weak reference that was originally null and one that's been garbage collected][null weak ref comment]. The JVM won't actually create a null weak reference anyway ([`NewWeakGlobalRef`] returns a null pointer in this case), and this code follows that behavior.
* A test verifies that weak references can be used across different threads.
* A test verifies that an object can be garbage-collected if there is only a weak reference to it.

### Note: Also Fixes #301

Note that this PR contains a fix for #301 (separately, as the first commit). That's needed because `WeakRef::upgrade_local` calls `JNIEnv::new_local_ref` to create the new local reference, which isn't otherwise possible due to #301.

This is technically a **breaking change**, although `JNIEnv::new_local_ref` doesn't seem very useful in its current form, so there may not be any existing uses of that method for this change to break.

[`NewWeakGlobalRef`]: https://docs.oracle.com/en/java/javase/11/docs/specs/jni/functions.html#newweakglobalref
[no JWeak comment]: https://github.com/jni-rs/jni-rs/pull/266#discussion_r504867022
[null weak ref comment]: https://github.com/jni-rs/jni-rs/pull/266#discussion_r504878736
[Option comment]: https://github.com/jni-rs/jni-rs/pull/266#discussion_r502779236

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Change is covered by [automated tests](https://github.com/jni-rs/jni-rs/blob/master/CONTRIBUTING.md#tests)
- [x] The [coding guidelines](https://github.com/jni-rs/jni-rs/blob/master/CONTRIBUTING.md#the-code-style) are followed
- [x] Public API has documentation
- [x] User-visible changes are mentioned in the Changelog
- [x] The continuous integration build passes
