### PR TITLE
get_direct_buffer_address(): Return *mut [u8]

### DIFF
--- a/src/wrapper/jnienv.rs
+++ b/src/wrapper/jnienv.rs
@@ -316,13 +316,13 @@ impl<'a> JNIEnv<'a> {
 
     /// Returns the starting address of the memory of the direct
     /// java.nio.ByteBuffer.
-    pub fn get_direct_buffer_address(&self, buf: JByteBuffer) -> Result<&mut [u8]> {
+    pub fn get_direct_buffer_address(&self, buf: JByteBuffer) -> Result<*mut [u8]> {
         non_null!(buf, "get_direct_buffer_address argument");
         let ptr: *mut c_void =
             jni_unchecked!(self.internal, GetDirectBufferAddress, buf.into_inner());
         non_null!(ptr, "get_direct_buffer_address return value");
         let capacity = self.get_direct_buffer_capacity(buf)?;
-        unsafe { Ok(slice::from_raw_parts_mut(ptr as *mut u8, capacity as usize)) }
+        unsafe { Ok(slice::from_raw_parts_mut(ptr as *mut u8, capacity as usize) as *mut [u8]) }
     }
 
     /// Returns the capacity of the direct java.nio.ByteBuffer.


### PR DESCRIPTION
Returning a &mut [u8] implies that the lifetime of the underlying
data is known. Return a raw pointer instead, to acknowledge that
the lifetime may be unknown.

## Overview

<!-- Please describe your changes here and list any open questions you might have. -->

### Definition of Done

- [ ] There are no TODOs left in the code
- [ ] Change is covered by [automated tests](https://github.com/jni-rs/jni-rs/blob/master/CONTRIBUTING.md#tests)
- [ ] The [coding guidelines](https://github.com/jni-rs/jni-rs/blob/master/CONTRIBUTING.md#the-code-style) are followed
- [ ] Public API has documentation
- [ ] User-visible changes are mentioned in the Changelog
- [ ] The continuous integration build passes
