### PR TITLE
Fix compilation _on_ android

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -23,6 +23,7 @@ const EXPECTED_JVM_FILENAME: &str = "jvm.dll";
 #[cfg(any(
     target_os = "freebsd",
     target_os = "linux",
+    target_os = "android",
     target_os = "netbsd",
     target_os = "openbsd"
 ))]


### PR DESCRIPTION
## Overview

<!-- Please describe your changes here and list any open questions you might have. -->

Who works on PCs nowadays? Everything is mobile! Using the Termux app, I can install git, rustc and everything I need to do the same work on my Android phone as I used to do on my laptop.

Unfortunately, this crate does not compile on Android because this case was not considered in the `build.rs` script. Here's my attempt to fix it.

(This PR was created exclusively on my phone, using zsh, git, cargo and vim in Termux, and my web browser of course)

### Definition of Done

- [x] There are no TODOs left in the code
- [ ] Change is covered by [automated tests](https://github.com/jni-rs/jni-rs/blob/master/CONTRIBUTING.md#tests)
- [x] The [coding guidelines](https://github.com/jni-rs/jni-rs/blob/master/CONTRIBUTING.md#the-code-style) are followed
- [x] Public API has documentation
- [ ] User-visible changes are mentioned in the Changelog
- [ ] The continuous integration build passes
