### PR TITLE
Replace `From<jni pointers>` with `unsafe` `::from_raw()` functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   IDs cacheable (with a documented 'Safety' note about ensuring they remain valid). ([#346](https://github.com/jni-rs/jni-rs/pull/346))
 - The `call_*_method_unchecked` functions now take `jni:sys::jvalue` arguments to avoid allocating
   a `Vec` on each call to map + collect `JValue`s as `sys:jvalue`s (#329)
+- The `From` trait implementations converting `jni_sys` types like `jobject` to `JObject` have been replaced
+  with `unsafe` `::from_raw` functions and corresponding `::into_raw` methods. Existing `::into_inner` APIs were
+  renamed `::into_raw` for symmetry. ([#197](https://github.com/jni-rs/jni-rs/issues/197))
+
 
 ## [0.19.0] — 2021-01-24
 

--- a/src/wrapper/macros.rs
+++ b/src/wrapper/macros.rs
@@ -4,7 +4,7 @@
 macro_rules! jni_non_null_call {
     ( $jnienv:expr, $name:tt $(, $args:expr )* ) => ({
         let res = jni_non_void_call!($jnienv, $name $(, $args)*);
-        non_null!(res, concat!(stringify!($name), " result")).into()
+        non_null!(res, concat!(stringify!($name), " result"))
     })
 }
 
@@ -14,6 +14,7 @@ macro_rules! jni_non_void_call {
     ( $jnienv:expr, $name:tt $(, $args:expr )* ) => ({
         log::trace!("calling checked jni method: {}", stringify!($name));
 
+        #[allow(unused_unsafe)]
         let res = unsafe {
             jni_method!($jnienv, $name)($jnienv, $($args),*)
         };
@@ -39,6 +40,7 @@ macro_rules! jni_void_call {
     ( $jnienv:expr, $name:tt $(, $args:expr )* ) => ({
         log::trace!("calling checked jni method: {}", stringify!($name));
 
+        #[allow(unused_unsafe)]
         unsafe {
             jni_method!($jnienv, $name)($jnienv, $($args),*)
         };
@@ -53,6 +55,7 @@ macro_rules! jni_unchecked {
     ( $jnienv:expr, $name:tt $(, $args:expr )* ) => ({
         log::trace!("calling unchecked jni method: {}", stringify!($name));
 
+        #[allow(unused_unsafe)]
         unsafe {
             jni_method!($jnienv, $name)($jnienv, $($args),*)
         }

--- a/src/wrapper/objects/global_ref.rs
+++ b/src/wrapper/objects/global_ref.rs
@@ -67,7 +67,7 @@ impl GlobalRefGuard {
     /// has already been called.
     unsafe fn from_raw(vm: JavaVM, obj: sys::jobject) -> Self {
         GlobalRefGuard {
-            obj: JObject::from(obj),
+            obj: JObject::from_raw(obj),
             vm,
         }
     }
@@ -86,7 +86,7 @@ impl Drop for GlobalRefGuard {
         fn drop_impl(env: &JNIEnv, global_ref: JObject) -> Result<()> {
             let internal = env.get_native_interface();
             // This method is safe to call in case of pending exceptions (see chapter 2 of the spec)
-            jni_unchecked!(internal, DeleteGlobalRef, global_ref.into_inner());
+            jni_unchecked!(internal, DeleteGlobalRef, global_ref.into_raw());
             Ok(())
         }
 

--- a/src/wrapper/objects/jbytebuffer.rs
+++ b/src/wrapper/objects/jbytebuffer.rs
@@ -6,12 +6,6 @@ use crate::{objects::JObject, sys::jobject};
 #[derive(Clone, Copy, Debug)]
 pub struct JByteBuffer<'a>(JObject<'a>);
 
-impl<'a> From<jobject> for JByteBuffer<'a> {
-    fn from(other: jobject) -> Self {
-        JByteBuffer(From::from(other))
-    }
-}
-
 impl<'a> ::std::ops::Deref for JByteBuffer<'a> {
     type Target = JObject<'a>;
 
@@ -27,13 +21,29 @@ impl<'a> From<JByteBuffer<'a>> for JObject<'a> {
 }
 
 impl<'a> From<JObject<'a>> for JByteBuffer<'a> {
-    fn from(other: JObject) -> JByteBuffer {
-        (other.into_inner() as jobject).into()
+    fn from(other: JObject) -> Self {
+        unsafe { Self::from_raw(other.into_raw()) }
     }
 }
 
 impl<'a> std::default::Default for JByteBuffer<'a> {
     fn default() -> Self {
-        JByteBuffer(JObject::null())
+        Self(JObject::null())
+    }
+}
+
+impl<'a> JByteBuffer<'a> {
+    /// Creates a [`JByteBuffer`] that wraps the given `raw` [`jobject`]
+    ///
+    /// # Safety
+    /// No runtime check is made to verify that the given [`jobject`] is an instance of
+    /// a `ByteBuffer`.
+    pub unsafe fn from_raw(raw: jobject) -> Self {
+        Self(JObject::from_raw(raw as jobject))
+    }
+
+    /// Unwrap to the raw jni type.
+    pub fn into_raw(self) -> jobject {
+        self.0.into_raw() as jobject
     }
 }

--- a/src/wrapper/objects/jclass.rs
+++ b/src/wrapper/objects/jclass.rs
@@ -9,12 +9,6 @@ use crate::{
 #[derive(Clone, Copy, Debug)]
 pub struct JClass<'a>(JObject<'a>);
 
-impl<'a> From<jclass> for JClass<'a> {
-    fn from(other: jclass) -> Self {
-        JClass(From::from(other as jobject))
-    }
-}
-
 impl<'a> ::std::ops::Deref for JClass<'a> {
     type Target = JObject<'a>;
 
@@ -31,13 +25,29 @@ impl<'a> From<JClass<'a>> for JObject<'a> {
 
 /// This conversion assumes that the `JObject` is a pointer to a class object.
 impl<'a> From<JObject<'a>> for JClass<'a> {
-    fn from(other: JObject) -> JClass {
-        (other.into_inner() as jclass).into()
+    fn from(other: JObject) -> Self {
+        unsafe { Self::from_raw(other.into_raw()) }
     }
 }
 
 impl<'a> std::default::Default for JClass<'a> {
     fn default() -> Self {
-        JClass(JObject::null())
+        Self(JObject::null())
+    }
+}
+
+impl<'a> JClass<'a> {
+    /// Creates a [`JClass`] that wraps the given `raw` [`jclass`]
+    ///
+    /// # Safety
+    ///
+    /// Expects a valid pointer or `null`
+    pub unsafe fn from_raw(raw: jclass) -> Self {
+        Self(JObject::from_raw(raw as jobject))
+    }
+
+    /// Unwrap to the raw jni type.
+    pub fn into_raw(self) -> jclass {
+        self.0.into_raw() as jclass
     }
 }

--- a/src/wrapper/objects/jfieldid.rs
+++ b/src/wrapper/objects/jfieldid.rs
@@ -14,18 +14,22 @@ pub struct JFieldID<'a> {
     lifetime: PhantomData<&'a ()>,
 }
 
-impl<'a> From<jfieldID> for JFieldID<'a> {
-    fn from(other: jfieldID) -> Self {
-        JFieldID {
-            internal: other,
+impl<'a> JFieldID<'a> {
+    /// Creates a [`JFieldID`] that wraps the given `raw` [`jfieldID`]
+    ///
+    /// # Safety
+    ///
+    /// Expects a valid, non-`null` ID
+    pub unsafe fn from_raw(raw: jfieldID) -> Self {
+        debug_assert!(!raw.is_null(), "from_raw methodID argument");
+        Self {
+            internal: raw,
             lifetime: PhantomData,
         }
     }
-}
 
-impl<'a> JFieldID<'a> {
     /// Unwrap to the internal jni type.
-    pub fn into_inner(self) -> jfieldID {
+    pub fn into_raw(self) -> jfieldID {
         self.internal
     }
 }

--- a/src/wrapper/objects/jmethodid.rs
+++ b/src/wrapper/objects/jmethodid.rs
@@ -26,15 +26,19 @@ pub struct JMethodID {
 unsafe impl Send for JMethodID {}
 unsafe impl Sync for JMethodID {}
 
-impl From<jmethodID> for JMethodID {
-    fn from(other: jmethodID) -> Self {
-        JMethodID { internal: other }
-    }
-}
-
 impl JMethodID {
+    /// Creates a [`JMethodID`] that wraps the given `raw` [`jmethodID`]
+    ///
+    /// # Safety
+    ///
+    /// Expects a valid, non-`null` ID
+    pub unsafe fn from_raw(raw: jmethodID) -> Self {
+        debug_assert!(!raw.is_null(), "from_raw methodID argument");
+        Self { internal: raw }
+    }
+
     /// Unwrap to the internal jni type.
-    pub fn into_inner(self) -> jmethodID {
+    pub fn into_raw(self) -> jmethodID {
         self.internal
     }
 }

--- a/src/wrapper/objects/jobject.rs
+++ b/src/wrapper/objects/jobject.rs
@@ -17,15 +17,6 @@ pub struct JObject<'a> {
     lifetime: PhantomData<&'a ()>,
 }
 
-impl<'a> From<jobject> for JObject<'a> {
-    fn from(other: jobject) -> Self {
-        JObject {
-            internal: other,
-            lifetime: PhantomData,
-        }
-    }
-}
-
 impl<'a> ::std::ops::Deref for JObject<'a> {
     type Target = jobject;
 
@@ -35,14 +26,26 @@ impl<'a> ::std::ops::Deref for JObject<'a> {
 }
 
 impl<'a> JObject<'a> {
+    /// Creates a [`JObject`] that wraps the given `raw` [`jobject`]
+    ///
+    /// # Safety
+    ///
+    /// Expects a valid pointer or `null`
+    pub unsafe fn from_raw(raw: jobject) -> Self {
+        Self {
+            internal: raw,
+            lifetime: PhantomData,
+        }
+    }
+
     /// Unwrap to the internal jni type.
-    pub fn into_inner(self) -> jobject {
+    pub fn into_raw(self) -> jobject {
         self.internal
     }
 
     /// Creates a new null object
     pub fn null() -> JObject<'a> {
-        (::std::ptr::null_mut() as jobject).into()
+        unsafe { Self::from_raw(std::ptr::null_mut() as jobject) }
     }
 }
 

--- a/src/wrapper/objects/jstaticfieldid.rs
+++ b/src/wrapper/objects/jstaticfieldid.rs
@@ -14,18 +14,22 @@ pub struct JStaticFieldID<'a> {
     lifetime: PhantomData<&'a ()>,
 }
 
-impl<'a> From<jfieldID> for JStaticFieldID<'a> {
-    fn from(other: jfieldID) -> Self {
-        JStaticFieldID {
-            internal: other,
+impl<'a> JStaticFieldID<'a> {
+    /// Creates a [`JStaticFieldID`] that wraps the given `raw` [`jfieldID`]
+    ///
+    /// # Safety
+    ///
+    /// Expects a valid, non-`null` ID
+    pub unsafe fn from_raw(raw: jfieldID) -> Self {
+        debug_assert!(!raw.is_null(), "from_raw methodID argument");
+        Self {
+            internal: raw,
             lifetime: PhantomData,
         }
     }
-}
 
-impl<'a> JStaticFieldID<'a> {
     /// Unwrap to the internal jni type.
-    pub fn into_inner(self) -> jfieldID {
+    pub fn into_raw(self) -> jfieldID {
         self.internal
     }
 }

--- a/src/wrapper/objects/jstaticmethodid.rs
+++ b/src/wrapper/objects/jstaticmethodid.rs
@@ -26,15 +26,19 @@ pub struct JStaticMethodID {
 unsafe impl Send for JStaticMethodID {}
 unsafe impl Sync for JStaticMethodID {}
 
-impl From<jmethodID> for JStaticMethodID {
-    fn from(other: jmethodID) -> Self {
-        JStaticMethodID { internal: other }
-    }
-}
-
 impl JStaticMethodID {
+    /// Creates a [`JStaticMethodID`] that wraps the given `raw` [`jmethodID`]
+    ///
+    /// # Safety
+    ///
+    /// Expects a valid, non-`null` ID
+    pub unsafe fn from_raw(raw: jmethodID) -> Self {
+        debug_assert!(!raw.is_null(), "from_raw methodID argument");
+        Self { internal: raw }
+    }
+
     /// Unwrap to the internal jni type.
-    pub fn into_inner(self) -> jmethodID {
+    pub fn into_raw(self) -> jmethodID {
         self.internal
     }
 }

--- a/src/wrapper/objects/jstring.rs
+++ b/src/wrapper/objects/jstring.rs
@@ -9,12 +9,6 @@ use crate::{
 #[derive(Clone, Copy)]
 pub struct JString<'a>(JObject<'a>);
 
-impl<'a> From<jstring> for JString<'a> {
-    fn from(other: jstring) -> Self {
-        JString(From::from(other as jobject))
-    }
-}
-
 impl<'a> ::std::ops::Deref for JString<'a> {
     type Target = JObject<'a>;
 
@@ -30,13 +24,29 @@ impl<'a> From<JString<'a>> for JObject<'a> {
 }
 
 impl<'a> From<JObject<'a>> for JString<'a> {
-    fn from(other: JObject) -> JString {
-        (other.into_inner() as jstring).into()
+    fn from(other: JObject) -> Self {
+        unsafe { Self::from_raw(other.into_raw()) }
     }
 }
 
 impl<'a> std::default::Default for JString<'a> {
     fn default() -> Self {
-        JString(JObject::null())
+        Self(JObject::null())
+    }
+}
+
+impl<'a> JString<'a> {
+    /// Creates a [`JString`] that wraps the given `raw` [`jstring`]
+    ///
+    /// # Safety
+    ///
+    /// Expects a valid pointer or `null`
+    pub unsafe fn from_raw(raw: jstring) -> Self {
+        Self(JObject::from_raw(raw as jobject))
+    }
+
+    /// Unwrap to the raw jni type.
+    pub fn into_raw(self) -> jstring {
+        self.0.into_raw() as jstring
     }
 }

--- a/src/wrapper/objects/jthrowable.rs
+++ b/src/wrapper/objects/jthrowable.rs
@@ -9,12 +9,6 @@ use crate::{
 #[derive(Clone, Copy)]
 pub struct JThrowable<'a>(JObject<'a>);
 
-impl<'a> From<jthrowable> for JThrowable<'a> {
-    fn from(other: jthrowable) -> Self {
-        JThrowable(From::from(other as jobject))
-    }
-}
-
 impl<'a> ::std::ops::Deref for JThrowable<'a> {
     type Target = JObject<'a>;
 
@@ -30,7 +24,29 @@ impl<'a> From<JThrowable<'a>> for JObject<'a> {
 }
 
 impl<'a> From<JObject<'a>> for JThrowable<'a> {
-    fn from(other: JObject) -> JThrowable {
-        (other.into_inner() as jthrowable).into()
+    fn from(other: JObject) -> Self {
+        unsafe { Self::from_raw(other.into_raw()) }
+    }
+}
+
+impl<'a> std::default::Default for JThrowable<'a> {
+    fn default() -> Self {
+        Self(JObject::null())
+    }
+}
+
+impl<'a> JThrowable<'a> {
+    /// Creates a [`JThrowable`] that wraps the given `raw` [`jthrowable`]
+    ///
+    /// # Safety
+    ///
+    /// Expects a valid pointer or `null`
+    pub unsafe fn from_raw(raw: jthrowable) -> Self {
+        Self(JObject::from_raw(raw as jobject))
+    }
+
+    /// Unwrap to the raw jni type.
+    pub fn into_raw(self) -> jthrowable {
+        self.0.into_raw() as jthrowable
     }
 }

--- a/tests/java_integers.rs
+++ b/tests/java_integers.rs
@@ -16,11 +16,9 @@ fn test_java_integers() {
             let integer_value =
                 env.new_object("java/lang/Integer", "(I)V", &[JValue::Int(value)])?;
 
-            let values_array = JObject::from(env.new_object_array(
-                array_length,
-                "java/lang/Integer",
-                integer_value,
-            )?);
+            let values_array =
+                env.new_object_array(array_length, "java/lang/Integer", integer_value)?;
+            let values_array = unsafe { JObject::from_raw(values_array) };
 
             let result = env
                 .call_static_method(

--- a/tests/jni_api.rs
+++ b/tests/jni_api.rs
@@ -305,7 +305,7 @@ pub fn java_byte_array_from_slice() {
     let java_array = env
         .byte_array_from_slice(buf)
         .expect("JNIEnv#byte_array_from_slice must create a java array from slice");
-    let obj = AutoLocal::new(&env, JObject::from(java_array));
+    let obj = AutoLocal::new(&env, unsafe { JObject::from_raw(java_array) });
 
     assert!(!obj.as_obj().is_null());
     let mut res: [i8; 3] = [0; 3];
@@ -613,7 +613,7 @@ pub fn get_direct_buffer_capacity_ok() {
 #[test]
 pub fn get_direct_buffer_capacity_wrong_arg() {
     let env = attach_current_thread();
-    let wrong_obj = JByteBuffer::from(env.new_string("wrong").unwrap().into_inner());
+    let wrong_obj = unsafe { JByteBuffer::from_raw(env.new_string("wrong").unwrap().into_raw()) };
     let capacity = env.get_direct_buffer_capacity(wrong_obj);
     assert!(capacity.is_err());
 }


### PR DESCRIPTION
This ensures that it's not possible to trivially convert arbitrary numbers as invalid pointers into types like JObject, JString, JClass etc in safe code due to `From` trait implementations for `jni_sys` types.

I.e this kind of thing shouldn't be possible in safe Rust:

```rust
    let bad_object = jni::objects::JObject::from(42 as jni_sys::jobject);
    let hash_code = env.call_method(bad_object, "hashCode", "()I", &[]).unwrap().i().unwrap();
```

This removes the `From<jni pointer>` trait implementation for `JObject`-based types and method and field IDs.

The same types now consistently have an `unsafe` `::from_raw()` functions instead of implementing the `From` trait and a corresponding `::into_raw()` method. Any pre-existing `::into_inner()` method was renamed to `::into_raw()` for consistency / symmetry.

Fixes: #197

## Overview

<!-- Please describe your changes here and list any open questions you might have. -->

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Change is covered by [automated tests](https://github.com/jni-rs/jni-rs/blob/master/CONTRIBUTING.md#tests)
- [x] The [coding guidelines](https://github.com/jni-rs/jni-rs/blob/master/CONTRIBUTING.md#the-code-style) are followed
- [x] Public API has documentation
- [x] User-visible changes are mentioned in the Changelog
- [x] The continuous integration build passes
