### PR TITLE
mark unchecked method calls as unsafe, fixes #385

### DIFF
--- a/benches/api_calls.rs
+++ b/benches/api_calls.rs
@@ -89,9 +89,8 @@ where
 {
     let x = JValue::from(x);
     let ret = ReturnType::Primitive(Primitive::Int);
-    let v = env
-        .call_static_method_unchecked(class, method_id, ret, &[x.into()])
-        .unwrap();
+    let v =
+        unsafe { env.call_static_method_unchecked(class, method_id, ret, &[x.into()]) }.unwrap();
     v.i().unwrap()
 }
 
@@ -100,7 +99,8 @@ where
     M: Desc<'m, JMethodID>,
 {
     let ret = ReturnType::Primitive(Primitive::Int);
-    let v = env.call_method_unchecked(obj, method_id, ret, &[]).unwrap();
+    // SAFETY: Caller retrieved method ID + class specifically for this use: Object.hashCode()I
+    let v = unsafe { env.call_method_unchecked(obj, method_id, ret, &[]) }.unwrap();
     v.i().unwrap()
 }
 
@@ -113,8 +113,8 @@ fn jni_object_call_static_unchecked<'c, C>(
 where
     C: Desc<'c, JClass<'c>>,
 {
-    let v = env
-        .call_static_method_unchecked(class, method_id, ReturnType::Object, args)
+    // SAFETY: Caller retrieved method ID and constructed arguments
+    let v = unsafe { env.call_static_method_unchecked(class, method_id, ReturnType::Object, args) }
         .unwrap();
     v.l().unwrap()
 }

