### PR TITLE
Suppress the not_unsafe_ptr_arg_deref Clippy warning

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,7 @@
 #![warn(missing_docs)]
 #![allow(clippy::upper_case_acronyms)]
+// TODO: https://github.com/jni-rs/jni-rs/issues/348
+#![allow(clippy::not_unsafe_ptr_arg_deref)]
 
 //! # Safe JNI Bindings in Rust
 //!


### PR DESCRIPTION
## Overview

Temporary suppression, should be fixed later (https://github.com/jni-rs/jni-rs/issues/348).

### Definition of Done

- [ ] There are no TODOs left in the code
- [ ] Change is covered by [automated tests](https://github.com/jni-rs/jni-rs/blob/master/CONTRIBUTING.md#tests)
- [ ] The [coding guidelines](https://github.com/jni-rs/jni-rs/blob/master/CONTRIBUTING.md#the-code-style) are followed
- [ ] Public API has documentation
- [ ] User-visible changes are mentioned in the Changelog
- [ ] The continuous integration build passes
