### PR TITLE
Update dynamic library path enviroment variable on macOS for test.

### DIFF
--- a/test_profile
+++ b/test_profile
@@ -18,3 +18,7 @@ fi
 LIBJVM_PATH="$(find "${JAVA_HOME}" -type f -name "${LIB_NAME}.*" -print0 -quit | xargs -0 -n1 dirname)"
 
 export LD_LIBRARY_PATH="${LIBJVM_PATH}"
+
+# on macOS, cargo use DYLD_FALLBACK_LIBRARY_PATH to locate dynamic libraries. 
+# See https://doc.rust-lang.org/cargo/reference/environment-variables.html#dynamic-library-paths
+export DYLD_FALLBACK_LIBRARY_PATH="${LIBJVM_PATH}":$DYLD_FALLBACK_LIBRARY_PATH


### PR DESCRIPTION
## Overview

According to https://doc.rust-lang.org/cargo/reference/environment-variables.html#dynamic-library-paths
macOS use `DYLD_FALLBACK_LIBRARY_PATH` instead of `LD_LIBRARY_PATH` to locate dynamic libraries.


### Definition of Done

- [x] There are no TODOs left in the code
- [x] Change is covered by [automated tests](https://github.com/jni-rs/jni-rs/blob/master/CONTRIBUTING.md#tests)
- [x] The [coding guidelines](https://github.com/jni-rs/jni-rs/blob/master/CONTRIBUTING.md#the-code-style) are followed
- [x] Public API has documentation
- [x] User-visible changes are mentioned in the Changelog
- [ ] The continuous integration build passes
