### PR TITLE
Fix header generation documentation

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -49,7 +49,7 @@
 //!
 //! To do that, first we need the name and type signature that our Rust function
 //! needs to adhere to. Luckily, the Java compiler can generate that for you!
-//! Run `javac -h . HelloWorld` and you'll get a `HelloWorld.h` output to your
+//! Run `javac -h . HelloWorld.java` and you'll get a `HelloWorld.h` output to your
 //! directory. It should look something like this:
 //!
 //! ```c


### PR DESCRIPTION
`javac -h . HelloWorld` returns the following error:
error: Class names, 'HelloWorld', are only accepted if annotation processing is explicitly requested

`javac -h . HelloWorld.java` works as expected.

Tested with Java 11 and Java 17.