### PR TITLE
allow no-alloc use of new_object_unchecked

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Changed
 - `JNIEnv::get_string` checks that the given object is a `java.lang.String` instance to avoid undefined behaviour from the JNI implementation potentially aborting the program. ([#328](https://github.com/jni-rs/jni-rs/issues/328))
 - `JNIEnv::call_*method_unchecked` was marked `unsafe`, as passing improper argument types, or a bad number of arguments, can cause a JVM crash. ([#385](https://github.com/jni-rs/jni-rs/issues/385))
+- The `JNIEnv::new_object_unchecked` function now takes arguments as `&[jni::sys::jvalue]` to avoid allocating, putting it inline with changes to `JniEnv::call_*_unchecked` from 0.20.0 ([#382](https://github.com/jni-rs/jni-rs/pull/382))
 
 ## [0.20.0] — 2022-10-17
 

--- a/src/wrapper/jnienv.rs
+++ b/src/wrapper/jnienv.rs
@@ -1126,7 +1126,8 @@ impl<'a> JNIEnv<'a> {
 
         let method_id: JMethodID = (class, ctor_sig).lookup(self)?;
 
-        self.new_object_unchecked(class, method_id, ctor_args)
+        let ctor_args: Vec<jvalue> = ctor_args.iter().map(|v| v.to_jni()).collect();
+        self.new_object_unchecked(class, method_id, &ctor_args)
     }
 
     /// Create a new object using a constructor. Arguments aren't checked
@@ -1136,15 +1137,14 @@ impl<'a> JNIEnv<'a> {
         &self,
         class: T,
         ctor_id: JMethodID,
-        ctor_args: &[JValue],
+        ctor_args: &[jvalue],
     ) -> Result<JObject<'a>>
     where
         T: Desc<'a, JClass<'c>>,
     {
         let class = class.lookup(self)?;
 
-        let jni_args: Vec<jvalue> = ctor_args.iter().map(|v| v.to_jni()).collect();
-        let jni_args = jni_args.as_ptr();
+        let jni_args = ctor_args.as_ptr();
 
         let obj = jni_non_null_call!(
             self.internal,

--- a/src/wrapper/jnienv.rs
+++ b/src/wrapper/jnienv.rs
@@ -1113,10 +1113,29 @@ impl<'a> JNIEnv<'a> {
         // parse the signature
         let parsed = TypeSignature::from_str(&ctor_sig)?;
 
+        // check arguments length
         if parsed.args.len() != ctor_args.len() {
             return Err(Error::InvalidArgList(parsed));
         }
 
+        // check arguments types
+        let base_types_match =
+            parsed
+                .args
+                .iter()
+                .zip(ctor_args.iter())
+                .all(|(exp, act)| match exp {
+                    JavaType::Primitive(p) => act.primitive_type() == Some(*p),
+                    JavaType::Object(_) | JavaType::Array(_) => act.primitive_type().is_none(),
+                    JavaType::Method(_) => {
+                        unreachable!("JavaType::Method(_) should not come from parsing a ctor sig")
+                    }
+                });
+        if !base_types_match {
+            return Err(Error::InvalidArgList(parsed));
+        }
+
+        // check return value
         if parsed.ret != ReturnType::Primitive(Primitive::Void) {
             return Err(Error::InvalidCtorReturn);
         }
@@ -1127,13 +1146,21 @@ impl<'a> JNIEnv<'a> {
         let method_id: JMethodID = (class, ctor_sig).lookup(self)?;
 
         let ctor_args: Vec<jvalue> = ctor_args.iter().map(|v| v.to_jni()).collect();
-        self.new_object_unchecked(class, method_id, &ctor_args)
+        // SAFETY: We've obtained the method_id above, so it is valid for this class.
+        // We've also validated the argument counts and types using the same type signature
+        // we fetched the original method ID from.
+        unsafe { self.new_object_unchecked(class, method_id, &ctor_args) }
     }
 
     /// Create a new object using a constructor. Arguments aren't checked
-    /// because
-    /// of the `JMethodID` usage.
-    pub fn new_object_unchecked<'c, T>(
+    /// because of the `JMethodID` usage.
+    ///
+    /// # Safety
+    ///
+    /// The provided JMethodID must be valid, and match the types and number of arguments, as well as return type
+    /// (always an Object for a constructor). If these are incorrect, the JVM may crash.  The JMethodID must also match
+    /// the passed type.
+    pub unsafe fn new_object_unchecked<'c, T>(
         &self,
         class: T,
         ctor_id: JMethodID,

--- a/tests/jni_api.rs
+++ b/tests/jni_api.rs
@@ -1,6 +1,6 @@
 #![cfg(feature = "invocation")]
 
-use std::str::FromStr;
+use std::{convert::TryFrom, str::FromStr};
 
 use jni::{
     descriptors::Desc,
@@ -329,6 +329,30 @@ pub fn call_static_method_unchecked_ok() {
     .unwrap();
 
     assert_eq!(val, 10);
+}
+
+#[test]
+pub fn call_new_object_unchecked_ok() {
+    let env = attach_current_thread();
+
+    let test_str = env.new_string(TESTING_OBJECT_STR).unwrap();
+    let string_class = env.find_class(STRING_CLASS).unwrap();
+
+    let ctor_method_id = env
+        .get_method_id(string_class, "<init>", "(Ljava/lang/String;)V")
+        .unwrap();
+    let val: JObject = env
+        .new_object_unchecked(
+            string_class,
+            ctor_method_id,
+            &[JValue::from(test_str).into()],
+        )
+        .expect("JNIEnv#new_object_unchecked should return JValue");
+
+    let jstr = JString::try_from(val).expect("asd");
+    let javastr = env.get_string(jstr).unwrap();
+    let rstr = javastr.to_str().unwrap();
+    assert_eq!(rstr, TESTING_OBJECT_STR);
 }
 
 #[test]


### PR DESCRIPTION
## Overview

To align with the previous changes to allow `call_*_unchecked` methods without allocating, convert `new_object_unchecked` to do the same.

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Change is covered by [automated tests](https://github.com/jni-rs/jni-rs/blob/master/CONTRIBUTING.md#tests)
- [x] The [coding guidelines](https://github.com/jni-rs/jni-rs/blob/master/CONTRIBUTING.md#the-code-style) are followed
- [x] Public API has documentation
- [x] User-visible changes are mentioned in the Changelog
- [x] The continuous integration build passes
