### PR TITLE
Documentation: Added panic documentation to JNIEnv#get_string()

### DIFF
--- a/src/wrapper/jnienv.rs
+++ b/src/wrapper/jnienv.rs
@@ -983,6 +983,9 @@ impl<'a> JNIEnv<'a> {
     ///
     /// This entails a call to `GetStringUTFChars` and only decodes java's
     /// modified UTF-8 format on conversion to a rust-compatible string.
+    ///
+    /// # Panics
+    /// This call panics when given an Object that is not a java.lang.String
     pub fn get_string(&self, obj: JString<'a>) -> Result<JavaStr<'a, '_>> {
         non_null!(obj, "get_string obj argument");
         JavaStr::from_env(self, obj)

--- a/src/wrapper/jnienv.rs
+++ b/src/wrapper/jnienv.rs
@@ -985,6 +985,7 @@ impl<'a> JNIEnv<'a> {
     /// modified UTF-8 format on conversion to a rust-compatible string.
     ///
     /// # Panics
+    ///
     /// This call panics when given an Object that is not a java.lang.String
     pub fn get_string(&self, obj: JString<'a>) -> Result<JavaStr<'a, '_>> {
         non_null!(obj, "get_string obj argument");


### PR DESCRIPTION
## Overview

<!-- Please describe your changes here and list any open questions you might have. -->
This PR adds panic documentation to JNIEnv#get_string(), this solves issue #328 partially. The documentation informs the end user that get_string() will panic if an Object is provided that is not a java.lang.String, this panic is caused in the JVM.

### Definition of Done

- [x] There are no TODOs left in the code
- [ ] Change is covered by [automated tests](https://github.com/jni-rs/jni-rs/blob/master/CONTRIBUTING.md#tests)
- [ ] The [coding guidelines](https://github.com/jni-rs/jni-rs/blob/master/CONTRIBUTING.md#the-code-style) are followed
- [ ] Public API has documentation
- [ ] User-visible changes are mentioned in the Changelog
- [ ] The continuous integration build passes
All unchecked are N.A.
