### PR TITLE
safety: Mark `new_direct_byte_buffer` as `unsafe`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Changed
 - The `release_string_utf_chars` function has been marked as unsafe. (#334)
+- Breaking change: Mark `JNIEnv::new_direct_byte_buffer` as `unsafe` (#320)
 
 ## [0.19.0] — 2021-01-24
 

--- a/src/wrapper/jnienv.rs
+++ b/src/wrapper/jnienv.rs
@@ -317,6 +317,7 @@ impl<'a> JNIEnv<'a> {
     /// `ByteBuffer`. The JVM may maintain references to the `ByteBuffer` beyond the lifetime
     /// of this `JNIEnv`.
     pub unsafe fn new_direct_byte_buffer(&self, data: &mut [u8]) -> Result<JByteBuffer<'a>> {
+        #[allow(unused_unsafe)]
         let obj: JObject = jni_non_null_call!(
             self.internal,
             NewDirectByteBuffer,

--- a/src/wrapper/jnienv.rs
+++ b/src/wrapper/jnienv.rs
@@ -304,7 +304,19 @@ impl<'a> JNIEnv<'a> {
     }
 
     /// Create a new instance of a direct java.nio.ByteBuffer.
-    pub fn new_direct_byte_buffer(&self, data: &mut [u8]) -> Result<JByteBuffer<'a>> {
+    ///
+    /// # Example
+    /// ```rust,ignore
+    /// let buf = vec![0; 1024 * 1024];
+    /// let direct_buffer = unsafe { env.new_direct_byte_buffer(buf.leak()) };
+    /// ```
+    ///
+    /// # Safety
+    ///
+    /// Caller must ensure the lifetime of `data` extends to all uses of the returned
+    /// `ByteBuffer`. The JVM may maintain references to the `ByteBuffer` beyond the lifetime
+    /// of this `JNIEnv`.
+    pub unsafe fn new_direct_byte_buffer(&self, data: &mut [u8]) -> Result<JByteBuffer<'a>> {
         let obj: JObject = jni_non_null_call!(
             self.internal,
             NewDirectByteBuffer,

--- a/tests/jni_api.rs
+++ b/tests/jni_api.rs
@@ -574,7 +574,7 @@ pub fn new_direct_byte_buffer() {
     let env = attach_current_thread();
     let mut vec: Vec<u8> = vec![0, 1, 2, 3];
     let buf = vec.as_mut_slice();
-    let result = env.new_direct_byte_buffer(buf);
+    let result = unsafe { env.new_direct_byte_buffer(buf) };
     assert!(result.is_ok());
     assert!(!result.unwrap().is_null());
 }
@@ -584,7 +584,7 @@ pub fn get_direct_buffer_capacity_ok() {
     let env = attach_current_thread();
     let mut vec: Vec<u8> = vec![0, 1, 2, 3];
     let buf = vec.as_mut_slice();
-    let result = env.new_direct_byte_buffer(buf).unwrap();
+    let result = unsafe { env.new_direct_byte_buffer(buf) }.unwrap();
     assert!(!result.is_null());
 
     let capacity = env.get_direct_buffer_capacity(result).unwrap();
@@ -604,7 +604,7 @@ pub fn get_direct_buffer_address_ok() {
     let env = attach_current_thread();
     let mut vec: Vec<u8> = vec![0, 1, 2, 3];
     let buf = vec.as_mut_slice();
-    let result = env.new_direct_byte_buffer(buf).unwrap();
+    let result = unsafe { env.new_direct_byte_buffer(buf) }.unwrap();
     assert!(!result.is_null());
 
     let dest_buffer = env.get_direct_buffer_address(result).unwrap();


### PR DESCRIPTION
## Overview

**:warning: Breaking Change! :warning:**

Currently, undefined behavior may be invoked with `JNIEnv::new_direct_byte_buffer` because it does not verify the lifetime of the received byte slice. Unfortunately, since the JVM may maintain a reference to the `ByteBuffer` for an unknown amount of time, it's not possible to statically enforce this.

Since we cannot lean on the borrow checker, this method is marked _unsafe_ which is a breaking change.

An argument can be made that `JNIEnv:: get_direct_buffer_address` should _also_ be marked unsafe. However, this method is safe assuming the invariants of `NewDirectByteBuffer` are held. It's typical practice in Rust to mark these methods safe.

Resolves https://github.com/jni-rs/jni-rs/issues/303

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Change is covered by [automated tests](https://github.com/jni-rs/jni-rs/blob/master/CONTRIBUTING.md#tests)
- [x] The [coding guidelines](https://github.com/jni-rs/jni-rs/blob/master/CONTRIBUTING.md#the-code-style) are followed
- [x] Public API has documentation
- [x] User-visible changes are mentioned in the Changelog
- [ ] The continuous integration build passes
