### PR TITLE
Remove useless generic argument in `define_unnamed_class`

### DIFF
--- a/src/wrapper/jnienv.rs
+++ b/src/wrapper/jnienv.rs
@@ -254,14 +254,7 @@ impl<'local> JNIEnv<'local> {
 
     /// Load a class from a buffer of raw class data. The name of the class is inferred from the
     /// buffer.
-    pub fn define_unnamed_class<S>(
-        &mut self,
-        loader: &JObject,
-        buf: &[u8],
-    ) -> Result<JClass<'local>>
-    where
-        S: Into<JNIString>,
-    {
+    pub fn define_unnamed_class(&mut self, loader: &JObject, buf: &[u8]) -> Result<JClass<'local>> {
         self.define_class_impl(ptr::null(), loader, buf)
     }
 


### PR DESCRIPTION
.. This is a breaking change, though

## Overview

see title

### Definition of Done

- [ ] There are no TODOs left in the code
- [ ] Change is covered by [automated tests](https://github.com/jni-rs/jni-rs/blob/master/CONTRIBUTING.md#tests)
- [ ] The [coding guidelines](https://github.com/jni-rs/jni-rs/blob/master/CONTRIBUTING.md#the-code-style) are followed
- [ ] Public API has documentation
- [ ] User-visible changes are mentioned in the Changelog
- [ ] The continuous integration build passes
