### PR TITLE
direct_buffer: Avoid mutable reference aliasing (UB)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,13 +17,15 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 - `Default` trait implemented for `JObject`, `JString`, `JClass`, and `JByteBuffer` (#199)
-- `JNIEnv#new_direct_byte_buffer_raw` function that allows creating a `JByteBuffer` from a pointer and size (#351)
+- `JNIEnv#new_direct_byte_buffer_raw` function that allows creating a `JByteBuffer` from a pointer and size ([#351](https://github.com/jni-rs/jni-rs/pull/351))
 - `Debug` trait implemented for `JavaVM`, `GlobalRef`, `GlobalRefGuard`, `JStaticMethodID` and `ReleaseMode`
 - `ReturnType` for specifying object return types without a String allocation. (#329)
 
 ### Changed
 - The `release_string_utf_chars` function has been marked as unsafe. (#334)
-- Breaking change: Mark `JNIEnv::new_direct_byte_buffer` as `unsafe` (#320)
+- Mark `JNIEnv::new_direct_byte_buffer` as `unsafe` ([#320](https://github.com/jni-rs/jni-rs/pull/320))
+- `JNIEnv::new_direct_byte_buffer` now takes a raw pointer and size instead of a slice ([#364](https://github.com/jni-rs/jni-rs/pull/364))
+- `JNIEnv::direct_buffer_address` returns a raw pointer instead of a slice ([#364](https://github.com/jni-rs/jni-rs/pull/364))
 - The lifetime of `AutoArray` is no longer tied to the lifetime of a particular `JNIEnv` reference. (#302)
 - Relaxed lifetime restrictions on `JNIEnv::new_local_ref`. Now it can be used to create a local
   reference from a global reference. (#301 / #319)


### PR DESCRIPTION
This aims to address some soundness issues with the direct_buffer wrapper functions which:
1. discard the slice lifetime when creating a buffer
2. enable shared mutable reference aliasing (which is considered undefined behaviour in Rust.)

For example the following was previously possible:
```rust
let mut vec: Vec<u8> = vec![0, 1, 2, 3];
let buf = env.new_direct_byte_buffer(&mut vec)?;
let slice_alias_a: &mut [u8] = env.get_direct_buffer_address();
let slice_alias_b: &mut [u8] = env.get_direct_buffer_address();
// ...
```
Where the same memory would be mutable via the original `vec` and any of the additional mutable slice aliases.

This doesn't uphold Rust's safety model since it enables shared mutable access to state from a single thread.

This patch removes the version of `new_direct_byte_buffer()` that takes a slice with a lifetime and replaces it with the recently added `new_direct_byte_buffer_raw()` implementation that takes an address pointer and size. This is an `unsafe` function that documents that the address needs to remain valid as long as the `JByteBuffer` may be accessed.

This adds some additional null pointer checks (and corresponding tests) that `new_direct_byte_buffer()` can't be provided a null address and `get_direct_buffer_capacity()` can't be given a null buffer.

This updates `get_direct_buffer_address()` to simply return the raw address pointer given to `new_direct_byte_buffer()` instead of returning a mutable slice that may lead to undefined behaviour.

If an application knows it has exclusive access to the buffer then it can use `unsafe` code to create it's own mutable slice from the raw pointer and size if needed.

Closes: #321

## Overview

<!-- Please describe your changes here and list any open questions you might have. -->

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Change is covered by [automated tests](https://github.com/jni-rs/jni-rs/blob/master/CONTRIBUTING.md#tests)
- [x] The [coding guidelines](https://github.com/jni-rs/jni-rs/blob/master/CONTRIBUTING.md#the-code-style) are followed
- [x] Public API has documentation
- [x] User-visible changes are mentioned in the Changelog
- [x] The continuous integration build passes
