### PR TITLE
Allow creation of byte buffer from mut pointer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 - `Default` trait implemented for `JObject`, `JString`, `JClass`, and `JByteBuffer` (#199)
+- `JNIEnv#new_direct_byte_buffer_raw` function that allows creating a `JByteBuffer` from a pointer and size (#351)
 
 ### Changed
 - The `release_string_utf_chars` function has been marked as unsafe. (#334)

--- a/src/wrapper/jnienv.rs
+++ b/src/wrapper/jnienv.rs
@@ -317,12 +317,21 @@ impl<'a> JNIEnv<'a> {
     /// `ByteBuffer`. The JVM may maintain references to the `ByteBuffer` beyond the lifetime
     /// of this `JNIEnv`.
     pub unsafe fn new_direct_byte_buffer(&self, data: &mut [u8]) -> Result<JByteBuffer<'a>> {
+        self.new_direct_byte_buffer_raw(data.as_mut_ptr(), data.len())
+    }
+
+    /// Create a new instance of a direct java.nio.ByteBuffer from a pointer and size directly
+    pub unsafe fn new_direct_byte_buffer_raw(
+        &self,
+        data: *mut u8,
+        len: usize,
+    ) -> Result<JByteBuffer<'a>> {
         #[allow(unused_unsafe)]
         let obj: JObject = jni_non_null_call!(
             self.internal,
             NewDirectByteBuffer,
-            data.as_mut_ptr() as *mut c_void,
-            data.len() as jlong
+            data as *mut c_void,
+            len as jlong
         );
         Ok(JByteBuffer::from(obj))
     }

--- a/src/wrapper/jnienv.rs
+++ b/src/wrapper/jnienv.rs
@@ -321,6 +321,10 @@ impl<'a> JNIEnv<'a> {
     }
 
     /// Create a new instance of a direct java.nio.ByteBuffer from a pointer and size directly
+    ///
+    /// # Safety
+    ///
+    /// Expects a valid pointer and length
     pub unsafe fn new_direct_byte_buffer_raw(
         &self,
         data: *mut u8,

--- a/tests/jni_api.rs
+++ b/tests/jni_api.rs
@@ -580,6 +580,18 @@ pub fn new_direct_byte_buffer() {
 }
 
 #[test]
+pub fn new_direct_byte_buffer_raw() {
+    let env = attach_current_thread();
+    let mut vec: Vec<u8> = vec![0, 1, 2, 3];
+    let buf = vec.as_mut_slice();
+    let result = unsafe {
+        env.new_direct_byte_buffer_raw(vec.as_mut_ptr(), vec.len())
+    };
+    assert!(result.is_ok());
+    assert!(!result.unwrap().is_null());
+}
+
+#[test]
 pub fn get_direct_buffer_capacity_ok() {
     let env = attach_current_thread();
     let mut vec: Vec<u8> = vec![0, 1, 2, 3];

--- a/tests/jni_api.rs
+++ b/tests/jni_api.rs
@@ -583,7 +583,6 @@ pub fn new_direct_byte_buffer() {
 pub fn new_direct_byte_buffer_raw() {
     let env = attach_current_thread();
     let mut vec: Vec<u8> = vec![0, 1, 2, 3];
-    let buf = vec.as_mut_slice();
     let result = unsafe {
         env.new_direct_byte_buffer_raw(vec.as_mut_ptr(), vec.len())
     };

--- a/tests/jni_api.rs
+++ b/tests/jni_api.rs
@@ -583,9 +583,7 @@ pub fn new_direct_byte_buffer() {
 pub fn new_direct_byte_buffer_raw() {
     let env = attach_current_thread();
     let mut vec: Vec<u8> = vec![0, 1, 2, 3];
-    let result = unsafe {
-        env.new_direct_byte_buffer_raw(vec.as_mut_ptr(), vec.len())
-    };
+    let result = unsafe { env.new_direct_byte_buffer_raw(vec.as_mut_ptr(), vec.len()) };
     assert!(result.is_ok());
     assert!(!result.unwrap().is_null());
 }


### PR DESCRIPTION
## Overview

It can be useful to create a new byte buffer directly from a pointer and length if a `&mut [u8]` is not available.
In my case I am trying to share an immutable `&[u8]` to my java code and enforce immutable using [asReadOnlyBuffer](https://docs.oracle.com/javase/10/docs/api/java/nio/ByteBuffer.html#asReadOnlyBuffer()).
According to the [rustnomicon](https://doc.rust-lang.org/nightly/nomicon/transmutes.html) transmuting `&[u8]` to `&mut [u8]` is always UB, even if it doesn't get mutated so being able to initialise directly from the raw pointer is needed.

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Change is covered by [automated tests](https://github.com/jni-rs/jni-rs/blob/master/CONTRIBUTING.md#tests)
- [x] The [coding guidelines](https://github.com/jni-rs/jni-rs/blob/master/CONTRIBUTING.md#the-code-style) are followed
- [x] Public API has documentation
- [x] User-visible changes are mentioned in the Changelog
- [x] The continuous integration build passes
