### PR TITLE
Implement Kotlin variants of get/set/take_rust_field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 - `Default` trait implemented for `JObject`, `JString`, `JClass`, and `JByteBuffer` (#199)
+- Kotlin specific methods for working with Rust objects and JNI: `take_rust_field_kt`, `get_rust_field_kt`, `set_rust_field_kt`
 
 ### Changed
 - The `release_string_utf_chars` function has been marked as unsafe. (#334)


### PR DESCRIPTION
## Overview

<!-- Please describe your changes here and list any open questions you might have. -->
This PR implements the Kotlin version of the get/set/take_rust_field functions.

For more info on why this is required, please see #333 , but to sum it up, the current methods rely on `null` and `J` field, which Kotlin can't use due to the way it works. Kotlin represents all primitive types as classes, and internally it may or may not use a `J`. While in Kotlin, using a `Long` results in a `J` internally, Kotlin does not allow `null` unless you specify it as a nullable type `Long?`. When you do this, it internally changes to use `java/lang/Long` instead of primitives, thus rendering the original functions incompatible.

Technically it IS possible to let it use the non-nullable `Long` type which results in primitive `J`, however we'd be setting null under the hood without any typecheck for the user (bad bad idea, besides, Kotlin may do optimizations based on the fact that it's never null, and we would be violating the types contract). The user could assume that the field can never be null, which would lead to bad situations.

(Completely unrelated note, but these get/set/take functions should all be marked `unsafe`, because they require the caller to uphold a guarantee that `T` is valid, otherwise it'll be UB. Thus, the unsafety is spilling onto the callers side)

(This fixes #333)

### Definition of Done

- [x] There are no TODOs left in the code
- [ ] Change is covered by [automated tests](https://github.com/jni-rs/jni-rs/blob/master/CONTRIBUTING.md#tests)
- [x] The [coding guidelines](https://github.com/jni-rs/jni-rs/blob/master/CONTRIBUTING.md#the-code-style) are followed
- [x] Public API has documentation
- [x] User-visible changes are mentioned in the Changelog
- [x] The continuous integration build passes
