### PR TITLE
JMethodID: remove lifetime and impl Send + Sync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - The lifetime of `AutoArray` is no longer tied to the lifetime of a particular `JNIEnv` reference. (#302)
 - Relaxed lifetime restrictions on `JNIEnv::new_local_ref`. Now it can be used to create a local
   reference from a global reference. (#301 / #319)
+- `JMethodID` implements `Send` + `Sync` and no longer has a lifetime parameter, making method
+  IDs cacheable (with a documented 'Safety' note about ensuring they remain valid). ([#346](https://github.com/jni-rs/jni-rs/pull/346))
 
 ## [0.19.0] — 2021-01-24
 

--- a/benches/api_calls.rs
+++ b/benches/api_calls.rs
@@ -38,7 +38,7 @@ fn jni_abs_safe(env: &JNIEnv, x: jint) -> jint {
 fn jni_call_static_unchecked<'c, C>(
     env: &JNIEnv<'c>,
     class: C,
-    method_id: JStaticMethodID<'c>,
+    method_id: JStaticMethodID,
     x: jint,
 ) -> jint
 where
@@ -61,7 +61,7 @@ fn jni_hash_safe(env: &JNIEnv, obj: JObject) -> jint {
 
 fn jni_call_unchecked<'m, M>(env: &JNIEnv<'m>, obj: JObject<'m>, method_id: M) -> jint
 where
-    M: Desc<'m, JMethodID<'m>>,
+    M: Desc<'m, JMethodID>,
 {
     let ret = JavaType::Primitive(Primitive::Int);
     let v = env.call_method_unchecked(obj, method_id, ret, &[]).unwrap();

--- a/src/wrapper/descriptors/method_desc.rs
+++ b/src/wrapper/descriptors/method_desc.rs
@@ -6,34 +6,34 @@ use crate::{
     JNIEnv,
 };
 
-impl<'a, 'c, T, U, V> Desc<'a, JMethodID<'a>> for (T, U, V)
+impl<'a, 'c, T, U, V> Desc<'a, JMethodID> for (T, U, V)
 where
     T: Desc<'a, JClass<'c>>,
     U: Into<JNIString>,
     V: Into<JNIString>,
 {
-    fn lookup(self, env: &JNIEnv<'a>) -> Result<JMethodID<'a>> {
+    fn lookup(self, env: &JNIEnv<'a>) -> Result<JMethodID> {
         env.get_method_id(self.0, self.1, self.2)
     }
 }
 
-impl<'a, 'c, T, Signature> Desc<'a, JMethodID<'a>> for (T, Signature)
+impl<'a, 'c, T, Signature> Desc<'a, JMethodID> for (T, Signature)
 where
     T: Desc<'a, JClass<'c>>,
     Signature: Into<JNIString>,
 {
-    fn lookup(self, env: &JNIEnv<'a>) -> Result<JMethodID<'a>> {
+    fn lookup(self, env: &JNIEnv<'a>) -> Result<JMethodID> {
         (self.0, "<init>", self.1).lookup(env)
     }
 }
 
-impl<'a, 'c, T, U, V> Desc<'a, JStaticMethodID<'a>> for (T, U, V)
+impl<'a, 'c, T, U, V> Desc<'a, JStaticMethodID> for (T, U, V)
 where
     T: Desc<'a, JClass<'c>>,
     U: Into<JNIString>,
     V: Into<JNIString>,
 {
-    fn lookup(self, env: &JNIEnv<'a>) -> Result<JStaticMethodID<'a>> {
+    fn lookup(self, env: &JNIEnv<'a>) -> Result<JStaticMethodID> {
         env.get_static_method_id(self.0, self.1, self.2)
     }
 }

--- a/src/wrapper/jnienv.rs
+++ b/src/wrapper/jnienv.rs
@@ -615,7 +615,7 @@ impl<'a> JNIEnv<'a> {
     /// let method_id: JMethodID =
     ///     env.get_method_id("java/lang/String", "substring", "(II)Ljava/lang/String;");
     /// ```
-    pub fn get_method_id<'c, T, U, V>(&self, class: T, name: U, sig: V) -> Result<JMethodID<'a>>
+    pub fn get_method_id<'c, T, U, V>(&self, class: T, name: U, sig: V) -> Result<JMethodID>
     where
         T: Desc<'a, JClass<'c>>,
         U: Into<JNIString>,
@@ -645,7 +645,7 @@ impl<'a> JNIEnv<'a> {
         class: T,
         name: U,
         sig: V,
-    ) -> Result<JStaticMethodID<'a>>
+    ) -> Result<JStaticMethodID>
     where
         T: Desc<'a, JClass<'c>>,
         U: Into<JNIString>,
@@ -761,7 +761,7 @@ impl<'a> JNIEnv<'a> {
     ///
     /// Under the hood, this simply calls the `CallStatic<Type>MethodA` method
     /// with the provided arguments.
-    pub fn call_static_method_unchecked<'c, 'm, T, U>(
+    pub fn call_static_method_unchecked<'c, T, U>(
         &self,
         class: T,
         method_id: U,
@@ -770,7 +770,7 @@ impl<'a> JNIEnv<'a> {
     ) -> Result<JValue<'a>>
     where
         T: Desc<'a, JClass<'c>>,
-        U: Desc<'a, JStaticMethodID<'m>>,
+        U: Desc<'a, JStaticMethodID>,
     {
         let class = class.lookup(self)?;
 
@@ -880,7 +880,7 @@ impl<'a> JNIEnv<'a> {
     ///
     /// Under the hood, this simply calls the `Call<Type>MethodA` method with
     /// the provided arguments.
-    pub fn call_method_unchecked<'m, O, T>(
+    pub fn call_method_unchecked<O, T>(
         &self,
         obj: O,
         method_id: T,
@@ -889,7 +889,7 @@ impl<'a> JNIEnv<'a> {
     ) -> Result<JValue<'a>>
     where
         O: Into<JObject<'a>>,
-        T: Desc<'a, JMethodID<'m>>,
+        T: Desc<'a, JMethodID>,
     {
         let method_id = method_id.lookup(self)?.into_inner();
 

--- a/src/wrapper/objects/jbytebuffer.rs
+++ b/src/wrapper/objects/jbytebuffer.rs
@@ -3,7 +3,7 @@ use crate::{objects::JObject, sys::jobject};
 /// Lifetime'd representation of a `jobject` that is an instance of the
 /// ByteBuffer Java class. Just a `JObject` wrapped in a new class.
 #[repr(transparent)]
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, Debug)]
 pub struct JByteBuffer<'a>(JObject<'a>);
 
 impl<'a> From<jobject> for JByteBuffer<'a> {

--- a/src/wrapper/objects/jlist.rs
+++ b/src/wrapper/objects/jlist.rs
@@ -13,11 +13,11 @@ use crate::{
 /// call.
 pub struct JList<'a: 'b, 'b> {
     internal: JObject<'a>,
-    get: JMethodID<'a>,
-    add: JMethodID<'a>,
-    add_idx: JMethodID<'a>,
-    remove: JMethodID<'a>,
-    size: JMethodID<'a>,
+    get: JMethodID,
+    add: JMethodID,
+    add_idx: JMethodID,
+    remove: JMethodID,
+    size: JMethodID,
     env: &'b JNIEnv<'a>,
 }
 

--- a/src/wrapper/objects/jmap.rs
+++ b/src/wrapper/objects/jmap.rs
@@ -13,9 +13,9 @@ use crate::{
 pub struct JMap<'a: 'b, 'b> {
     internal: JObject<'a>,
     class: AutoLocal<'a, 'b>,
-    get: JMethodID<'a>,
-    put: JMethodID<'a>,
-    remove: JMethodID<'a>,
+    get: JMethodID,
+    put: JMethodID,
+    remove: JMethodID,
     env: &'b JNIEnv<'a>,
 }
 
@@ -188,10 +188,10 @@ impl<'a: 'b, 'b> JMap<'a, 'b> {
 /// and generic enough to use elsewhere.
 pub struct JMapIter<'a, 'b, 'c> {
     map: &'c JMap<'a, 'b>,
-    has_next: JMethodID<'a>,
-    next: JMethodID<'a>,
-    get_key: JMethodID<'a>,
-    get_value: JMethodID<'a>,
+    has_next: JMethodID,
+    next: JMethodID,
+    get_key: JMethodID,
+    get_value: JMethodID,
     iter: AutoLocal<'a, 'b>,
 }
 

--- a/src/wrapper/objects/jmethodid.rs
+++ b/src/wrapper/objects/jmethodid.rs
@@ -1,29 +1,38 @@
-use std::marker::PhantomData;
-
 use crate::sys::jmethodID;
 
-/// Wrapper around `sys::jmethodid` that adds a lifetime. This prevents it from
-/// outliving the context in which it was acquired and getting GC'd out from
-/// under us. It matches C's representation of the raw pointer, so it can be
-/// used in any of the extern function argument positions that would take a
-/// `jmethodid`.
+/// Wrapper around `sys::jmethodid` that implements `Send` + `Sync` since method IDs
+/// are valid across threads (not tied to a `JNIEnv`). There is no lifetime associated
+/// with these since they aren't garbage collected like objects and their lifetime
+/// is not implicitly connected with the scope in which they are queried.
+///
+/// It matches C's representation of the raw pointer, so it can be used in any
+/// of the extern function argument positions that would take a `jmethodid`.
+///
+/// # Safety
+///
+/// According to the JNI spec method IDs may be released when the corresponding class is
+/// unloaded. Since this constraint can't be encoded as a Rust lifetime,
+/// and to avoid the excessive cost of having every Method ID be associated with
+/// a global reference to the corresponding class then it is the developers
+/// responsibility to ensure they hold some class reference for the lifetime of
+/// cached method IDs.
 #[repr(transparent)]
 #[derive(Copy, Clone, Debug)]
-pub struct JMethodID<'a> {
+pub struct JMethodID {
     internal: jmethodID,
-    lifetime: PhantomData<&'a ()>,
 }
 
-impl<'a> From<jmethodID> for JMethodID<'a> {
+// Method IDs are valid across threads (not tied to a JNIEnv)
+unsafe impl Send for JMethodID {}
+unsafe impl Sync for JMethodID {}
+
+impl From<jmethodID> for JMethodID {
     fn from(other: jmethodID) -> Self {
-        JMethodID {
-            internal: other,
-            lifetime: PhantomData,
-        }
+        JMethodID { internal: other }
     }
 }
 
-impl<'a> JMethodID<'a> {
+impl JMethodID {
     /// Unwrap to the internal jni type.
     pub fn into_inner(self) -> jmethodID {
         self.internal

--- a/src/wrapper/objects/jstaticmethodid.rs
+++ b/src/wrapper/objects/jstaticmethodid.rs
@@ -1,30 +1,38 @@
-use std::marker::PhantomData;
-
 use crate::sys::jmethodID;
 
-/// Wrapper around `sys::jmethodid` that adds a lifetime. This prevents it from
-/// outliving the context in which it was acquired and getting GC'd out from
-/// under us. It matches C's representation of the raw pointer, so it can be
-/// used in any of the extern function argument positions that would take a
-/// `jmethodid`. This represents static methods only since they require a
-/// different set of JNI signatures.
+/// Wrapper around `sys::jmethodid` that implements `Send` + `Sync` since method IDs
+/// are valid across threads (not tied to a `JNIEnv`). There is no lifetime associated
+/// with these since they aren't garbage collected like objects and their lifetime
+/// is not implicitly connected with the scope in which they are queried.
+///
+/// It matches C's representation of the raw pointer, so it can be used in any
+/// of the extern function argument positions that would take a `jmethodid`.
+///
+/// # Safety
+///
+/// According to the JNI spec method IDs may be released when the corresponding class is
+/// unloaded. Since this constraint can't be encoded as a Rust lifetime,
+/// and to avoid the excessive cost of having every Method ID be associated with
+/// a global reference to the corresponding class then it is the developers
+/// responsibility to ensure they hold some class reference for the lifetime of
+/// cached method IDs.
 #[repr(transparent)]
 #[derive(Copy, Clone, Debug)]
-pub struct JStaticMethodID<'a> {
+pub struct JStaticMethodID {
     internal: jmethodID,
-    lifetime: PhantomData<&'a ()>,
 }
 
-impl<'a> From<jmethodID> for JStaticMethodID<'a> {
+// Method IDs are valid across threads (not tied to a JNIEnv)
+unsafe impl Send for JStaticMethodID {}
+unsafe impl Sync for JStaticMethodID {}
+
+impl From<jmethodID> for JStaticMethodID {
     fn from(other: jmethodID) -> Self {
-        JStaticMethodID {
-            internal: other,
-            lifetime: PhantomData,
-        }
+        JStaticMethodID { internal: other }
     }
 }
 
-impl<'a> JStaticMethodID<'a> {
+impl JStaticMethodID {
     /// Unwrap to the internal jni type.
     pub fn into_inner(self) -> jmethodID {
         self.internal


### PR DESCRIPTION
## Overview

Method IDs by their nature are intended to be cached by applications
which was generally precluded by the lifetime parameter. According
to the JNI spec method IDs are also not garbage collected as previously
documented and they remain valid until their corresponding class is
unloaded. Since the real lifetime details can't be represented via a
Rust lifetime (and it would be an excessive cost at this level of
abstraction to pair every method ID with a global reference to the
class) then this patch removes the Rust lifetime and adds "Safety"
documentation to explain what developers need to do if caching method
IDs.

It's perhaps also worth noting that the very conservative lifetime
parameter that existed before wouldn't have provided any technical
safety against a method's class being unloaded within that lifetime.

As method IDs are not tied to a thread / JNIEnv it also makes sense to
declare them as Send + Sync safe.

Fixes: #38 
Fixes: #270  
Closes: #274 

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Change is covered by [automated tests](https://github.com/jni-rs/jni-rs/blob/master/CONTRIBUTING.md#tests)
- [x] The [coding guidelines](https://github.com/jni-rs/jni-rs/blob/master/CONTRIBUTING.md#the-code-style) are followed
- [x] Public API has documentation
- [x] User-visible changes are mentioned in the Changelog
- [x] The continuous integration build passes
