### PR TITLE
Avoid potentual panic in InternalAttachGuard

### DIFF
--- a/src/wrapper/java_vm/vm.rs
+++ b/src/wrapper/java_vm/vm.rs
@@ -12,6 +12,7 @@ use crate::{errors::*, sys, JNIEnv};
 
 #[cfg(feature = "invocation")]
 use crate::InitArgs;
+use std::thread::Thread;
 
 /// The Java VM, providing [Invocation API][invocation-api] support.
 ///
@@ -348,11 +349,17 @@ enum ThreadType {
 #[derive(Debug)]
 struct InternalAttachGuard {
     java_vm: *mut sys::JavaVM,
+    /// A call std::thread::current() function can panic in case the local data has been destroyed
+    /// before the thead local variables. The possibility of this happening depends on the platform
+    /// implementation of the crate::sys_common::thread_local_dtor::register_dtor_fallback.
+    /// The InternalAttachGuard is a thread-local vairable, so capture the thread meta-data
+    /// during creation
+    thread: Thread
 }
 
 impl InternalAttachGuard {
     fn new(java_vm: *mut sys::JavaVM) -> Self {
-        Self { java_vm }
+        Self { java_vm, thread: current() }
     }
 
     /// Stores guard in thread local storage.
@@ -384,8 +391,8 @@ impl InternalAttachGuard {
 
         debug!(
             "Attached thread {} ({:?}). {} threads attached",
-            current().name().unwrap_or_default(),
-            current().id(),
+            self.thread.name().unwrap_or_default(),
+            self.thread.id(),
             ATTACHED_THREADS.load(Ordering::SeqCst)
         );
 
@@ -406,8 +413,8 @@ impl InternalAttachGuard {
 
         debug!(
             "Attached daemon thread {} ({:?}). {} threads attached",
-            current().name().unwrap_or_default(),
-            current().id(),
+            self.thread.name().unwrap_or_default(),
+            self.thread.id(),
             ATTACHED_THREADS.load(Ordering::SeqCst)
         );
 
@@ -421,8 +428,8 @@ impl InternalAttachGuard {
         ATTACHED_THREADS.fetch_sub(1, Ordering::SeqCst);
         debug!(
             "Detached thread {} ({:?}). {} threads remain attached",
-            current().name().unwrap_or_default(),
-            current().id(),
+            self.thread.name().unwrap_or_default(),
+            self.thread.id(),
             ATTACHED_THREADS.load(Ordering::SeqCst)
         );
 
@@ -436,8 +443,8 @@ impl Drop for InternalAttachGuard {
             error!(
                 "Error detaching current thread: {:#?}\nThread {} id={:?}",
                 e,
-                current().name().unwrap_or_default(),
-                current().id(),
+                self.thread.name().unwrap_or_default(),
+                self.thread.id(),
             );
         }
     }

--- a/src/wrapper/java_vm/vm.rs
+++ b/src/wrapper/java_vm/vm.rs
@@ -354,12 +354,15 @@ struct InternalAttachGuard {
     /// implementation of the crate::sys_common::thread_local_dtor::register_dtor_fallback.
     /// The InternalAttachGuard is a thread-local vairable, so capture the thread meta-data
     /// during creation
-    thread: Thread
+    thread: Thread,
 }
 
 impl InternalAttachGuard {
     fn new(java_vm: *mut sys::JavaVM) -> Self {
-        Self { java_vm, thread: current() }
+        Self {
+            java_vm,
+            thread: current(),
+        }
     }
 
     /// Stores guard in thread local storage.


### PR DESCRIPTION
## Overview

This PR fixes issue #354. The call to ``std::thread::current()`` panics and does not provide debug information when in certain cases. To avoid the problem we preserve the thread information when we create it.

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Change is covered by [automated tests](https://github.com/jni-rs/jni-rs/blob/master/CONTRIBUTING.md#tests)
- [x] The [coding guidelines](https://github.com/jni-rs/jni-rs/blob/master/CONTRIBUTING.md#the-code-style) are followed
- [x] Public API has documentation
- [x] User-visible changes are mentioned in the Changelog
- [x] The continuous integration build passes
