### PR TITLE
Checked version of JNIEnv::get_string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+- `JNIEnv::get_string` checks that the given object is a `java.lang.String` instance to avoid undefined behaviour from the JNI implementation potentially aborting the program. ([#328](https://github.com/jni-rs/jni-rs/issues/328))
+
+### Added
+- `JNIEnv::get_string_unchecked` is a cheaper, `unsafe` alternative to `get_string` that doesn't check the given object is a `java.lang.String` instance. ([#328](https://github.com/jni-rs/jni-rs/issues/328))
+
 
 ## [0.20.0] — 2022-10-17
 

--- a/benches/api_calls.rs
+++ b/benches/api_calls.rs
@@ -26,6 +26,9 @@ static SIG_MATH_ABS: &str = "(I)I";
 static SIG_OBJECT_HASH_CODE: &str = "()I";
 static SIG_LOCAL_DATE_TIME_OF: &str = "(IIIIIII)Ljava/time/LocalDateTime;";
 
+// 32 characters
+static TEST_STRING_UNICODE: &str = "_񍷕㳧~δ򗊁᪘׷ġ˥쩽|ņ/򖕡ٶԦ萴퀉֒ٞHy󢕒%ӓ娎񢞊ăꊦȮ񳗌";
+
 #[inline(never)]
 fn native_abs(x: i32) -> i32 {
     x.abs()
@@ -312,22 +315,22 @@ mod tests {
     #[bench]
     fn jni_get_string(b: &mut Bencher) {
         let env = VM.attach_current_thread().unwrap();
-        let string = env.new_string("test").unwrap();
+        let string = env.new_string(TEST_STRING_UNICODE).unwrap();
 
         b.iter(|| {
             let s: String = env.get_string(string).unwrap().into();
-            assert_eq!(s, "test");
+            assert_eq!(s, TEST_STRING_UNICODE);
         });
     }
 
     #[bench]
     fn jni_get_string_unchecked(b: &mut Bencher) {
         let env = VM.attach_current_thread().unwrap();
-        let string = env.new_string("test").unwrap();
+        let string = env.new_string(TEST_STRING_UNICODE).unwrap();
 
         b.iter(|| {
             let s: String = unsafe { env.get_string_unchecked(string) }.unwrap().into();
-            assert_eq!(s, "test");
+            assert_eq!(s, TEST_STRING_UNICODE);
         });
     }
 

--- a/benches/api_calls.rs
+++ b/benches/api_calls.rs
@@ -309,6 +309,28 @@ mod tests {
         });
     }
 
+    #[bench]
+    fn jni_get_string(b: &mut Bencher) {
+        let env = VM.attach_current_thread().unwrap();
+        let string = env.new_string("test").unwrap();
+
+        b.iter(|| {
+            let s: String = env.get_string(string).unwrap().into();
+            assert_eq!(s, "test");
+        });
+    }
+
+    #[bench]
+    fn jni_get_string_unchecked(b: &mut Bencher) {
+        let env = VM.attach_current_thread().unwrap();
+        let string = env.new_string("test").unwrap();
+
+        b.iter(|| {
+            let s: String = unsafe { env.get_string_unchecked(string) }.unwrap().into();
+            assert_eq!(s, "test");
+        });
+    }
+
     /// A benchmark measuring Push/PopLocalFrame overhead.
     ///
     /// Such operations are *required* if one attaches a long-running

--- a/tests/jni_api.rs
+++ b/tests/jni_api.rs
@@ -894,6 +894,21 @@ pub fn test_conversion() {
     assert!(unwrap(&env, env.is_same_object(orig_obj, actual)));
 }
 
+#[test]
+pub fn test_null_get_string() {
+    let env = attach_current_thread();
+    let ret = env.get_string(unsafe { JString::from_raw(std::ptr::null_mut() as _) });
+    assert!(ret.is_err());
+}
+
+#[test]
+pub fn test_invalid_list_get_string() {
+    let env = attach_current_thread();
+    let class = env.auto_local(env.find_class("java/util/List").unwrap());
+    let ret = env.get_string(class.as_obj().into());
+    assert!(ret.is_err());
+}
+
 fn test_throwable_descriptor_with_default_type<'a, D>(env: &JNIEnv<'a>, descriptor: D)
 where
     D: Desc<'a, JThrowable<'a>>,


### PR DESCRIPTION
## Overview
This PR:
- Renames `JNIEnv::get_string` to `JNIEnv::get_string_unchecked`, and marks it unsafe
- Adds a new `JNIEnv::get_string` which checks whether the object passed in is actually a java.lang.String
- Adds a new error variant describing that the type of the parameter passed in is incorrect.

See also: #328 

This PR is backwards compatible, though the code will become slightly slower due to the addition of the class check

Open questions:
- Can we optimize the `find_class` call for `java/lang/String` to be put in a once cell? Or must the lifetime of the `JClass` be tied to the `JNIEnv`'s lifetime?

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Change is covered by [automated tests](https://github.com/jni-rs/jni-rs/blob/master/CONTRIBUTING.md#tests)
- [X] The [coding guidelines](https://github.com/jni-rs/jni-rs/blob/master/CONTRIBUTING.md#the-code-style) are followed
- [X] Public API has documentation
- [x] User-visible changes are mentioned in the Changelog
- [ ] The continuous integration build passes
