### PR TITLE
Mark all rust_field APIs as `unsafe`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - The `From` trait implementations converting `jni_sys` types like `jobject` to `JObject` have been replaced
   with `unsafe` `::from_raw` functions and corresponding `::into_raw` methods. Existing `::into_inner` APIs were
   renamed `::into_raw` for symmetry. ([#197](https://github.com/jni-rs/jni-rs/issues/197))
+- The APIs `JNIEnv::set_rust_field`, `JNIEnv::get_rust_field` and `JNIEnv::take_rust_field` have been marked as `unsafe` ([#219](https://github.com/jni-rs/jni-rs/issues/219))
 
 
 ## [0.19.0] — 2021-01-24


### PR DESCRIPTION
## Overview

The APIs `JNIEnv::set_rust_field`, `JNIEnv::get_rust_field` and `JNIEnv::take_rust_field` are all _very_ unsafe and rely on the caller being sure that the field will contain a valid pointer for `T` and that the field isn't somehow copied by Java and then taken multiple times by Rust.

In addition to marking each function as `unsafe` the documentation has
been updated to add a `# Safety` section for each function.

The documentation has also been updated to take into account issue https://github.com/jni-rs/jni-rs/issues/336
by suggesting the use of `Closeable` instead of any use of a `finalizer`
for cleaning up Rust resources.

The documentation also tries to clarify that the Java object is locked
whenever a rust field is set or accessed.

Instead of implying that leaking memory is unsafe (as the previous docs
did) they now just highlight the fact that `set_rust_field` may lead
to a leak if `take_rust_field` is not called in the future.

Fixes: https://github.com/jni-rs/jni-rs/issues/219
Fixes: https://github.com/jni-rs/jni-rs/issues/336

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Change is covered by [automated tests](https://github.com/jni-rs/jni-rs/blob/master/CONTRIBUTING.md#tests)
- [x] The [coding guidelines](https://github.com/jni-rs/jni-rs/blob/master/CONTRIBUTING.md#the-code-style) are followed
- [x] Public API has documentation
- [x] User-visible changes are mentioned in the Changelog
- [x] The continuous integration build passes
