### PR TITLE
derive Debug for more types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 - `Default` trait implemented for `JObject`, `JString`, `JClass`, and `JByteBuffer` (#199)
 - `JNIEnv#new_direct_byte_buffer_raw` function that allows creating a `JByteBuffer` from a pointer and size (#351)
+- `Debug` trait implemented for `JavaVM`, `GlobalRef`, `GlobalRefGuard`, `JStaticMethodID` and `ReleaseMode`
 
 ### Changed
 - The `release_string_utf_chars` function has been marked as unsafe. (#334)

--- a/src/wrapper/java_vm/vm.rs
+++ b/src/wrapper/java_vm/vm.rs
@@ -132,6 +132,7 @@ use std::thread::Thread;
 /// [actd]: struct.JavaVM.html#method.attach_current_thread_as_daemon
 /// [spec-references]: https://docs.oracle.com/en/java/javase/12/docs/specs/jni/design.html#referencing-java-objects
 #[repr(transparent)]
+#[derive(Debug)]
 pub struct JavaVM(*mut sys::JavaVM);
 
 unsafe impl Send for JavaVM {}

--- a/src/wrapper/objects/global_ref.rs
+++ b/src/wrapper/objects/global_ref.rs
@@ -21,11 +21,12 @@ use crate::{errors::Result, objects::JObject, sys, JNIEnv, JavaVM};
 /// the `GlobalRef#drop` will print a warning and implicitly `attach` and `detach` it, which
 /// significantly affects performance.
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct GlobalRef {
     inner: Arc<GlobalRefGuard>,
 }
 
+#[derive(Debug)]
 struct GlobalRefGuard {
     obj: JObject<'static>,
     vm: JavaVM,

--- a/src/wrapper/objects/jstaticmethodid.rs
+++ b/src/wrapper/objects/jstaticmethodid.rs
@@ -9,7 +9,7 @@ use crate::sys::jmethodID;
 /// `jmethodid`. This represents static methods only since they require a
 /// different set of JNI signatures.
 #[repr(transparent)]
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, Debug)]
 pub struct JStaticMethodID<'a> {
     internal: jmethodID,
     lifetime: PhantomData<&'a ()>,

--- a/src/wrapper/objects/release_mode.rs
+++ b/src/wrapper/objects/release_mode.rs
@@ -4,7 +4,7 @@ use crate::sys::JNI_ABORT;
 ///
 /// This defines the release mode of AutoArray (and AutoPrimitiveArray) resources, and
 /// related release array functions.
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, Debug)]
 #[repr(i32)]
 pub enum ReleaseMode {
     /// Copy back the content and free the elems buffer. For read-only access, prefer


### PR DESCRIPTION
## Overview

Not implementing the Debug trait for these types here forces
downstream users to implement Debug manually for any types
that encapsulate these types.

This implements Debug for some of the types that are more likely
to be encapsulated by downstream types.




### Definition of Done

- [x] There are no TODOs left in the code
- [x] Change is covered by [automated tests](https://github.com/jni-rs/jni-rs/blob/master/CONTRIBUTING.md#tests)
- [x] The [coding guidelines](https://github.com/jni-rs/jni-rs/blob/master/CONTRIBUTING.md#the-code-style) are followed
- [x] Public API has documentation
- [x] User-visible changes are mentioned in the Changelog
- [x] The continuous integration build passes
