### PR TITLE
Fix example build error by using the new into_raw instead of into_inner

### DIFF
--- a/example/mylib/src/lib.rs
+++ b/example/mylib/src/lib.rs
@@ -38,7 +38,7 @@ pub extern "system" fn Java_HelloWorld_hello(
         .new_string(format!("Hello, {}!", input))
         .expect("Couldn't create java string!");
     // Finally, extract the raw pointer to return.
-    output.into_inner()
+    output.into_raw()
 }
 
 #[no_mangle]


### PR DESCRIPTION
## Overview

Fix the example code into_inner method missing build error by using the newer into_raw method.

Fixes: #377 

### Definition of Done

- [x] There are no TODOs left in the code
- [ ] Change is covered by [automated tests](https://github.com/jni-rs/jni-rs/blob/master/CONTRIBUTING.md#tests)
- [x] The [coding guidelines](https://github.com/jni-rs/jni-rs/blob/master/CONTRIBUTING.md#the-code-style) are followed
- [x] Public API has documentation
- [x] User-visible changes are mentioned in the Changelog
- [x] The continuous integration build passes
