### PR TITLE
fix: add target_os clause for Android

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Changed
 - The `release_string_utf_chars` function has been marked as unsafe. (#334)
 
+### Fixed
+- Android support in build.rs (#358)
+
 ## [0.19.0] — 2021-01-24
 
 ### Added

--- a/build.rs
+++ b/build.rs
@@ -24,6 +24,7 @@ const EXPECTED_JVM_FILENAME: &str = "jvm.dll";
     target_os = "freebsd",
     target_os = "linux",
     target_os = "netbsd",
+    target_os = "android",
     target_os = "openbsd"
 ))]
 const EXPECTED_JVM_FILENAME: &str = "libjvm.so";


### PR DESCRIPTION
## Overview

<!-- Please describe your changes here and list any open questions you might have. -->

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Change is covered by [automated tests](https://github.com/jni-rs/jni-rs/blob/master/CONTRIBUTING.md#tests)
- [x] The [coding guidelines](https://github.com/jni-rs/jni-rs/blob/master/CONTRIBUTING.md#the-code-style) are followed
- [x] Public API has documentation
- [x] User-visible changes are mentioned in the Changelog
- [ ] The continuous integration build passes