--- a/src/wrapper/errors.rs
+++ b/src/wrapper/errors.rs
@@ -13,7 +13,7 @@ pub enum Error {
     WrongJValueType(&'static str, &'static str),
     #[error("Invalid constructor return type (must be void)")]
     InvalidCtorReturn,
-    #[error("Invalid number of arguments passed to java method: {0}")]
+    #[error("Invalid number or type of arguments passed to java method: {0}")]
     InvalidArgList(TypeSignature),
     #[error("Method not found: {name} {sig}")]
     MethodNotFound { name: String, sig: String },

--- a/src/wrapper/objects/jlist.rs
+++ b/src/wrapper/objects/jlist.rs
@@ -62,12 +62,16 @@ impl<'a: 'b, 'b> JList<'a, 'b> {
     /// Look up the value for a key. Returns `Some` if it's found and `None` if
     /// a null pointer would be returned.
     pub fn get(&self, idx: jint) -> Result<Option<JObject<'a>>> {
-        let result = self.env.call_method_unchecked(
-            self.internal,
-            self.get,
-            ReturnType::Object,
-            &[JValue::from(idx).to_jni()],
-        );
+        // SAFETY: We keep the class loaded, and fetched the method ID for this function.
+        // Provided argument is statically known as a JObject/null, rather than another primitive type.
+        let result = unsafe {
+            self.env.call_method_unchecked(
+                self.internal,
+                self.get,
+                ReturnType::Object,
+                &[JValue::from(idx).to_jni()],
+            )
+        };
 
         match result {
             Ok(val) => Ok(Some(val.l()?)),
@@ -80,12 +84,16 @@ impl<'a: 'b, 'b> JList<'a, 'b> {
 
     /// Append an element to the list
     pub fn add(&self, value: JObject<'a>) -> Result<()> {
-        let result = self.env.call_method_unchecked(
-            self.internal,
-            self.add,
-            ReturnType::Primitive(Primitive::Boolean),
-            &[JValue::from(value).to_jni()],
-        );
+        // SAFETY: We keep the class loaded, and fetched the method ID for this function.
+        // Provided argument is statically known as a JObject/null, rather than another primitive type.
+        let result = unsafe {
+            self.env.call_method_unchecked(
+                self.internal,
+                self.add,
+                ReturnType::Primitive(Primitive::Boolean),
+                &[JValue::from(value).to_jni()],
+            )
+        };
 
         let _ = result?;
         Ok(())
@@ -93,12 +101,16 @@ impl<'a: 'b, 'b> JList<'a, 'b> {
 
     /// Insert an element at a specific index
     pub fn insert(&self, idx: jint, value: JObject<'a>) -> Result<()> {
-        let result = self.env.call_method_unchecked(
-            self.internal,
-            self.add_idx,
-            ReturnType::Primitive(Primitive::Void),
-            &[JValue::from(idx).to_jni(), JValue::from(value).to_jni()],
-        );
+        // SAFETY: We keep the class loaded, and fetched the method ID for this function.
+        // Provided argument is statically known as a JObject/null, rather than another primitive type.
+        let result = unsafe {
+            self.env.call_method_unchecked(
+                self.internal,
+                self.add_idx,
+                ReturnType::Primitive(Primitive::Void),
+                &[JValue::from(idx).to_jni(), JValue::from(value).to_jni()],
+            )
+        };
 
         let _ = result?;
         Ok(())
@@ -106,12 +118,16 @@ impl<'a: 'b, 'b> JList<'a, 'b> {
 
     /// Remove an element from the list by index
     pub fn remove(&self, idx: jint) -> Result<Option<JObject<'a>>> {
-        let result = self.env.call_method_unchecked(
-            self.internal,
-            self.remove,
-            ReturnType::Object,
-            &[JValue::from(idx).to_jni()],
-        );
+        // SAFETY: We keep the class loaded, and fetched the method ID for this function.
+        // Provided argument is statically known as a int, rather than any other java type.
+        let result = unsafe {
+            self.env.call_method_unchecked(
+                self.internal,
+                self.remove,
+                ReturnType::Object,
+                &[JValue::from(idx).to_jni()],
+            )
+        };
 
         match result {
             Ok(val) => Ok(Some(val.l()?)),
@@ -124,12 +140,15 @@ impl<'a: 'b, 'b> JList<'a, 'b> {
 
     /// Get the size of the list
     pub fn size(&self) -> Result<jint> {
-        let result = self.env.call_method_unchecked(
-            self.internal,
-            self.size,
-            ReturnType::Primitive(Primitive::Int),
-            &[],
-        );
+        // SAFETY: We keep the class loaded, and fetched the method ID for this function.
+        let result = unsafe {
+            self.env.call_method_unchecked(
+                self.internal,
+                self.size,
+                ReturnType::Primitive(Primitive::Int),
+                &[],
+            )
+        };
 
         result.and_then(|v| v.i())
     }
@@ -143,12 +162,16 @@ impl<'a: 'b, 'b> JList<'a, 'b> {
             return Ok(None);
         }
 
-        let result = self.env.call_method_unchecked(
-            self.internal,
-            self.remove,
-            ReturnType::Object,
-            &[JValue::from(size - 1).to_jni()],
-        );
+        // SAFETY: We keep the class loaded, and fetched the method ID for this function.
+        // Provided argument is statically known as a int.
+        let result = unsafe {
+            self.env.call_method_unchecked(
+                self.internal,
+                self.remove,
+                ReturnType::Object,
+                &[JValue::from(size - 1).to_jni()],
+            )
+        };
 
         match result {
             Ok(val) => Ok(Some(val.l()?)),

--- a/tests/jni_api.rs
+++ b/tests/jni_api.rs
@@ -247,6 +247,53 @@ pub fn with_local_frame_pending_exception() {
 }
 
 #[test]
+pub fn call_method_ok() {
+    let env = attach_current_thread();
+
+    let s = env.new_string(TESTING_OBJECT_STR).unwrap();
+
+    let v: jint = env
+        .call_method(s, "indexOf", "(I)I", &[JValue::Int('S' as i32)])
+        .expect("JNIEnv#call_method should return JValue")
+        .i()
+        .unwrap();
+
+    assert_eq!(v, 2);
+}
+
+#[test]
+pub fn call_method_with_bad_args_errs() {
+    let env = attach_current_thread();
+
+    let s = env.new_string(TESTING_OBJECT_STR).unwrap();
+
+    let is_bad_typ = env
+        .call_method(s, "indexOf", "(I)I", &[JValue::Float(3.1415)])
+        .map_err(|error| matches!(error, Error::InvalidArgList(_)))
+        .expect_err("JNIEnv#callmethod with bad arg type should err");
+
+    assert!(
+        is_bad_typ,
+        "ErrorKind::InvalidArgList expected when passing bad value type"
+    );
+
+    let is_bad_len = env
+        .call_method(
+            s,
+            "indexOf",
+            "(I)I",
+            &[JValue::Int('S' as i32), JValue::Long(3)],
+        )
+        .map_err(|error| matches!(error, Error::InvalidArgList(_)))
+        .expect_err("JNIEnv#call_method with bad arg lengths should err");
+
+    assert!(
+        is_bad_len,
+        "ErrorKind::InvalidArgList expected when passing bad argument lengths"
+    );
+}
+
+#[test]
 pub fn call_static_method_ok() {
     let env = attach_current_thread();
 
@@ -269,16 +316,17 @@ pub fn call_static_method_unchecked_ok() {
     let abs_method_id = env
         .get_static_method_id(math_class, MATH_ABS_METHOD_NAME, MATH_ABS_SIGNATURE)
         .unwrap();
-    let val: jint = env
-        .call_static_method_unchecked(
+    let val: jint = unsafe {
+        env.call_static_method_unchecked(
             math_class,
             abs_method_id,
             ReturnType::Primitive(Primitive::Int),
             &[x.into()],
         )
-        .expect("JNIEnv#call_static_method_unchecked should return JValue")
-        .i()
-        .unwrap();
+    }
+    .expect("JNIEnv#call_static_method_unchecked should return JValue")
+    .i()
+    .unwrap();
 
     assert_eq!(val, 10);
 }
@@ -298,6 +346,7 @@ pub fn call_static_method_throws() {
         .map_err(|error| matches!(error, Error::JavaException))
         .expect_err("JNIEnv#call_static_method_unsafe should return error");
 
+    // Throws a java.lang.ArithmeticException: integer overflow
     assert!(
         is_java_exception,
         "ErrorKind::JavaException expected as error"
@@ -306,19 +355,39 @@ pub fn call_static_method_throws() {
 }
 
 #[test]
-pub fn call_static_method_wrong_arg() {
+pub fn call_static_method_with_bad_args_errs() {
     let env = attach_current_thread();
 
     let x = JValue::Double(4.567_891_23);
-    env.call_static_method(
-        MATH_CLASS,
-        MATH_TO_INT_METHOD_NAME,
-        MATH_TO_INT_SIGNATURE,
-        &[x],
-    )
-    .expect_err("JNIEnv#call_static_method_unsafe should return error");
+    let is_bad_typ = env
+        .call_static_method(
+            MATH_CLASS,
+            MATH_TO_INT_METHOD_NAME,
+            MATH_TO_INT_SIGNATURE,
+            &[x],
+        )
+        .map_err(|error| matches!(error, Error::InvalidArgList(_)))
+        .expect_err("JNIEnv#call_static_method with bad arg type should err");
 
-    assert_pending_java_exception(&env);
+    assert!(
+        is_bad_typ,
+        "ErrorKind::InvalidArgList expected when passing bad value type"
+    );
+
+    let is_bad_len = env
+        .call_static_method(
+            MATH_CLASS,
+            MATH_TO_INT_METHOD_NAME,
+            MATH_TO_INT_SIGNATURE,
+            &[JValue::Int(2), JValue::Int(3)],
+        )
+        .map_err(|error| matches!(error, Error::InvalidArgList(_)))
+        .expect_err("JNIEnv#call_static_method with bad arg lengths should err");
+
+    assert!(
+        is_bad_len,
+        "ErrorKind::InvalidArgList expected when passing bad argument lengths"
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Overview

Marked the unchecked family of method calls as unsafe, per #385.

Passing in the incorrect number of arguments to a given method can cause the JVM to read past the argument buffer. Similarly, passing the wrong types of arguments can cause memory unsafety as well (ex: passing in a non-zero'd primitive when it expects an object pointer)

To reflect this, I also updated the safe wrappers to check the basic argument types that would case a JNI error - primitive types, and that objects are objects. If an object of the wrong type is provided, then the JVM should throw a regular exception.

Note too that the previous test, `tests::call_static_method_wrong_arg` was incorrect - it indeed threw an exception, but the exception was instead for a `java.lang.ArithmeticException: integer overflow` error when passing a `double` that the JVM interpreted as a `int`. This is unfortunately something the JVM itself can't really check for, so the safe wrappers were updated. The tests were then changed to ensure those checks worked.

I've kept the new_object_unchecked changes within my other PR in #382, so that+related tests aren't included here.

Please let me know if you spot any issues

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Change is covered by [automated tests](https://github.com/jni-rs/jni-rs/blob/master/CONTRIBUTING.md#tests)
- [x] The [coding guidelines](https://github.com/jni-rs/jni-rs/blob/master/CONTRIBUTING.md#the-code-style) are followed
- [x] Public API has documentation
- [x] User-visible changes are mentioned in the Changelog
- [ ] The continuous integration build passes
