### PR TITLE
JNIEnv::get_superclass return none instead of a nullpointer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - `JNIEnv::get_string` checks that the given object is a `java.lang.String` instance to avoid undefined behaviour from the JNI implementation potentially aborting the program. ([#328](https://github.com/jni-rs/jni-rs/issues/328))
 - `JNIEnv::call_*method_unchecked` was marked `unsafe`, as passing improper argument types, or a bad number of arguments, can cause a JVM crash. ([#385](https://github.com/jni-rs/jni-rs/issues/385))
 - The `JNIEnv::new_object_unchecked` function now takes arguments as `&[jni::sys::jvalue]` to avoid allocating, putting it inline with changes to `JniEnv::call_*_unchecked` from 0.20.0 ([#382](https://github.com/jni-rs/jni-rs/pull/382))
+- The `get_superclass` function now returns an Option instead of a null pointer if the class has no superclass ([#151](https://github.com/jni-rs/jni-rs/issues/151))
 
 ## [0.20.0] — 2022-10-17
 

--- a/tests/jni_api.rs
+++ b/tests/jni_api.rs
@@ -889,7 +889,7 @@ fn get_super_class_ok() {
     let env = attach_current_thread();
     let result = env.get_superclass(ARRAYLIST_CLASS);
     assert!(result.is_ok());
-    assert!(!result.unwrap().is_null());
+    assert!(result.unwrap().is_some());
 }
 
 #[test]
@@ -897,7 +897,7 @@ fn get_super_class_null() {
     let env = attach_current_thread();
     let result = env.get_superclass("java/lang/Object");
     assert!(result.is_ok());
-    assert!(result.unwrap().is_null());
+    assert!(result.unwrap().is_none());
 }
 
 #[test]


### PR DESCRIPTION
## Overview
This PR changes the return type of `JNIEnv::get_superclass` to `Result<Option<JClass<'a>>>` from `Result<JClass<'a>>`.
`None` is returned when the class `class` has no superclass (i.e. is `java.lang.Object` an interface).

Documentation of the function was updated accordingly, and now also mentions `Errors`

Fixes #151

### Open questions
- Might it be better to check if `class` is `java.lang.Object` or an interface, rather than calling the method and checking if the pointer is null? (Probably need to benchmark that)

### Definition of Done

- [X] There are no TODOs left in the code
- [X] Change is covered by [automated tests](https://github.com/jni-rs/jni-rs/blob/master/CONTRIBUTING.md#tests)
- [X] The [coding guidelines](https://github.com/jni-rs/jni-rs/blob/master/CONTRIBUTING.md#the-code-style) are followed
- [X] Public API has documentation
- [X] User-visible changes are mentioned in the Changelog
- [ ] The continuous integration build passes
