### PR TITLE
fixing documentation example into_inner() => into_raw()

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -131,7 +131,7 @@
 //!         .expect("Couldn't create java string!");
 //!
 //!     // Finally, extract the raw pointer to return.
-//!     output.into_inner()
+//!     output.into_raw()
 //! }
 //! ```
 //!


### PR DESCRIPTION
## Overview

Just a simple documentation change, I see that the repo example has already migrated, but copying examples from documentation yields a compile-time error.
