### PR TITLE
Fix #301: Relax `new_local_ref` lifetime restrictions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - The `release_string_utf_chars` function has been marked as unsafe. (#334)
 - Breaking change: Mark `JNIEnv::new_direct_byte_buffer` as `unsafe` (#320)
 - The lifetime of `AutoArray` is no longer tied to the lifetime of a particular `JNIEnv` reference. (#302)
+- Relaxed lifetime restrictions on `JNIEnv::new_local_ref`. Now it can be used to create a local
+  reference from a global reference. (#301 / #319)
 
 ## [0.19.0] — 2021-01-24
 

--- a/src/wrapper/jnienv.rs
+++ b/src/wrapper/jnienv.rs
@@ -375,11 +375,15 @@ impl<'a> JNIEnv<'a> {
 
     /// Create a new local ref to an object.
     ///
-    /// Note that the object passed to this is *already* a local ref. This
-    /// creates yet another reference to it, which is most likely not what you
-    /// want.
-    pub fn new_local_ref<T>(&self, obj: JObject<'a>) -> Result<JObject<'a>> {
-        let local: JObject = jni_unchecked!(self.internal, NewLocalRef, obj.into_inner()).into();
+    /// This is useful for creating a local reference from a [global reference][GlobalRef] or
+    /// creating a local reference in a different [local reference frame][JNIEnv::with_local_frame]
+    /// than the original.
+    pub fn new_local_ref<'b, O>(&self, obj: O) -> Result<JObject<'a>>
+    where
+        O: Into<JObject<'b>>,
+    {
+        let local: JObject =
+            jni_unchecked!(self.internal, NewLocalRef, obj.into().into_inner()).into();
         Ok(local)
     }
 


### PR DESCRIPTION
## Overview

This PR changes `JNIEnv::new_local_ref` to fix issue #301.

This is also included in PR #304, but @maurolacy [requested a separate PR with this only](https://github.com/jni-rs/jni-rs/issues/301#issuecomment-843360198).

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Change is covered by [automated tests](https://github.com/jni-rs/jni-rs/blob/master/CONTRIBUTING.md#tests)
- [x] The [coding guidelines](https://github.com/jni-rs/jni-rs/blob/master/CONTRIBUTING.md#the-code-style) are followed
- [x] Public API has documentation
- [x] User-visible changes are mentioned in the Changelog
- [ ] The continuous integration build passes

Fixes: #301
