### PR TITLE
No field id lifetimes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,8 +29,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - The lifetime of `AutoArray` is no longer tied to the lifetime of a particular `JNIEnv` reference. (#302)
 - Relaxed lifetime restrictions on `JNIEnv::new_local_ref`. Now it can be used to create a local
   reference from a global reference. (#301 / #319)
-- `JMethodID` implements `Send` + `Sync` and no longer has a lifetime parameter, making method
+- `JMethodID` and `JStaticMethodID` implement `Send` + `Sync` and no longer has a lifetime parameter, making method
   IDs cacheable (with a documented 'Safety' note about ensuring they remain valid). ([#346](https://github.com/jni-rs/jni-rs/pull/346))
+- `JFieldID` and `JStaticFieldID` implement `Send` + `Sync` and no longer has a lifetime parameter, making field
+  IDs cacheable (with a documented 'Safety' note about ensuring they remain valid). ([#346](https://github.com/jni-rs/jni-rs/pull/365))
 - The `call_*_method_unchecked` functions now take `jni:sys::jvalue` arguments to avoid allocating
   a `Vec` on each call to map + collect `JValue`s as `sys:jvalue`s (#329)
 - The `From` trait implementations converting `jni_sys` types like `jobject` to `JObject` have been replaced

--- a/src/wrapper/descriptors/field_desc.rs
+++ b/src/wrapper/descriptors/field_desc.rs
@@ -6,24 +6,24 @@ use crate::{
     JNIEnv,
 };
 
-impl<'a, 'c, T, U, V> Desc<'a, JFieldID<'a>> for (T, U, V)
+impl<'a, 'c, T, U, V> Desc<'a, JFieldID> for (T, U, V)
 where
     T: Desc<'a, JClass<'c>>,
     U: Into<JNIString>,
     V: Into<JNIString>,
 {
-    fn lookup(self, env: &JNIEnv<'a>) -> Result<JFieldID<'a>> {
+    fn lookup(self, env: &JNIEnv<'a>) -> Result<JFieldID> {
         env.get_field_id(self.0, self.1, self.2)
     }
 }
 
-impl<'a, 'c, T, U, V> Desc<'a, JStaticFieldID<'a>> for (T, U, V)
+impl<'a, 'c, T, U, V> Desc<'a, JStaticFieldID> for (T, U, V)
 where
     T: Desc<'a, JClass<'c>>,
     U: Into<JNIString>,
     V: Into<JNIString>,
 {
-    fn lookup(self, env: &JNIEnv<'a>) -> Result<JStaticFieldID<'a>> {
+    fn lookup(self, env: &JNIEnv<'a>) -> Result<JStaticFieldID> {
         env.get_static_field_id(self.0, self.1, self.2)
     }
 }

--- a/src/wrapper/jnienv.rs
+++ b/src/wrapper/jnienv.rs
@@ -682,7 +682,7 @@ impl<'a> JNIEnv<'a> {
     /// ```rust,ignore
     /// let field_id = env.get_field_id("com/my/Class", "intField", "I");
     /// ```
-    pub fn get_field_id<'c, T, U, V>(&self, class: T, name: U, sig: V) -> Result<JFieldID<'a>>
+    pub fn get_field_id<'c, T, U, V>(&self, class: T, name: U, sig: V) -> Result<JFieldID>
     where
         T: Desc<'a, JClass<'c>>,
         U: Into<JNIString>,
@@ -727,7 +727,7 @@ impl<'a> JNIEnv<'a> {
         class: T,
         name: U,
         sig: V,
-    ) -> Result<JStaticFieldID<'a>>
+    ) -> Result<JStaticFieldID>
     where
         T: Desc<'a, JClass<'c>>,
         U: Into<JNIString>,
@@ -1701,15 +1701,10 @@ impl<'a> JNIEnv<'a> {
     }
 
     /// Get a field without checking the provided type against the actual field.
-    pub fn get_field_unchecked<'f, O, T>(
-        &self,
-        obj: O,
-        field: T,
-        ty: ReturnType,
-    ) -> Result<JValue<'a>>
+    pub fn get_field_unchecked<O, T>(&self, obj: O, field: T, ty: ReturnType) -> Result<JValue<'a>>
     where
         O: Into<JObject<'a>>,
-        T: Desc<'a, JFieldID<'f>>,
+        T: Desc<'a, JFieldID>,
     {
         let obj = obj.into();
         non_null!(obj, "get_field_typed obj argument");
@@ -1745,10 +1740,10 @@ impl<'a> JNIEnv<'a> {
     }
 
     /// Set a field without any type checking.
-    pub fn set_field_unchecked<'f, O, T>(&self, obj: O, field: T, val: JValue) -> Result<()>
+    pub fn set_field_unchecked<O, T>(&self, obj: O, field: T, val: JValue) -> Result<()>
     where
         O: Into<JObject<'a>>,
-        T: Desc<'a, JFieldID<'f>>,
+        T: Desc<'a, JFieldID>,
     {
         let obj = obj.into();
         non_null!(obj, "set_field_typed obj argument");
@@ -1851,7 +1846,7 @@ impl<'a> JNIEnv<'a> {
 
     /// Get a static field without checking the provided type against the actual
     /// field.
-    pub fn get_static_field_unchecked<'c, 'f, T, U>(
+    pub fn get_static_field_unchecked<'c, T, U>(
         &self,
         class: T,
         field: U,
@@ -1859,7 +1854,7 @@ impl<'a> JNIEnv<'a> {
     ) -> Result<JValue<'a>>
     where
         T: Desc<'a, JClass<'c>>,
-        U: Desc<'a, JStaticFieldID<'f>>,
+        U: Desc<'a, JStaticFieldID>,
     {
         use JavaType::Primitive as JP;
 
@@ -1920,10 +1915,10 @@ impl<'a> JNIEnv<'a> {
     }
 
     /// Set a static field. Requires a class lookup and a field id lookup internally.
-    pub fn set_static_field<'c, 'f, T, U>(&self, class: T, field: U, value: JValue) -> Result<()>
+    pub fn set_static_field<'c, T, U>(&self, class: T, field: U, value: JValue) -> Result<()>
     where
         T: Desc<'a, JClass<'c>>,
-        U: Desc<'a, JStaticFieldID<'f>>,
+        U: Desc<'a, JStaticFieldID>,
     {
         let class = class.lookup(self)?.into_raw();
         let field = field.lookup(self)?.into_raw();

--- a/src/wrapper/objects/jfieldid.rs
+++ b/src/wrapper/objects/jfieldid.rs
@@ -1,31 +1,44 @@
-use std::marker::PhantomData;
-
 use crate::sys::jfieldID;
 
-/// Wrapper around `sys::jfieldid` that adds a lifetime. This prevents it from
-/// outliving the context in which it was acquired and getting GC'd out from
-/// under us. It matches C's representation of the raw pointer, so it can be
-/// used in any of the extern function argument positions that would take a
-/// `jfieldid`.
+/// Wrapper around [`jfieldID`] that implements `Send` + `Sync` since method IDs
+/// are valid across threads (not tied to a `JNIEnv`).
+///
+/// There is no lifetime associated with these since they aren't garbage
+/// collected like objects and their lifetime is not implicitly connected with
+/// the scope in which they are queried.
+///
+/// It matches C's representation of the raw pointer, so it can be used in any
+/// of the extern function argument positions that would take a [`jfieldID`].
+///
+/// # Safety
+///
+/// According to the JNI spec field IDs may be invalidated when the
+/// corresponding class is unloaded.
+///
+/// Since this constraint can't be encoded as a Rust lifetime, and to avoid the
+/// excessive cost of having every Method ID be associated with a global
+/// reference to the corresponding class then it is the developers
+/// responsibility to ensure they hold some class reference for the lifetime of
+/// cached method IDs.
 #[repr(transparent)]
 #[derive(Copy, Clone)]
-pub struct JFieldID<'a> {
+pub struct JFieldID {
     internal: jfieldID,
-    lifetime: PhantomData<&'a ()>,
 }
 
-impl<'a> JFieldID<'a> {
+// Field IDs are valid across threads (not tied to a JNIEnv)
+unsafe impl Send for JFieldID {}
+unsafe impl Sync for JFieldID {}
+
+impl JFieldID {
     /// Creates a [`JFieldID`] that wraps the given `raw` [`jfieldID`]
     ///
     /// # Safety
     ///
     /// Expects a valid, non-`null` ID
     pub unsafe fn from_raw(raw: jfieldID) -> Self {
-        debug_assert!(!raw.is_null(), "from_raw methodID argument");
-        Self {
-            internal: raw,
-            lifetime: PhantomData,
-        }
+        debug_assert!(!raw.is_null(), "from_raw fieldID argument");
+        Self { internal: raw }
     }
 
     /// Unwrap to the internal jni type.

--- a/src/wrapper/objects/jmethodid.rs
+++ b/src/wrapper/objects/jmethodid.rs
@@ -1,19 +1,23 @@
 use crate::sys::jmethodID;
 
-/// Wrapper around `sys::jmethodid` that implements `Send` + `Sync` since method IDs
-/// are valid across threads (not tied to a `JNIEnv`). There is no lifetime associated
-/// with these since they aren't garbage collected like objects and their lifetime
-/// is not implicitly connected with the scope in which they are queried.
+/// Wrapper around [`jmethodID`] that implements `Send` + `Sync` since method IDs
+/// are valid across threads (not tied to a `JNIEnv`).
+///
+/// There is no lifetime associated with these since they aren't garbage
+/// collected like objects and their lifetime is not implicitly connected with
+/// the scope in which they are queried.
 ///
 /// It matches C's representation of the raw pointer, so it can be used in any
-/// of the extern function argument positions that would take a `jmethodid`.
+/// of the extern function argument positions that would take a [`jmethodID`].
 ///
 /// # Safety
 ///
-/// According to the JNI spec method IDs may be released when the corresponding class is
-/// unloaded. Since this constraint can't be encoded as a Rust lifetime,
-/// and to avoid the excessive cost of having every Method ID be associated with
-/// a global reference to the corresponding class then it is the developers
+/// According to the JNI spec method IDs may be invalidated when the
+/// corresponding class is unloaded.
+///
+/// Since this constraint can't be encoded as a Rust lifetime, and to avoid the
+/// excessive cost of having every Method ID be associated with a global
+/// reference to the corresponding class then it is the developers
 /// responsibility to ensure they hold some class reference for the lifetime of
 /// cached method IDs.
 #[repr(transparent)]

--- a/src/wrapper/objects/jstaticfieldid.rs
+++ b/src/wrapper/objects/jstaticfieldid.rs
@@ -1,31 +1,44 @@
-use std::marker::PhantomData;
-
 use crate::sys::jfieldID;
 
-/// Wrapper around `sys::jstaticfieldid` that adds a lifetime. This prevents it
-/// from outliving the context in which it was acquired and getting GC'd out
-/// from under us. It matches C's representation of the raw pointer, so it can
-/// be used in any of the extern function argument positions that would take a
-/// `jstaticfieldid`.
+/// Wrapper around [`jfieldID`] that implements `Send` + `Sync` since field IDs
+/// are valid across threads (not tied to a `JNIEnv`).
+///
+/// There is no lifetime associated with these since they aren't garbage
+/// collected like objects and their lifetime is not implicitly connected with
+/// the scope in which they are queried.
+///
+/// It matches C's representation of the raw pointer, so it can be used in any
+/// of the extern function argument positions that would take a [`jfieldID`].
+///
+/// # Safety
+///
+/// According to the JNI spec field IDs may be invalidated when the
+/// corresponding class is unloaded.
+///
+/// Since this constraint can't be encoded as a Rust lifetime, and to avoid the
+/// excessive cost of having every Method ID be associated with a global
+/// reference to the corresponding class then it is the developers
+/// responsibility to ensure they hold some class reference for the lifetime of
+/// cached method IDs.
 #[repr(transparent)]
-#[derive(Copy, Clone)]
-pub struct JStaticFieldID<'a> {
+#[derive(Copy, Clone, Debug)]
+pub struct JStaticFieldID {
     internal: jfieldID,
-    lifetime: PhantomData<&'a ()>,
 }
 
-impl<'a> JStaticFieldID<'a> {
+// Static Field IDs are valid across threads (not tied to a JNIEnv)
+unsafe impl Send for JStaticFieldID {}
+unsafe impl Sync for JStaticFieldID {}
+
+impl JStaticFieldID {
     /// Creates a [`JStaticFieldID`] that wraps the given `raw` [`jfieldID`]
     ///
     /// # Safety
     ///
     /// Expects a valid, non-`null` ID
     pub unsafe fn from_raw(raw: jfieldID) -> Self {
-        debug_assert!(!raw.is_null(), "from_raw methodID argument");
-        Self {
-            internal: raw,
-            lifetime: PhantomData,
-        }
+        debug_assert!(!raw.is_null(), "from_raw fieldID argument");
+        Self { internal: raw }
     }
 
     /// Unwrap to the internal jni type.

--- a/src/wrapper/objects/jstaticmethodid.rs
+++ b/src/wrapper/objects/jstaticmethodid.rs
@@ -1,19 +1,23 @@
 use crate::sys::jmethodID;
 
-/// Wrapper around `sys::jmethodid` that implements `Send` + `Sync` since method IDs
-/// are valid across threads (not tied to a `JNIEnv`). There is no lifetime associated
-/// with these since they aren't garbage collected like objects and their lifetime
-/// is not implicitly connected with the scope in which they are queried.
+/// Wrapper around [`jmethodID`] that implements `Send` + `Sync` since method IDs
+/// are valid across threads (not tied to a `JNIEnv`).
+///
+/// There is no lifetime associated with these since they aren't garbage
+/// collected like objects and their lifetime is not implicitly connected with
+/// the scope in which they are queried.
 ///
 /// It matches C's representation of the raw pointer, so it can be used in any
-/// of the extern function argument positions that would take a `jmethodid`.
+/// of the extern function argument positions that would take a [`jmethodID`].
 ///
 /// # Safety
 ///
-/// According to the JNI spec method IDs may be released when the corresponding class is
-/// unloaded. Since this constraint can't be encoded as a Rust lifetime,
-/// and to avoid the excessive cost of having every Method ID be associated with
-/// a global reference to the corresponding class then it is the developers
+/// According to the JNI spec method IDs may be invalidated when the
+/// corresponding class is unloaded.
+///
+/// Since this constraint can't be encoded as a Rust lifetime, and to avoid the
+/// excessive cost of having every Method ID be associated with a global
+/// reference to the corresponding class then it is the developers
 /// responsibility to ensure they hold some class reference for the lifetime of
 /// cached method IDs.
 #[repr(transparent)]


### PR DESCRIPTION
## Overview

This essentially applies the same reasoning as for #346 (which remove the lifetime parameter for `JMethodID`s) for field IDs which are treated in much the same way by the JVM.

Field IDs by their nature are intended to be cached by applications
which was generally precluded by the lifetime parameter. According
to the JNI spec, field IDs are also not garbage collected as previously
documented and they remain valid until their corresponding class is
unloaded.

Since the real lifetime details can't be represented via a Rust lifetime
(and it would be an excessive cost at this level of abstraction to pair
every field ID with a global reference to the class) then this patch
removes the Rust lifetime and adds "Safety" documentation to explain
what developers need to do if caching field IDs.

It's perhaps also worth noting that the very conservative lifetime
parameter that existed before wouldn't have provided any technical
safety against a method's class being unloaded within that lifetime.

As field IDs are not tied to a thread / JNIEnv it also makes sense to
declare them as Send + Sync safe.

Fixes: #363



### Definition of Done

- [x] There are no TODOs left in the code
- [x] Change is covered by [automated tests](https://github.com/jni-rs/jni-rs/blob/master/CONTRIBUTING.md#tests)
- [x] The [coding guidelines](https://github.com/jni-rs/jni-rs/blob/master/CONTRIBUTING.md#the-code-style) are followed
- [x] Public API has documentation
- [x] User-visible changes are mentioned in the Changelog
- [x] The continuous integration build passes
