### PR TITLE
Remove `get_string_utf_chars` and `release_string_utf_chars` from `JNIEnv`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - The `JNIEnv::new_object_unchecked` function now takes arguments as `&[jni::sys::jvalue]` to avoid allocating, putting it inline with changes to `JniEnv::call_*_unchecked` from 0.20.0 ([#382](https://github.com/jni-rs/jni-rs/pull/382))
 - The `get_superclass` function now returns an Option instead of a null pointer if the class has no superclass ([#151](https://github.com/jni-rs/jni-rs/issues/151))
 
+### Removed
+- `get_string_utf_chars` and `release_string_utf_chars` from `JNIEnv` (See `JavaStr::into_raw()` and `JavaStr::from_raw()` instead) ([#372](https://github.com/jni-rs/jni-rs/pull/372))
+
 ## [0.20.0] — 2022-10-17
 
 ### Added

--- a/src/wrapper/jnienv.rs
+++ b/src/wrapper/jnienv.rs
@@ -1262,46 +1262,6 @@ impl<'a> JNIEnv<'a> {
         unsafe { self.get_string_unchecked(obj) }
     }
 
-    /// Get a pointer to the character array beneath a JString.
-    ///
-    /// Array contains Java's modified UTF-8.
-    ///
-    /// # Attention
-    /// This will leak memory if `release_string_utf_chars` is never called.
-    pub fn get_string_utf_chars(&self, obj: JString) -> Result<*const c_char> {
-        non_null!(obj, "get_string_utf_chars obj argument");
-        let ptr: *const c_char = jni_non_null_call!(
-            self.internal,
-            GetStringUTFChars,
-            obj.into_raw(),
-            ::std::ptr::null::<jboolean>() as *mut jboolean
-        );
-        Ok(ptr)
-    }
-
-    /// Unpin the array returned by `get_string_utf_chars`.
-    ///
-    /// # Safety
-    ///
-    /// The behaviour is undefined if the array isn't returned by the `get_string_utf_chars`
-    /// function.
-    ///
-    /// # Examples
-    ///
-    /// ```no_run
-    /// # let env = unsafe { jni::JNIEnv::from_raw(std::ptr::null_mut()).unwrap() };
-    /// let s = env.new_string("test").unwrap();
-    /// let array = env.get_string_utf_chars(s).unwrap();
-    /// unsafe { env.release_string_utf_chars(s, array).unwrap() };
-    /// ```
-    #[allow(unused_unsafe)]
-    pub unsafe fn release_string_utf_chars(&self, obj: JString, arr: *const c_char) -> Result<()> {
-        non_null!(obj, "release_string_utf_chars obj argument");
-        // This method is safe to call in case of pending exceptions (see the chapter 2 of the spec)
-        jni_unchecked!(self.internal, ReleaseStringUTFChars, obj.into_raw(), arr);
-        Ok(())
-    }
-
     /// Create a new java string object from a rust string. This requires a
     /// re-encoding of rusts *real* UTF-8 strings to java's modified UTF-8
     /// format.


### PR DESCRIPTION
## Overview

This PR updates the documentation for `JNIEnv::get_string_utf_chars`, providing more details on safety and adding error documentation. This PR also marks the function as `unsafe`

### Open questions
- Do we want to rename this function to `get_string_utf_chars_unchecked` and add a checked variant, like done with `get_string` in #370?
- Do we want to add a newtype wrapper around the pointer with a `Drop` impl to avoid the potential memory leak? 

See also: #371 
### Definition of Done

- [x] There are no TODOs left in the code
- [x] Change is covered by [automated tests](https://github.com/jni-rs/jni-rs/blob/master/CONTRIBUTING.md#tests)
- [X] The [coding guidelines](https://github.com/jni-rs/jni-rs/blob/master/CONTRIBUTING.md#the-code-style) are followed
- [X] Public API has documentation
- [x] User-visible changes are mentioned in the Changelog
- [x] The continuous integration build passes
