### PR TITLE
Don't tie the lifetime of `AutoArray` to a particular `JNIEnv` ref

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Changed
 - The `release_string_utf_chars` function has been marked as unsafe. (#334)
 - Breaking change: Mark `JNIEnv::new_direct_byte_buffer` as `unsafe` (#320)
+- The lifetime of `AutoArray` is no longer tied to the lifetime of a particular `JNIEnv` reference. (#302)
 
 ## [0.19.0] — 2021-01-24
 

--- a/src/wrapper/jnienv.rs
+++ b/src/wrapper/jnienv.rs
@@ -2042,7 +2042,7 @@ impl<'a> JNIEnv<'a> {
         &self,
         array: jarray,
         mode: ReleaseMode,
-    ) -> Result<AutoArray<T>> {
+    ) -> Result<AutoArray<'a, T>> {
         non_null!(array, "get_array_elements array argument");
         AutoArray::new(self, array.into(), mode)
     }
@@ -2052,7 +2052,7 @@ impl<'a> JNIEnv<'a> {
         &self,
         array: jintArray,
         mode: ReleaseMode,
-    ) -> Result<AutoArray<jint>> {
+    ) -> Result<AutoArray<'a, jint>> {
         self.get_array_elements(array, mode)
     }
 
@@ -2061,7 +2061,7 @@ impl<'a> JNIEnv<'a> {
         &self,
         array: jlongArray,
         mode: ReleaseMode,
-    ) -> Result<AutoArray<jlong>> {
+    ) -> Result<AutoArray<'a, jlong>> {
         self.get_array_elements(array, mode)
     }
 
@@ -2070,7 +2070,7 @@ impl<'a> JNIEnv<'a> {
         &self,
         array: jbyteArray,
         mode: ReleaseMode,
-    ) -> Result<AutoArray<jbyte>> {
+    ) -> Result<AutoArray<'a, jbyte>> {
         self.get_array_elements(array, mode)
     }
 
@@ -2079,7 +2079,7 @@ impl<'a> JNIEnv<'a> {
         &self,
         array: jbooleanArray,
         mode: ReleaseMode,
-    ) -> Result<AutoArray<jboolean>> {
+    ) -> Result<AutoArray<'a, jboolean>> {
         self.get_array_elements(array, mode)
     }
 
@@ -2088,7 +2088,7 @@ impl<'a> JNIEnv<'a> {
         &self,
         array: jcharArray,
         mode: ReleaseMode,
-    ) -> Result<AutoArray<jchar>> {
+    ) -> Result<AutoArray<'a, jchar>> {
         self.get_array_elements(array, mode)
     }
 
@@ -2097,7 +2097,7 @@ impl<'a> JNIEnv<'a> {
         &self,
         array: jshortArray,
         mode: ReleaseMode,
-    ) -> Result<AutoArray<jshort>> {
+    ) -> Result<AutoArray<'a, jshort>> {
         self.get_array_elements(array, mode)
     }
 
@@ -2106,7 +2106,7 @@ impl<'a> JNIEnv<'a> {
         &self,
         array: jfloatArray,
         mode: ReleaseMode,
-    ) -> Result<AutoArray<jfloat>> {
+    ) -> Result<AutoArray<'a, jfloat>> {
         self.get_array_elements(array, mode)
     }
 
@@ -2115,7 +2115,7 @@ impl<'a> JNIEnv<'a> {
         &self,
         array: jdoubleArray,
         mode: ReleaseMode,
-    ) -> Result<AutoArray<jdouble>> {
+    ) -> Result<AutoArray<'a, jdouble>> {
         self.get_array_elements(array, mode)
     }
 

--- a/tests/jni_api.rs
+++ b/tests/jni_api.rs
@@ -333,8 +333,12 @@ macro_rules! test_get_array_elements {
             // Use a scope to test Drop
             {
                 // Get byte array elements auto wrapper
-                let auto_ptr: AutoArray<$jni_type> =
-                    env.$jni_get(java_array, ReleaseMode::CopyBack).unwrap();
+                let auto_ptr: AutoArray<$jni_type> = {
+                    // Make sure the lifetime is tied to the environment,
+                    // not the particular JNIEnv reference
+                    let temporary_env: JNIEnv = *env;
+                    temporary_env.$jni_get(java_array, ReleaseMode::CopyBack).unwrap()
+                };
 
                 // Check array size
                 assert_eq!(auto_ptr.size().unwrap(), 2);


### PR DESCRIPTION
## Overview

Now that JNIEnv is publicly Copy, it's clear that the important lifetime is its parameter, not the lifetime of any particular reference. That means that AutoArray can live as long as the actual JNIEnv.

Fixes #302.

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Change is covered by [automated tests](https://github.com/jni-rs/jni-rs/blob/master/CONTRIBUTING.md#tests)
- [x] The [coding guidelines](https://github.com/jni-rs/jni-rs/blob/master/CONTRIBUTING.md#the-code-style) are followed
- [x] Public API has documentation
- [x] User-visible changes are mentioned in the Changelog
- [x] The continuous integration build passes
