### PR TITLE
Impl Default as null for jobject wrappers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+- `Default` trait implemented for `JObject`, `JString`, `JClass`, and `JByteBuffer` (#199)
+
 ### Changed
 - The `release_string_utf_chars` function has been marked as unsafe. (#334)
 

--- a/src/wrapper/objects/jbytebuffer.rs
+++ b/src/wrapper/objects/jbytebuffer.rs
@@ -31,3 +31,9 @@ impl<'a> From<JObject<'a>> for JByteBuffer<'a> {
         (other.into_inner() as jobject).into()
     }
 }
+
+impl<'a> std::default::Default for JByteBuffer<'a> {
+    fn default() -> Self {
+        JByteBuffer(JObject::null())
+    }
+}

--- a/src/wrapper/objects/jclass.rs
+++ b/src/wrapper/objects/jclass.rs
@@ -35,3 +35,9 @@ impl<'a> From<JObject<'a>> for JClass<'a> {
         (other.into_inner() as jclass).into()
     }
 }
+
+impl<'a> std::default::Default for JClass<'a> {
+    fn default() -> Self {
+        JClass(JObject::null())
+    }
+}

--- a/src/wrapper/objects/jobject.rs
+++ b/src/wrapper/objects/jobject.rs
@@ -45,3 +45,9 @@ impl<'a> JObject<'a> {
         (::std::ptr::null_mut() as jobject).into()
     }
 }
+
+impl<'a> std::default::Default for JObject<'a> {
+    fn default() -> Self {
+        Self::null()
+    }
+}

--- a/src/wrapper/objects/jstring.rs
+++ b/src/wrapper/objects/jstring.rs
@@ -34,3 +34,9 @@ impl<'a> From<JObject<'a>> for JString<'a> {
         (other.into_inner() as jstring).into()
     }
 }
+
+impl<'a> std::default::Default for JString<'a> {
+    fn default() -> Self {
+        JString(JObject::null())
+    }
+}


### PR DESCRIPTION
## Overview

Provided `std::default::Default` implementations for `JObject`, `JString`, `JClass`, and `JByteBuffer`.
These types are simple plain wrappers around `jni::sys::jobject` or `JObject`.

This solves issue #199 for these types but leaves the primitive pointer types untouched.

### Definition of Done

- [x] There are no TODOs left in the code
- [ ] Change is covered by [automated tests](https://github.com/jni-rs/jni-rs/blob/master/CONTRIBUTING.md#tests)
- [x] The [coding guidelines](https://github.com/jni-rs/jni-rs/blob/master/CONTRIBUTING.md#the-code-style) are followed
- [x] Public API has documentation
- [x] User-visible changes are mentioned in the Changelog
- [ ] The continuous integration build passes
