### PR TITLE
Allocation free use

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - `Default` trait implemented for `JObject`, `JString`, `JClass`, and `JByteBuffer` (#199)
 - `JNIEnv#new_direct_byte_buffer_raw` function that allows creating a `JByteBuffer` from a pointer and size (#351)
 - `Debug` trait implemented for `JavaVM`, `GlobalRef`, `GlobalRefGuard`, `JStaticMethodID` and `ReleaseMode`
+- `ReturnType` for specifying object return types without a String allocation. (#329)
 
 ### Changed
 - The `release_string_utf_chars` function has been marked as unsafe. (#334)
@@ -28,6 +29,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   reference from a global reference. (#301 / #319)
 - `JMethodID` implements `Send` + `Sync` and no longer has a lifetime parameter, making method
   IDs cacheable (with a documented 'Safety' note about ensuring they remain valid). ([#346](https://github.com/jni-rs/jni-rs/pull/346))
+- The `call_*_method_unchecked` functions now take `jni:sys::jvalue` arguments to avoid allocating
+  a `Vec` on each call to map + collect `JValue`s as `sys:jvalue`s (#329)
 
 ## [0.19.0] — 2021-01-24
 

--- a/benches/api_calls.rs
+++ b/benches/api_calls.rs
@@ -3,12 +3,13 @@
 
 extern crate test;
 
+use jni_sys::jvalue;
 use lazy_static::lazy_static;
 
 use jni::{
     descriptors::Desc,
     objects::{JClass, JMethodID, JObject, JStaticMethodID, JValue},
-    signature::{JavaType, Primitive},
+    signature::{Primitive, ReturnType},
     sys::jint,
     InitArgsBuilder, JNIEnv, JNIVersion, JavaVM,
 };
@@ -84,9 +85,9 @@ where
     C: Desc<'c, JClass<'c>>,
 {
     let x = JValue::from(x);
-    let ret = JavaType::Primitive(Primitive::Int);
+    let ret = ReturnType::Primitive(Primitive::Int);
     let v = env
-        .call_static_method_unchecked(class, method_id, ret, &[x])
+        .call_static_method_unchecked(class, method_id, ret, &[x.into()])
         .unwrap();
     v.i().unwrap()
 }
@@ -95,7 +96,7 @@ fn jni_int_call_unchecked<'m, M>(env: &JNIEnv<'m>, obj: JObject<'m>, method_id: 
 where
     M: Desc<'m, JMethodID>,
 {
-    let ret = JavaType::Primitive(Primitive::Int);
+    let ret = ReturnType::Primitive(Primitive::Int);
     let v = env.call_method_unchecked(obj, method_id, ret, &[]).unwrap();
     v.i().unwrap()
 }
@@ -104,30 +105,13 @@ fn jni_object_call_static_unchecked<'c, C>(
     env: &JNIEnv<'c>,
     class: C,
     method_id: JStaticMethodID,
-    ret: JavaType,
-    args: &[JValue],
+    args: &[jvalue],
 ) -> JObject<'c>
 where
     C: Desc<'c, JClass<'c>>,
 {
     let v = env
-        .call_static_method_unchecked(class, method_id, ret, args)
-        .unwrap();
-    v.l().unwrap()
-}
-
-fn jni_object_call_unchecked<'a, M>(
-    env: &JNIEnv<'a>,
-    obj: JObject<'a>,
-    method_id: M,
-    ret: JavaType,
-    args: &[JValue],
-) -> JObject<'a>
-where
-    M: Desc<'a, JMethodID>,
-{
-    let v = env
-        .call_method_unchecked(obj, method_id, ret, args)
+        .call_static_method_unchecked(class, method_id, ReturnType::Object, args)
         .unwrap();
     v.l().unwrap()
 }
@@ -203,20 +187,18 @@ mod tests {
             .unwrap();
 
         b.iter(|| {
-            let ret_type = JavaType::Object(CLASS_LOCAL_DATE_TIME.to_string());
             let obj = jni_object_call_static_unchecked(
                 &env,
                 class,
                 method_id,
-                ret_type,
                 &[
-                    1.into(),
-                    1.into(),
-                    1.into(),
-                    1.into(),
-                    1.into(),
-                    1.into(),
-                    1.into(),
+                    JValue::Int(1).into(),
+                    JValue::Int(1).into(),
+                    JValue::Int(1).into(),
+                    JValue::Int(1).into(),
+                    JValue::Int(1).into(),
+                    JValue::Int(1).into(),
+                    JValue::Int(1).into(),
                 ],
             );
             env.delete_local_ref(obj).unwrap();

--- a/src/wrapper/jnienv.rs
+++ b/src/wrapper/jnienv.rs
@@ -767,7 +767,7 @@ impl<'a> JNIEnv<'a> {
         class: T,
         method_id: U,
         ret: ReturnType,
-        args: &[JValue],
+        args: &[jvalue],
     ) -> Result<JValue<'a>>
     where
         T: Desc<'a, JClass<'c>>,
@@ -778,7 +778,6 @@ impl<'a> JNIEnv<'a> {
         let method_id = method_id.lookup(self)?.into_inner();
 
         let class = class.into_inner();
-        let args: Vec<jvalue> = args.iter().map(|v| v.to_jni()).collect();
         let jni_args = args.as_ptr();
 
         // TODO clean this up
@@ -884,7 +883,7 @@ impl<'a> JNIEnv<'a> {
         obj: O,
         method_id: T,
         ret: ReturnType,
-        args: &[JValue],
+        args: &[jvalue],
     ) -> Result<JValue<'a>>
     where
         O: Into<JObject<'a>>,
@@ -894,7 +893,6 @@ impl<'a> JNIEnv<'a> {
 
         let obj = obj.into().into_inner();
 
-        let args: Vec<jvalue> = args.iter().map(|v| v.to_jni()).collect();
         let jni_args = args.as_ptr();
 
         // TODO clean this up
@@ -981,7 +979,8 @@ impl<'a> JNIEnv<'a> {
 
         let class = self.auto_local(self.get_object_class(obj)?);
 
-        self.call_method_unchecked(obj, (&class, name, sig), parsed.ret, args)
+        let args: Vec<jvalue> = args.iter().map(|v| v.to_jni()).collect();
+        self.call_method_unchecked(obj, (&class, name, sig), parsed.ret, &args)
     }
 
     /// Calls a static method safely. This comes with a number of
@@ -1016,7 +1015,8 @@ impl<'a> JNIEnv<'a> {
         // and we'll need that for the next call.
         let class = class.lookup(self)?;
 
-        self.call_static_method_unchecked(class, (class, name, sig), parsed.ret, args)
+        let args: Vec<jvalue> = args.iter().map(|v| v.to_jni()).collect();
+        self.call_static_method_unchecked(class, (class, name, sig), parsed.ret, &args)
     }
 
     /// Create a new object using a constructor. This is done safely using

--- a/src/wrapper/objects/jlist.rs
+++ b/src/wrapper/objects/jlist.rs
@@ -1,7 +1,7 @@
 use crate::{
     errors::*,
     objects::{JMethodID, JObject},
-    signature::{JavaType, Primitive},
+    signature::{Primitive, ReturnType},
     sys::jint,
     JNIEnv,
 };
@@ -65,7 +65,7 @@ impl<'a: 'b, 'b> JList<'a, 'b> {
         let result = self.env.call_method_unchecked(
             self.internal,
             self.get,
-            JavaType::Object("java/lang/Object".into()),
+            ReturnType::Object,
             &[idx.into()],
         );
 
@@ -83,7 +83,7 @@ impl<'a: 'b, 'b> JList<'a, 'b> {
         let result = self.env.call_method_unchecked(
             self.internal,
             self.add,
-            JavaType::Primitive(Primitive::Boolean),
+            ReturnType::Primitive(Primitive::Boolean),
             &[value.into()],
         );
 
@@ -96,7 +96,7 @@ impl<'a: 'b, 'b> JList<'a, 'b> {
         let result = self.env.call_method_unchecked(
             self.internal,
             self.add_idx,
-            JavaType::Primitive(Primitive::Void),
+            ReturnType::Primitive(Primitive::Void),
             &[idx.into(), value.into()],
         );
 
@@ -109,7 +109,7 @@ impl<'a: 'b, 'b> JList<'a, 'b> {
         let result = self.env.call_method_unchecked(
             self.internal,
             self.remove,
-            JavaType::Object("java/lang/Object".into()),
+            ReturnType::Object,
             &[idx.into()],
         );
 
@@ -127,7 +127,7 @@ impl<'a: 'b, 'b> JList<'a, 'b> {
         let result = self.env.call_method_unchecked(
             self.internal,
             self.size,
-            JavaType::Primitive(Primitive::Int),
+            ReturnType::Primitive(Primitive::Int),
             &[],
         );
 
@@ -146,7 +146,7 @@ impl<'a: 'b, 'b> JList<'a, 'b> {
         let result = self.env.call_method_unchecked(
             self.internal,
             self.remove,
-            JavaType::Object("java/lang/Object".into()),
+            ReturnType::Object,
             &[(size - 1).into()],
         );
 

--- a/src/wrapper/objects/jlist.rs
+++ b/src/wrapper/objects/jlist.rs
@@ -1,6 +1,6 @@
 use crate::{
     errors::*,
-    objects::{JMethodID, JObject},
+    objects::{JMethodID, JObject, JValue},
     signature::{Primitive, ReturnType},
     sys::jint,
     JNIEnv,
@@ -66,7 +66,7 @@ impl<'a: 'b, 'b> JList<'a, 'b> {
             self.internal,
             self.get,
             ReturnType::Object,
-            &[idx.into()],
+            &[JValue::from(idx).to_jni()],
         );
 
         match result {
@@ -84,7 +84,7 @@ impl<'a: 'b, 'b> JList<'a, 'b> {
             self.internal,
             self.add,
             ReturnType::Primitive(Primitive::Boolean),
-            &[value.into()],
+            &[JValue::from(value).to_jni()],
         );
 
         let _ = result?;
@@ -97,7 +97,7 @@ impl<'a: 'b, 'b> JList<'a, 'b> {
             self.internal,
             self.add_idx,
             ReturnType::Primitive(Primitive::Void),
-            &[idx.into(), value.into()],
+            &[JValue::from(idx).to_jni(), JValue::from(value).to_jni()],
         );
 
         let _ = result?;
@@ -110,7 +110,7 @@ impl<'a: 'b, 'b> JList<'a, 'b> {
             self.internal,
             self.remove,
             ReturnType::Object,
-            &[idx.into()],
+            &[JValue::from(idx).to_jni()],
         );
 
         match result {
@@ -147,7 +147,7 @@ impl<'a: 'b, 'b> JList<'a, 'b> {
             self.internal,
             self.remove,
             ReturnType::Object,
-            &[(size - 1).into()],
+            &[JValue::from(size - 1).to_jni()],
         );
 
         match result {

--- a/src/wrapper/objects/jmap.rs
+++ b/src/wrapper/objects/jmap.rs
@@ -1,6 +1,6 @@
 use crate::{
     errors::*,
-    objects::{AutoLocal, JMethodID, JObject},
+    objects::{AutoLocal, JMethodID, JObject, JValue},
     signature::{Primitive, ReturnType},
     JNIEnv,
 };
@@ -68,7 +68,7 @@ impl<'a: 'b, 'b> JMap<'a, 'b> {
             self.internal,
             self.get,
             ReturnType::Object,
-            &[key.into()],
+            &[JValue::from(key).to_jni()],
         );
 
         match result {
@@ -87,7 +87,7 @@ impl<'a: 'b, 'b> JMap<'a, 'b> {
             self.internal,
             self.put,
             ReturnType::Object,
-            &[key.into(), value.into()],
+            &[JValue::from(key).to_jni(), JValue::from(value).to_jni()],
         );
 
         match result {
@@ -106,7 +106,7 @@ impl<'a: 'b, 'b> JMap<'a, 'b> {
             self.internal,
             self.remove,
             ReturnType::Object,
-            &[key.into()],
+            &[JValue::from(key).to_jni()],
         );
 
         match result {

--- a/src/wrapper/objects/jmap.rs
+++ b/src/wrapper/objects/jmap.rs
@@ -1,7 +1,7 @@
 use crate::{
     errors::*,
     objects::{AutoLocal, JMethodID, JObject},
-    signature::{JavaType, Primitive},
+    signature::{Primitive, ReturnType},
     JNIEnv,
 };
 
@@ -67,7 +67,7 @@ impl<'a: 'b, 'b> JMap<'a, 'b> {
         let result = self.env.call_method_unchecked(
             self.internal,
             self.get,
-            JavaType::Object("java/lang/Object".into()),
+            ReturnType::Object,
             &[key.into()],
         );
 
@@ -86,7 +86,7 @@ impl<'a: 'b, 'b> JMap<'a, 'b> {
         let result = self.env.call_method_unchecked(
             self.internal,
             self.put,
-            JavaType::Object("java/lang/Object".into()),
+            ReturnType::Object,
             &[key.into(), value.into()],
         );
 
@@ -105,7 +105,7 @@ impl<'a: 'b, 'b> JMap<'a, 'b> {
         let result = self.env.call_method_unchecked(
             self.internal,
             self.remove,
-            JavaType::Object("java/lang/Object".into()),
+            ReturnType::Object,
             &[key.into()],
         );
 
@@ -152,7 +152,7 @@ impl<'a: 'b, 'b> JMap<'a, 'b> {
                 .call_method_unchecked(
                     self.internal,
                     (&self.class, "entrySet", "()Ljava/util/Set;"),
-                    JavaType::Object("java/util/Set".into()),
+                    ReturnType::Object,
                     &[],
                 )?
                 .l()?;
@@ -162,7 +162,7 @@ impl<'a: 'b, 'b> JMap<'a, 'b> {
                 .call_method_unchecked(
                     entry_set,
                     ("java/util/Set", "iterator", "()Ljava/util/Iterator;"),
-                    JavaType::Object("java/util/Iterator".into()),
+                    ReturnType::Object,
                     &[],
                 )?
                 .l()?;
@@ -204,7 +204,7 @@ impl<'a: 'b, 'b: 'c, 'c> JMapIter<'a, 'b, 'c> {
             .call_method_unchecked(
                 iter,
                 self.has_next,
-                JavaType::Primitive(Primitive::Boolean),
+                ReturnType::Primitive(Primitive::Boolean),
                 &[],
             )?
             .z()?;
@@ -215,34 +215,19 @@ impl<'a: 'b, 'b: 'c, 'c> JMapIter<'a, 'b, 'c> {
         let next = self
             .map
             .env
-            .call_method_unchecked(
-                iter,
-                self.next,
-                JavaType::Object("java/util/Map$Entry".into()),
-                &[],
-            )?
+            .call_method_unchecked(iter, self.next, ReturnType::Object, &[])?
             .l()?;
 
         let key = self
             .map
             .env
-            .call_method_unchecked(
-                next,
-                self.get_key,
-                JavaType::Object("java/lang/Object".into()),
-                &[],
-            )?
+            .call_method_unchecked(next, self.get_key, ReturnType::Object, &[])?
             .l()?;
 
         let value = self
             .map
             .env
-            .call_method_unchecked(
-                next,
-                self.get_value,
-                JavaType::Object("java/lang/Object".into()),
-                &[],
-            )?
+            .call_method_unchecked(next, self.get_value, ReturnType::Object, &[])?
             .l()?;
 
         Ok(Some((key, value)))

--- a/src/wrapper/signature.rs
+++ b/src/wrapper/signature.rs
@@ -70,6 +70,35 @@ impl fmt::Display for JavaType {
     }
 }
 
+#[allow(missing_docs)]
+#[derive(Eq, PartialEq, Debug, Clone)]
+pub enum ReturnType {
+    Primitive(Primitive),
+    Object,
+    Array,
+}
+
+impl FromStr for ReturnType {
+    type Err = Error;
+
+    fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
+        parser(parse_return)
+            .parse(s)
+            .map(|res| res.0)
+            .map_err(|e| Error::ParseFailed(e, s.to_owned()))
+    }
+}
+
+impl fmt::Display for ReturnType {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match *self {
+            ReturnType::Primitive(ref ty) => ty.fmt(f),
+            ReturnType::Object => write!(f, "L;"),
+            ReturnType::Array => write!(f, "["),
+        }
+    }
+}
+
 /// A method type signature. This is the structure representation of something
 /// like `(Ljava/lang/String;)Z`. Used by the `call_(object|static)_method`
 /// functions on jnienv to ensure safety.
@@ -77,7 +106,7 @@ impl fmt::Display for JavaType {
 #[derive(Eq, PartialEq, Debug, Clone)]
 pub struct TypeSignature {
     pub args: Vec<JavaType>,
-    pub ret: JavaType,
+    pub ret: ReturnType,
 }
 
 impl TypeSignature {
@@ -105,7 +134,7 @@ impl fmt::Display for TypeSignature {
     }
 }
 
-fn parse_primitive<S: Stream<Token = char>>(input: &mut S) -> StdParseResult<JavaType, S>
+fn parse_primitive<S: Stream<Token = char>>(input: &mut S) -> StdParseResult<Primitive, S>
 where
     S::Error: ParseError<char, S::Range, S::Position>,
 {
@@ -128,7 +157,6 @@ where
         .or(long)
         .or(short)
         .or(void))
-    .map(JavaType::Primitive)
     .parse_stream(input)
     .into()
 }
@@ -160,9 +188,22 @@ where
     S::Error: ParseError<char, S::Range, S::Position>,
 {
     parser(parse_primitive)
+        .map(JavaType::Primitive)
         .or(parser(parse_array))
         .or(parser(parse_object))
         .or(parser(parse_sig))
+        .parse_stream(input)
+        .into()
+}
+
+fn parse_return<S: Stream<Token = char>>(input: &mut S) -> StdParseResult<ReturnType, S>
+where
+    S::Error: ParseError<char, S::Range, S::Position>,
+{
+    parser(parse_primitive)
+        .map(ReturnType::Primitive)
+        .or(parser(parse_array).map(|_| ReturnType::Array))
+        .or(parser(parse_object).map(|_| ReturnType::Object))
         .parse_stream(input)
         .into()
 }
@@ -180,7 +221,7 @@ fn parse_sig<S: Stream<Token = char>>(input: &mut S) -> StdParseResult<JavaType,
 where
     S::Error: ParseError<char, S::Range, S::Position>,
 {
-    (parser(parse_args), parser(parse_type))
+    (parser(parse_args), parser(parse_return))
         .map(|(a, r)| TypeSignature { args: a, ret: r })
         .map(|sig| JavaType::Method(Box::new(sig)))
         .parse_stream(input)
@@ -196,7 +237,8 @@ mod test {
         let inputs = [
             "(Ljava/lang/String;I)V",
             "[Lherp;",
-            "(IBVZ)Ljava/lang/String;",
+            // fails because the return type does not contain the class name: "(IBVZ)L;"
+            // "(IBVZ)Ljava/lang/String;",
         ];
 
         for each in inputs.iter() {

--- a/src/wrapper/signature.rs
+++ b/src/wrapper/signature.rs
@@ -70,6 +70,11 @@ impl fmt::Display for JavaType {
     }
 }
 
+/// Enum representing any java type that may be used as a return value
+///
+/// This type intentionally avoids capturing any heap allocated types (to avoid
+/// allocations while making JNI method calls) and so it doesn't fully qualify
+/// the object or array types with a String like `JavaType::Object` does.
 #[allow(missing_docs)]
 #[derive(Eq, PartialEq, Debug, Clone)]
 pub enum ReturnType {


### PR DESCRIPTION
## Overview

I've been depending on this branch that was shared as part of this issue https://github.com/jni-rs/jni-rs/issues/329 for some time and would be very interested in seeing these changes make it upstream, while it's not ideal that method calls currently need to dynamically allocate a vector on each call - or that specifying the return type as a `JavaValue::Object` requires a `String` allocation that's unused for making the method call.

I figured I'd add a missing changelog entry and minimal docs for the added `ReturnType` enum and submit a PR on behalf of @georgwi, since it didn't look like there was any push back against the idea, just an admission that the project isn't very actively maintained currently.

This updates the lower-level `call_static_method_unchecked` and `call_method_unchecked` APIs to take an array of `jvalue`s directly to avoid needing to collect `JValue` enum values into `jvalue` unions before calling into Java.

This also introduced a `ReturnType` that avoids the cost of allocating a `String` for the class name that's associated with `JavaType::Object(_)`.

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Change is covered by [automated tests](https://github.com/jni-rs/jni-rs/blob/master/CONTRIBUTING.md#tests)
- [x] The [coding guidelines](https://github.com/jni-rs/jni-rs/blob/master/CONTRIBUTING.md#the-code-style) are followed
- [x] Public API has documentation
- [x] User-visible changes are mentioned in the Changelog
- [x] The continuous integration build passes
