### PR TITLE
Make JObject and JNIEnv !Copy to prevent use-after-free

### DIFF
--- a/benches/api_calls.rs
+++ b/benches/api_calls.rs
@@ -249,7 +249,7 @@ mod tests {
             .unwrap();
 
         b.iter(|| {
-            let obj = env.new_object_unchecked(class, ctor_id, &[]).unwrap();
+            let obj = unsafe { env.new_object_unchecked(class, ctor_id, &[]) }.unwrap();
             env.delete_local_ref(obj).unwrap();
         });
     }
@@ -274,7 +274,7 @@ mod tests {
             .unwrap();
 
         b.iter(|| {
-            let obj = env.new_object_unchecked(class, ctor_id, &[]).unwrap();
+            let obj = unsafe { env.new_object_unchecked(class, ctor_id, &[]) }.unwrap();
             env.delete_local_ref(obj).unwrap();
         });
     }

--- a/benches/api_calls.rs
+++ b/benches/api_calls.rs
@@ -34,7 +34,7 @@ fn native_abs(x: i32) -> i32 {
     x.abs()
 }
 
-fn jni_abs_safe(env: &JNIEnv, x: jint) -> jint {
+fn jni_abs_safe(env: &mut JNIEnv, x: jint) -> jint {
     let x = JValue::from(x);
     let v = env
         .call_static_method(CLASS_MATH, METHOD_MATH_ABS, SIG_MATH_ABS, &[x])
@@ -42,15 +42,15 @@ fn jni_abs_safe(env: &JNIEnv, x: jint) -> jint {
     v.i().unwrap()
 }
 
-fn jni_hash_safe(env: &JNIEnv, obj: JObject) -> jint {
+fn jni_hash_safe(env: &mut JNIEnv, obj: &JObject) -> jint {
     let v = env
         .call_method(obj, METHOD_OBJECT_HASH_CODE, SIG_OBJECT_HASH_CODE, &[])
         .unwrap();
     v.i().unwrap()
 }
 
-fn jni_local_date_time_of_safe<'e>(
-    env: &JNIEnv<'e>,
+fn jni_local_date_time_of_safe<'local>(
+    env: &mut JNIEnv<'local>,
     year: jint,
     month: jint,
     day_of_month: jint,
@@ -58,7 +58,7 @@ fn jni_local_date_time_of_safe<'e>(
     minute: jint,
     second: jint,
     nanosecond: jint,
-) -> JObject<'e> {
+) -> JObject<'local> {
     let v = env
         .call_static_method(
             CLASS_LOCAL_DATE_TIME,
@@ -78,25 +78,29 @@ fn jni_local_date_time_of_safe<'e>(
     v.l().unwrap()
 }
 
-fn jni_int_call_static_unchecked<'c, C>(
-    env: &JNIEnv<'c>,
+fn jni_int_call_static_unchecked<'local, C>(
+    env: &mut JNIEnv<'local>,
     class: C,
     method_id: JStaticMethodID,
     x: jint,
 ) -> jint
 where
-    C: Desc<'c, JClass<'c>>,
+    C: Desc<'local, JClass<'local>>,
 {
     let x = JValue::from(x);
     let ret = ReturnType::Primitive(Primitive::Int);
     let v =
-        unsafe { env.call_static_method_unchecked(class, method_id, ret, &[x.into()]) }.unwrap();
+        unsafe { env.call_static_method_unchecked(class, method_id, ret, &[x.as_jni()]) }.unwrap();
     v.i().unwrap()
 }
 
-fn jni_int_call_unchecked<'m, M>(env: &JNIEnv<'m>, obj: JObject<'m>, method_id: M) -> jint
+fn jni_int_call_unchecked<'local, M>(
+    env: &mut JNIEnv<'local>,
+    obj: &JObject<'local>,
+    method_id: M,
+) -> jint
 where
-    M: Desc<'m, JMethodID>,
+    M: Desc<'local, JMethodID>,
 {
     let ret = ReturnType::Primitive(Primitive::Int);
     // SAFETY: Caller retrieved method ID + class specifically for this use: Object.hashCode()I
@@ -104,14 +108,14 @@ where
     v.i().unwrap()
 }
 
-fn jni_object_call_static_unchecked<'c, C>(
-    env: &JNIEnv<'c>,
+fn jni_object_call_static_unchecked<'local, C>(
+    env: &mut JNIEnv<'local>,
     class: C,
     method_id: JStaticMethodID,
     args: &[jvalue],
-) -> JObject<'c>
+) -> JObject<'local>
 where
-    C: Desc<'c, JClass<'c>>,
+    C: Desc<'local, JClass<'local>>,
 {
     // SAFETY: Caller retrieved method ID and constructed arguments
     let v = unsafe { env.call_static_method_unchecked(class, method_id, ReturnType::Object, args) }
@@ -145,63 +149,63 @@ mod tests {
 
     #[bench]
     fn jni_call_static_abs_method_safe(b: &mut Bencher) {
-        let env = VM.attach_current_thread().unwrap();
+        let mut env = VM.attach_current_thread().unwrap();
 
-        b.iter(|| jni_abs_safe(&env, -3));
+        b.iter(|| jni_abs_safe(&mut env, -3));
     }
 
     #[bench]
     fn jni_call_static_abs_method_unchecked_str(b: &mut Bencher) {
-        let env = VM.attach_current_thread().unwrap();
+        let mut env = VM.attach_current_thread().unwrap();
         let class = CLASS_MATH;
         let method_id = env
             .get_static_method_id(class, METHOD_MATH_ABS, SIG_MATH_ABS)
             .unwrap();
 
-        b.iter(|| jni_int_call_static_unchecked(&env, class, method_id, -3));
+        b.iter(|| jni_int_call_static_unchecked(&mut env, class, method_id, -3));
     }
 
     #[bench]
     fn jni_call_static_abs_method_unchecked_jclass(b: &mut Bencher) {
-        let env = VM.attach_current_thread().unwrap();
-        let class: JClass = CLASS_MATH.lookup(&env).unwrap();
+        let mut env = VM.attach_current_thread().unwrap();
+        let class = Desc::<JClass>::lookup(CLASS_MATH, &mut env).unwrap();
         let method_id = env
-            .get_static_method_id(class, METHOD_MATH_ABS, SIG_MATH_ABS)
+            .get_static_method_id(&class, METHOD_MATH_ABS, SIG_MATH_ABS)
             .unwrap();
 
-        b.iter(|| jni_int_call_static_unchecked(&env, class, method_id, -3));
+        b.iter(|| jni_int_call_static_unchecked(&mut env, &class, method_id, -3));
     }
 
     #[bench]
     fn jni_call_static_date_time_method_safe(b: &mut Bencher) {
-        let env = VM.attach_current_thread().unwrap();
+        let mut env = VM.attach_current_thread().unwrap();
         b.iter(|| {
-            let obj = jni_local_date_time_of_safe(&env, 1, 1, 1, 1, 1, 1, 1);
+            let obj = jni_local_date_time_of_safe(&mut env, 1, 1, 1, 1, 1, 1, 1);
             env.delete_local_ref(obj).unwrap();
         });
     }
 
     #[bench]
     fn jni_call_static_date_time_method_unchecked_jclass(b: &mut Bencher) {
-        let env = VM.attach_current_thread().unwrap();
-        let class: JClass = CLASS_LOCAL_DATE_TIME.lookup(&env).unwrap();
+        let mut env = VM.attach_current_thread().unwrap();
+        let class = Desc::<JClass>::lookup(CLASS_LOCAL_DATE_TIME, &mut env).unwrap();
         let method_id = env
-            .get_static_method_id(class, METHOD_LOCAL_DATE_TIME_OF, SIG_LOCAL_DATE_TIME_OF)
+            .get_static_method_id(&class, METHOD_LOCAL_DATE_TIME_OF, SIG_LOCAL_DATE_TIME_OF)
             .unwrap();
 
         b.iter(|| {
             let obj = jni_object_call_static_unchecked(
-                &env,
-                class,
+                &mut env,
+                &class,
                 method_id,
                 &[
-                    JValue::Int(1).into(),
-                    JValue::Int(1).into(),
-                    JValue::Int(1).into(),
-                    JValue::Int(1).into(),
-                    JValue::Int(1).into(),
-                    JValue::Int(1).into(),
-                    JValue::Int(1).into(),
+                    JValue::Int(1).as_jni(),
+                    JValue::Int(1).as_jni(),
+                    JValue::Int(1).as_jni(),
+                    JValue::Int(1).as_jni(),
+                    JValue::Int(1).as_jni(),
+                    JValue::Int(1).as_jni(),
+                    JValue::Int(1).as_jni(),
                 ],
             );
             env.delete_local_ref(obj).unwrap();
@@ -210,28 +214,28 @@ mod tests {
 
     #[bench]
     fn jni_call_object_hash_method_safe(b: &mut Bencher) {
-        let env = VM.attach_current_thread().unwrap();
+        let mut env = VM.attach_current_thread().unwrap();
         let s = env.new_string("").unwrap();
         let obj = black_box(JObject::from(s));
 
-        b.iter(|| jni_hash_safe(&env, obj));
+        b.iter(|| jni_hash_safe(&mut env, &obj));
     }
 
     #[bench]
     fn jni_call_object_hash_method_unchecked(b: &mut Bencher) {
-        let env = VM.attach_current_thread().unwrap();
+        let mut env = VM.attach_current_thread().unwrap();
         let s = env.new_string("").unwrap();
         let obj = black_box(JObject::from(s));
         let method_id = env
-            .get_method_id(obj, METHOD_OBJECT_HASH_CODE, SIG_OBJECT_HASH_CODE)
+            .get_method_id(&obj, METHOD_OBJECT_HASH_CODE, SIG_OBJECT_HASH_CODE)
             .unwrap();
 
-        b.iter(|| jni_int_call_unchecked(&env, obj, method_id));
+        b.iter(|| jni_int_call_unchecked(&mut env, &obj, method_id));
     }
 
     #[bench]
     fn jni_new_object_str(b: &mut Bencher) {
-        let env = VM.attach_current_thread().unwrap();
+        let mut env = VM.attach_current_thread().unwrap();
         let class = CLASS_OBJECT;
 
         b.iter(|| {
@@ -242,7 +246,7 @@ mod tests {
 
     #[bench]
     fn jni_new_object_by_id_str(b: &mut Bencher) {
-        let env = VM.attach_current_thread().unwrap();
+        let mut env = VM.attach_current_thread().unwrap();
         let class = CLASS_OBJECT;
         let ctor_id = env
             .get_method_id(class, METHOD_CTOR, SIG_OBJECT_CTOR)
@@ -256,35 +260,35 @@ mod tests {
 
     #[bench]
     fn jni_new_object_jclass(b: &mut Bencher) {
-        let env = VM.attach_current_thread().unwrap();
-        let class: JClass = CLASS_OBJECT.lookup(&env).unwrap();
+        let mut env = VM.attach_current_thread().unwrap();
+        let class = Desc::<JClass>::lookup(CLASS_OBJECT, &mut env).unwrap();
 
         b.iter(|| {
-            let obj = env.new_object(class, SIG_OBJECT_CTOR, &[]).unwrap();
+            let obj = env.new_object(&class, SIG_OBJECT_CTOR, &[]).unwrap();
             env.delete_local_ref(obj).unwrap();
         });
     }
 
     #[bench]
     fn jni_new_object_by_id_jclass(b: &mut Bencher) {
-        let env = VM.attach_current_thread().unwrap();
-        let class: JClass = CLASS_OBJECT.lookup(&env).unwrap();
+        let mut env = VM.attach_current_thread().unwrap();
+        let class = Desc::<JClass>::lookup(CLASS_OBJECT, &mut env).unwrap();
         let ctor_id = env
-            .get_method_id(class, METHOD_CTOR, SIG_OBJECT_CTOR)
+            .get_method_id(&class, METHOD_CTOR, SIG_OBJECT_CTOR)
             .unwrap();
 
         b.iter(|| {
-            let obj = unsafe { env.new_object_unchecked(class, ctor_id, &[]) }.unwrap();
+            let obj = unsafe { env.new_object_unchecked(&class, ctor_id, &[]) }.unwrap();
             env.delete_local_ref(obj).unwrap();
         });
     }
 
     #[bench]
     fn jni_new_global_ref(b: &mut Bencher) {
-        let env = VM.attach_current_thread().unwrap();
+        let mut env = VM.attach_current_thread().unwrap();
         let class = CLASS_OBJECT;
         let obj = env.new_object(class, SIG_OBJECT_CTOR, &[]).unwrap();
-        let global_ref = env.new_global_ref(obj).unwrap();
+        let global_ref = env.new_global_ref(&obj).unwrap();
         env.delete_local_ref(obj).unwrap();
 
         b.iter(|| env.new_global_ref(&global_ref).unwrap());
@@ -314,11 +318,11 @@ mod tests {
 
     #[bench]
     fn jni_get_string(b: &mut Bencher) {
-        let env = VM.attach_current_thread().unwrap();
+        let mut env = VM.attach_current_thread().unwrap();
         let string = env.new_string(TEST_STRING_UNICODE).unwrap();
 
         b.iter(|| {
-            let s: String = env.get_string(string).unwrap().into();
+            let s: String = env.get_string(&string).unwrap().into();
             assert_eq!(s, TEST_STRING_UNICODE);
         });
     }
@@ -329,7 +333,7 @@ mod tests {
         let string = env.new_string(TEST_STRING_UNICODE).unwrap();
 
         b.iter(|| {
-            let s: String = unsafe { env.get_string_unchecked(string) }.unwrap().into();
+            let s: String = unsafe { env.get_string_unchecked(&string) }.unwrap().into();
             assert_eq!(s, TEST_STRING_UNICODE);
         });
     }
@@ -344,9 +348,9 @@ mod tests {
     fn jni_noop_with_local_frame(b: &mut Bencher) {
         // Local frame size actually doesn't matter since JVM does not preallocate anything.
         const LOCAL_FRAME_SIZE: i32 = 32;
-        let env = VM.attach_current_thread().unwrap();
+        let mut env = VM.attach_current_thread().unwrap();
         b.iter(|| {
-            env.with_local_frame(LOCAL_FRAME_SIZE, || Ok(JObject::null()))
+            env.with_local_frame(LOCAL_FRAME_SIZE, |_| Ok(JObject::null()))
                 .unwrap()
         });
     }
@@ -366,10 +370,10 @@ mod tests {
 
     #[bench]
     fn native_arc(b: &mut Bencher) {
-        let env = VM.attach_current_thread().unwrap();
+        let mut env = VM.attach_current_thread().unwrap();
         let class = CLASS_OBJECT;
         let obj = env.new_object(class, SIG_OBJECT_CTOR, &[]).unwrap();
-        let global_ref = env.new_global_ref(obj).unwrap();
+        let global_ref = env.new_global_ref(&obj).unwrap();
         env.delete_local_ref(obj).unwrap();
         let arc = Arc::new(global_ref);
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -95,7 +95,7 @@
 //! The last thing we need to do is to define our exported method. Add this to
 //! your crate's `src/lib.rs`:
 //!
-//! ```rust,ignore
+//! ```rust,no_run
 //! // This is the interface to the JVM that we'll call the majority of our
 //! // methods on.
 //! use jni::JNIEnv;
@@ -113,17 +113,17 @@
 //! // This keeps Rust from "mangling" the name and making it unique for this
 //! // crate.
 //! #[no_mangle]
-//! pub extern "system" fn Java_HelloWorld_hello(env: JNIEnv,
+//! pub extern "system" fn Java_HelloWorld_hello<'local>(mut env: JNIEnv<'local>,
 //! // This is the class that owns our static method. It's not going to be used,
 //! // but still must be present to match the expected signature of a static
 //! // native method.
-//!                                              class: JClass,
-//!                                              input: JString)
-//!                                              -> jstring {
+//!                                                      class: JClass<'local>,
+//!                                                      input: JString<'local>)
+//!                                                      -> jstring {
 //!     // First, we have to get the string out of Java. Check out the `strings`
 //!     // module for more info on how this works.
 //!     let input: String =
-//!         env.get_string(input).expect("Couldn't get java string!").into();
+//!         env.get_string(&input).expect("Couldn't get java string!").into();
 //!
 //!     // Then we have to create a new Java string to return. Again, more info
 //!     // in the `strings` module.

--- a/src/wrapper/descriptors/class_desc.rs
+++ b/src/wrapper/descriptors/class_desc.rs
@@ -6,34 +6,47 @@ use crate::{
     JNIEnv,
 };
 
-impl<'a, T> Desc<'a, JClass<'a>> for T
+unsafe impl<'local, T> Desc<'local, JClass<'local>> for T
 where
     T: Into<JNIString>,
 {
-    fn lookup(self, env: &JNIEnv<'a>) -> Result<JClass<'a>> {
-        env.find_class(self)
+    type Output = AutoLocal<'local, JClass<'local>>;
+
+    fn lookup(self, env: &mut JNIEnv<'local>) -> Result<Self::Output> {
+        Ok(AutoLocal::new(env.find_class(self)?, env))
     }
 }
 
-impl<'a, 'b> Desc<'a, JClass<'a>> for JObject<'b> {
-    fn lookup(self, env: &JNIEnv<'a>) -> Result<JClass<'a>> {
-        env.get_object_class(self)
+unsafe impl<'local, 'other_local> Desc<'local, JClass<'local>> for JObject<'other_local> {
+    type Output = AutoLocal<'local, JClass<'local>>;
+
+    fn lookup(self, env: &mut JNIEnv<'local>) -> Result<Self::Output> {
+        Desc::<JClass>::lookup(&self, env)
+    }
+}
+
+unsafe impl<'local, 'other_local, 'obj_ref> Desc<'local, JClass<'local>>
+    for &'obj_ref JObject<'other_local>
+{
+    type Output = AutoLocal<'local, JClass<'local>>;
+
+    fn lookup(self, env: &mut JNIEnv<'local>) -> Result<Self::Output> {
+        Ok(env.auto_local(env.get_object_class(self)?))
     }
 }
 
 /// This conversion assumes that the `GlobalRef` is a pointer to a class object.
-impl<'a, 'b> Desc<'a, JClass<'b>> for &'b GlobalRef {
-    fn lookup(self, _: &JNIEnv<'a>) -> Result<JClass<'b>> {
-        Ok(self.as_obj().into())
-    }
-}
 
-/// This conversion assumes that the `AutoLocal` is a pointer to a class object.
-impl<'a, 'b, 'c> Desc<'a, JClass<'b>> for &'b AutoLocal<'c, '_>
-where
-    'c: 'b,
-{
-    fn lookup(self, _: &JNIEnv<'a>) -> Result<JClass<'b>> {
-        Ok(self.as_obj().into())
+// TODO: Generify `GlobalRef` and get rid of this `impl`. The transmute is
+// sound-ish at the moment (`JClass` is currently `repr(transparent)`
+// around `JObject`), but that may change in the future. Moreover, this
+// doesn't check if the global reference actually refers to a
+// `java.lang.Class` object.
+unsafe impl<'local, 'obj_ref> Desc<'local, JClass<'static>> for &'obj_ref GlobalRef {
+    type Output = &'obj_ref JClass<'static>;
+
+    fn lookup(self, _: &mut JNIEnv<'local>) -> Result<Self::Output> {
+        let obj: &JObject<'static> = self.as_ref();
+        Ok(unsafe { std::mem::transmute(obj) })
     }
 }

--- a/src/wrapper/descriptors/desc.rs
+++ b/src/wrapper/descriptors/desc.rs
@@ -1,17 +1,134 @@
-use crate::{errors::*, JNIEnv};
+use crate::{
+    errors::*,
+    objects::{AutoLocal, JObject},
+    JNIEnv,
+};
+
+#[cfg(doc)]
+use crate::objects::{JClass, JMethodID};
 
 /// Trait for things that can be looked up through the JNI via a descriptor.
 /// This will be something like the fully-qualified class name
 /// `java/lang/String` or a tuple containing a class descriptor, method name,
 /// and method signature. For convenience, this is also implemented for the
 /// concrete types themselves in addition to their descriptors.
-pub trait Desc<'a, T> {
+///
+/// # Safety
+///
+/// Implementations of this trait must return the correct value from the
+/// `lookup` method. It must not, for example, return a random [`JMethodID`] or
+/// the [`JClass`] of a class other than the one requested. Returning such an
+/// incorrect value results in undefined behavior. This requirement also
+/// applies to the returned value's implementation of `AsRef<T>`.
+pub unsafe trait Desc<'local, T> {
+    /// The type that this `Desc` returns.
+    type Output: AsRef<T>;
+
     /// Look up the concrete type from the JVM.
-    fn lookup(self, _: &JNIEnv<'a>) -> Result<T>;
+    ///
+    /// Note that this method does not return exactly `T`. Instead, it returns
+    /// some type that implements `AsRef<T>`. For this reason, it is often
+    /// necessary to use turbofish syntax when calling this method:
+    ///
+    /// ```rust,no_run
+    /// # use jni::{descriptors::Desc, errors::Result, JNIEnv, objects::JClass};
+    /// #
+    /// # fn example(env: &mut JNIEnv) -> Result<()> {
+    /// // The value returned by `lookup` is not exactly `JClass`.
+    /// let class/*: impl AsRef<JClass> */ =
+    ///     Desc::<JClass>::lookup("java/lang/Object", env)?;
+    ///
+    /// // But `&JClass` can be borrowed from it.
+    /// let class: &JClass = class.as_ref();
+    /// # Ok(())
+    /// # }
+    /// ```
+    ///
+    /// **Warning:** Many built-in implementations of this trait return
+    /// [`AutoLocal`] from this method. If you then call [`JObject::as_raw`] on
+    /// the returned object reference, this may result in the reference being
+    /// [deleted][JNIEnv::delete_local_ref] before it is used, causing
+    /// undefined behavior.
+    ///
+    /// For example, don't do this:
+    ///
+    /// ```rust,no_run
+    /// # use jni::{descriptors::Desc, errors::Result, JNIEnv, objects::JClass};
+    /// #
+    /// # fn some_function<T>(ptr: *mut T) {}
+    /// #
+    /// # fn example(env: &mut JNIEnv) -> Result<()> {
+    /// // Undefined behavior: the `JClass` is dropped before the raw pointer
+    /// // is passed to `some_function`!
+    /// some_function(Desc::<JClass>::lookup("java/lang/Object", env)?.as_raw());
+    /// # Ok(())
+    /// # }
+    /// ```
+    ///
+    /// Instead, do this:
+    ///
+    /// ```rust,no_run
+    /// # use jni::{descriptors::Desc, errors::Result, JNIEnv, objects::JClass};
+    /// #
+    /// # fn some_function<T>(ptr: *mut T) {}
+    /// #
+    /// # fn example(env: &mut JNIEnv) -> Result<()> {
+    /// let class = Desc::<JClass>::lookup("java/lang/Object", env)?;
+    ///
+    /// some_function(class.as_raw());
+    ///
+    /// drop(class);
+    /// # Ok(())
+    /// # }
+    /// ```
+    ///
+    /// This will still work without the call to `drop` at the end, but calling
+    /// `drop` ensures that the reference is not accidentally dropped earlier
+    /// than it should be.
+    fn lookup(self, _: &mut JNIEnv<'local>) -> Result<Self::Output>;
 }
 
-impl<'a, T> Desc<'a, T> for T {
-    fn lookup(self, _: &JNIEnv<'a>) -> Result<T> {
+unsafe impl<'local, T> Desc<'local, T> for T
+where
+    T: AsRef<T>,
+{
+    type Output = Self;
+
+    fn lookup(self, _: &mut JNIEnv<'local>) -> Result<T> {
+        Ok(self)
+    }
+}
+
+unsafe impl<'local, 't_ref, T> Desc<'local, T> for &'t_ref T
+where
+    T: AsRef<T>,
+{
+    type Output = Self;
+
+    fn lookup(self, _: &mut JNIEnv<'local>) -> Result<Self::Output> {
+        Ok(self)
+    }
+}
+
+unsafe impl<'local, 'other_local, T> Desc<'local, T> for AutoLocal<'other_local, T>
+where
+    T: AsRef<T> + Into<JObject<'other_local>>,
+{
+    type Output = Self;
+
+    fn lookup(self, _: &mut JNIEnv<'local>) -> Result<Self::Output> {
+        Ok(self)
+    }
+}
+
+unsafe impl<'local, 'other_local, 'obj_ref, T> Desc<'local, T>
+    for &'obj_ref AutoLocal<'other_local, T>
+where
+    T: AsRef<T> + Into<JObject<'other_local>>,
+{
+    type Output = Self;
+
+    fn lookup(self, _: &mut JNIEnv<'local>) -> Result<Self::Output> {
         Ok(self)
     }
 }

--- a/src/wrapper/descriptors/field_desc.rs
+++ b/src/wrapper/descriptors/field_desc.rs
@@ -6,24 +6,28 @@ use crate::{
     JNIEnv,
 };
 
-impl<'a, 'c, T, U, V> Desc<'a, JFieldID> for (T, U, V)
+unsafe impl<'local, 'other_local, T, U, V> Desc<'local, JFieldID> for (T, U, V)
 where
-    T: Desc<'a, JClass<'c>>,
+    T: Desc<'local, JClass<'other_local>>,
     U: Into<JNIString>,
     V: Into<JNIString>,
 {
-    fn lookup(self, env: &JNIEnv<'a>) -> Result<JFieldID> {
+    type Output = JFieldID;
+
+    fn lookup(self, env: &mut JNIEnv<'local>) -> Result<Self::Output> {
         env.get_field_id(self.0, self.1, self.2)
     }
 }
 
-impl<'a, 'c, T, U, V> Desc<'a, JStaticFieldID> for (T, U, V)
+unsafe impl<'local, 'other_local, T, U, V> Desc<'local, JStaticFieldID> for (T, U, V)
 where
-    T: Desc<'a, JClass<'c>>,
+    T: Desc<'local, JClass<'other_local>>,
     U: Into<JNIString>,
     V: Into<JNIString>,
 {
-    fn lookup(self, env: &JNIEnv<'a>) -> Result<JStaticFieldID> {
+    type Output = JStaticFieldID;
+
+    fn lookup(self, env: &mut JNIEnv<'local>) -> Result<Self::Output> {
         env.get_static_field_id(self.0, self.1, self.2)
     }
 }

--- a/src/wrapper/descriptors/method_desc.rs
+++ b/src/wrapper/descriptors/method_desc.rs
@@ -6,34 +6,40 @@ use crate::{
     JNIEnv,
 };
 
-impl<'a, 'c, T, U, V> Desc<'a, JMethodID> for (T, U, V)
+unsafe impl<'local, 'other_local, T, U, V> Desc<'local, JMethodID> for (T, U, V)
 where
-    T: Desc<'a, JClass<'c>>,
+    T: Desc<'local, JClass<'other_local>>,
     U: Into<JNIString>,
     V: Into<JNIString>,
 {
-    fn lookup(self, env: &JNIEnv<'a>) -> Result<JMethodID> {
+    type Output = JMethodID;
+
+    fn lookup(self, env: &mut JNIEnv<'local>) -> Result<Self::Output> {
         env.get_method_id(self.0, self.1, self.2)
     }
 }
 
-impl<'a, 'c, T, Signature> Desc<'a, JMethodID> for (T, Signature)
+unsafe impl<'local, 'other_local, T, Signature> Desc<'local, JMethodID> for (T, Signature)
 where
-    T: Desc<'a, JClass<'c>>,
+    T: Desc<'local, JClass<'other_local>>,
     Signature: Into<JNIString>,
 {
-    fn lookup(self, env: &JNIEnv<'a>) -> Result<JMethodID> {
-        (self.0, "<init>", self.1).lookup(env)
+    type Output = JMethodID;
+
+    fn lookup(self, env: &mut JNIEnv<'local>) -> Result<Self::Output> {
+        Desc::<JMethodID>::lookup((self.0, "<init>", self.1), env)
     }
 }
 
-impl<'a, 'c, T, U, V> Desc<'a, JStaticMethodID> for (T, U, V)
+unsafe impl<'local, 'other_local, T, U, V> Desc<'local, JStaticMethodID> for (T, U, V)
 where
-    T: Desc<'a, JClass<'c>>,
+    T: Desc<'local, JClass<'other_local>>,
     U: Into<JNIString>,
     V: Into<JNIString>,
 {
-    fn lookup(self, env: &JNIEnv<'a>) -> Result<JStaticMethodID> {
+    type Output = JStaticMethodID;
+
+    fn lookup(self, env: &mut JNIEnv<'local>) -> Result<Self::Output> {
         env.get_static_method_id(self.0, self.1, self.2)
     }
 }

--- a/src/wrapper/executor.rs
+++ b/src/wrapper/executor.rs
@@ -70,14 +70,14 @@ impl Executor {
     /// Allocates a local frame with the specified capacity.
     pub fn with_attached_capacity<F, R>(&self, capacity: i32, f: F) -> Result<R>
     where
-        F: FnOnce(&JNIEnv) -> Result<R>,
+        F: FnOnce(&mut JNIEnv) -> Result<R>,
     {
         assert!(capacity > 0, "capacity should be a positive integer");
 
-        let jni_env = self.vm.attach_current_thread_as_daemon()?;
+        let mut jni_env = self.vm.attach_current_thread_as_daemon()?;
         let mut result = None;
-        jni_env.with_local_frame(capacity, || {
-            result = Some(f(&jni_env));
+        jni_env.with_local_frame(capacity, |jni_env| {
+            result = Some(f(jni_env));
             Ok(JObject::null())
         })?;
 
@@ -92,7 +92,7 @@ impl Executor {
     /// [the default capacity](constant.DEFAULT_LOCAL_FRAME_CAPACITY.html).
     pub fn with_attached<F, R>(&self, f: F) -> Result<R>
     where
-        F: FnOnce(&JNIEnv) -> Result<R>,
+        F: FnOnce(&mut JNIEnv) -> Result<R>,
     {
         self.with_attached_capacity(DEFAULT_LOCAL_FRAME_CAPACITY, f)
     }

--- a/src/wrapper/objects/auto_local.rs
+++ b/src/wrapper/objects/auto_local.rs
@@ -1,4 +1,8 @@
-use std::mem;
+use std::{
+    mem::ManuallyDrop,
+    ops::{Deref, DerefMut},
+    ptr,
+};
 
 use log::debug;
 
@@ -14,28 +18,41 @@ use crate::{objects::JObject, JNIEnv};
 /// This wrapper provides automatic local ref deletion when it goes out of
 /// scope.
 ///
-/// NOTE: This comes with some potential safety risks. DO NOT use this to wrap
-/// something unless you're SURE it won't be used after this wrapper gets
-/// dropped. Otherwise, you'll get a nasty JVM crash.
-///
 /// See also the [JNI specification][spec-references] for details on referencing Java objects
 /// and some [extra information][android-jni-references].
 ///
 /// [spec-references]: https://docs.oracle.com/en/java/javase/12/docs/specs/jni/design.html#referencing-java-objects
 /// [android-jni-references]: https://developer.android.com/training/articles/perf-jni#local-and-global-references
-pub struct AutoLocal<'a: 'b, 'b> {
-    obj: JObject<'a>,
-    env: &'b JNIEnv<'a>,
+#[derive(Debug)]
+pub struct AutoLocal<'local, T>
+where
+    T: Into<JObject<'local>>,
+{
+    obj: ManuallyDrop<T>,
+    env: JNIEnv<'local>,
 }
 
-impl<'a, 'b> AutoLocal<'a, 'b> {
+impl<'local, T> AutoLocal<'local, T>
+where
+    // Note that this bound prevents `AutoLocal` from wrapping a `GlobalRef`, which implements
+    // `AsRef<JObject<'static>>` but *not* `Into<JObject<'static>>`. This is good, because trying
+    // to delete a global reference as though it were local would cause undefined behavior.
+    T: Into<JObject<'local>>,
+{
     /// Creates a new auto-delete wrapper for a local ref.
     ///
     /// Once this wrapper goes out of scope, the `delete_local_ref` will be
     /// called on the object. While wrapped, the object can be accessed via
     /// the `Deref` impl.
-    pub fn new(env: &'b JNIEnv<'a>, obj: JObject<'a>) -> Self {
-        AutoLocal { obj, env }
+    pub fn new(obj: T, env: &JNIEnv<'local>) -> Self {
+        // Safety: The cloned `JNIEnv` will not be used to create any local references, only to
+        // delete one.
+        let env = unsafe { env.unsafe_clone() };
+
+        AutoLocal {
+            obj: ManuallyDrop::new(obj),
+            env,
+        }
     }
 
     /// Forget the wrapper, returning the original object.
@@ -45,27 +62,54 @@ impl<'a, 'b> AutoLocal<'a, 'b> {
     /// dropped. You must either remember to delete the local ref manually, or
     /// be
     /// ok with it getting deleted once the foreign method returns.
-    pub fn forget(self) -> JObject<'a> {
-        let obj = self.obj;
-        mem::forget(self);
-        obj
-    }
+    pub fn forget(self) -> T {
+        // We need to move `self.obj` out of `self`. Normally that's trivial, but moving out of a
+        // type with a `Drop` implementation is not allowed. We'll have to do it manually (and
+        // carefully) with `unsafe`.
+        //
+        // This could be done without `unsafe` by adding `where T: Default` and using
+        // `std::mem::replace` to extract `self.obj`, but doing it this way avoids unnecessarily
+        // running the drop routine on `self`.
 
-    /// Get a reference to the wrapped object
-    ///
-    /// Unlike `forget`, this ensures the wrapper from being dropped while the
-    /// returned `JObject` is still live.
-    pub fn as_obj<'c>(&self) -> JObject<'c>
-    where
-        'a: 'c,
-    {
-        self.obj
+        // Before we mutilate `self`, make sure its drop code will not be automatically run. That
+        // would cause undefined behavior.
+        let mut self_md = ManuallyDrop::new(self);
+
+        unsafe {
+            // Drop the `JNIEnv` in place. As of this writing, that's a no-op, but if `JNIEnv`
+            // gains any drop code in the future, this will run it.
+            //
+            // Safety: The `&mut` proves that `self_md.env` is valid and not aliased. It is not
+            // accessed again after this point. It is wrapped inside `ManuallyDrop`, and will
+            // therefore not be dropped twice.
+            ptr::drop_in_place(&mut self_md.env);
+
+            // Move `obj` out of `self` and return it.
+            //
+            // Safety: The `&mut` proves that `self_md.obj` is valid and not aliased. It is not
+            // accessed again after this point. It is wrapped inside `ManuallyDrop`, and will
+            // therefore not be dropped after it is moved.
+            ptr::read(&*self_md.obj)
+        }
     }
 }
 
-impl<'a, 'b> Drop for AutoLocal<'a, 'b> {
+impl<'local, T> Drop for AutoLocal<'local, T>
+where
+    T: Into<JObject<'local>>,
+{
     fn drop(&mut self) {
-        let res = self.env.delete_local_ref(self.obj);
+        // Extract the local reference from `self.obj` so that we can delete it.
+        //
+        // This is needed because it is not allowed to move out of `self` during drop. A safe
+        // alternative would be to wrap `self.obj` in `Option`, but that would incur a run-time
+        // performance penalty from constantly checking if it's `None`.
+        //
+        // Safety: `self.obj` is not used again after this `take` call.
+        let obj = unsafe { ManuallyDrop::take(&mut self.obj) };
+
+        // Delete the extracted local reference.
+        let res = self.env.delete_local_ref(obj);
         match res {
             Ok(()) => {}
             Err(e) => debug!("error dropping global ref: {:#?}", e),
@@ -73,8 +117,40 @@ impl<'a, 'b> Drop for AutoLocal<'a, 'b> {
     }
 }
 
-impl<'a> From<&'a AutoLocal<'a, '_>> for JObject<'a> {
-    fn from(other: &'a AutoLocal) -> JObject<'a> {
-        other.as_obj()
+impl<'local, T, U> AsRef<U> for AutoLocal<'local, T>
+where
+    T: AsRef<U> + Into<JObject<'local>>,
+{
+    fn as_ref(&self) -> &U {
+        self.obj.as_ref()
+    }
+}
+
+impl<'local, T, U> AsMut<U> for AutoLocal<'local, T>
+where
+    T: AsMut<U> + Into<JObject<'local>>,
+{
+    fn as_mut(&mut self) -> &mut U {
+        self.obj.as_mut()
+    }
+}
+
+impl<'local, T> Deref for AutoLocal<'local, T>
+where
+    T: Into<JObject<'local>>,
+{
+    type Target = T;
+
+    fn deref(&self) -> &Self::Target {
+        &self.obj
+    }
+}
+
+impl<'local, T> DerefMut for AutoLocal<'local, T>
+where
+    T: Into<JObject<'local>>,
+{
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.obj
     }
 }

--- a/src/wrapper/objects/jbytebuffer.rs
+++ b/src/wrapper/objects/jbytebuffer.rs
@@ -3,36 +3,55 @@ use crate::{objects::JObject, sys::jobject};
 /// Lifetime'd representation of a `jobject` that is an instance of the
 /// ByteBuffer Java class. Just a `JObject` wrapped in a new class.
 #[repr(transparent)]
-#[derive(Clone, Copy, Debug)]
-pub struct JByteBuffer<'a>(JObject<'a>);
+#[derive(Debug)]
+pub struct JByteBuffer<'local>(JObject<'local>);
 
-impl<'a> ::std::ops::Deref for JByteBuffer<'a> {
-    type Target = JObject<'a>;
+impl<'local> AsRef<JByteBuffer<'local>> for JByteBuffer<'local> {
+    fn as_ref(&self) -> &JByteBuffer<'local> {
+        self
+    }
+}
+
+impl<'local> AsRef<JObject<'local>> for JByteBuffer<'local> {
+    fn as_ref(&self) -> &JObject<'local> {
+        self
+    }
+}
+
+impl<'local> ::std::ops::Deref for JByteBuffer<'local> {
+    type Target = JObject<'local>;
 
     fn deref(&self) -> &Self::Target {
         &self.0
     }
 }
 
-impl<'a> From<JByteBuffer<'a>> for JObject<'a> {
+impl<'local> From<JByteBuffer<'local>> for JObject<'local> {
     fn from(other: JByteBuffer) -> JObject {
         other.0
     }
 }
 
-impl<'a> From<JObject<'a>> for JByteBuffer<'a> {
+impl<'local> From<JObject<'local>> for JByteBuffer<'local> {
     fn from(other: JObject) -> Self {
         unsafe { Self::from_raw(other.into_raw()) }
     }
 }
 
-impl<'a> std::default::Default for JByteBuffer<'a> {
+impl<'local, 'obj_ref> From<&'obj_ref JObject<'local>> for &'obj_ref JByteBuffer<'local> {
+    fn from(other: &'obj_ref JObject<'local>) -> Self {
+        // Safety: `JByteBuffer` is `repr(transparent)` around `JObject`.
+        unsafe { &*(other as *const JObject<'local> as *const JByteBuffer<'local>) }
+    }
+}
+
+impl<'local> std::default::Default for JByteBuffer<'local> {
     fn default() -> Self {
         Self(JObject::null())
     }
 }
 
-impl<'a> JByteBuffer<'a> {
+impl<'local> JByteBuffer<'local> {
     /// Creates a [`JByteBuffer`] that wraps the given `raw` [`jobject`]
     ///
     /// # Safety

--- a/src/wrapper/objects/jclass.rs
+++ b/src/wrapper/objects/jclass.rs
@@ -6,37 +6,57 @@ use crate::{
 /// Lifetime'd representation of a `jclass`. Just a `JObject` wrapped in a new
 /// class.
 #[repr(transparent)]
-#[derive(Clone, Copy, Debug)]
-pub struct JClass<'a>(JObject<'a>);
+#[derive(Debug)]
+pub struct JClass<'local>(JObject<'local>);
 
-impl<'a> ::std::ops::Deref for JClass<'a> {
-    type Target = JObject<'a>;
+impl<'local> AsRef<JClass<'local>> for JClass<'local> {
+    fn as_ref(&self) -> &JClass<'local> {
+        self
+    }
+}
+
+impl<'local> AsRef<JObject<'local>> for JClass<'local> {
+    fn as_ref(&self) -> &JObject<'local> {
+        self
+    }
+}
+
+impl<'local> ::std::ops::Deref for JClass<'local> {
+    type Target = JObject<'local>;
 
     fn deref(&self) -> &Self::Target {
         &self.0
     }
 }
 
-impl<'a> From<JClass<'a>> for JObject<'a> {
+impl<'local> From<JClass<'local>> for JObject<'local> {
     fn from(other: JClass) -> JObject {
         other.0
     }
 }
 
 /// This conversion assumes that the `JObject` is a pointer to a class object.
-impl<'a> From<JObject<'a>> for JClass<'a> {
+impl<'local> From<JObject<'local>> for JClass<'local> {
     fn from(other: JObject) -> Self {
         unsafe { Self::from_raw(other.into_raw()) }
     }
 }
 
-impl<'a> std::default::Default for JClass<'a> {
+/// This conversion assumes that the `JObject` is a pointer to a class object.
+impl<'local, 'obj_ref> From<&'obj_ref JObject<'local>> for &'obj_ref JClass<'local> {
+    fn from(other: &'obj_ref JObject<'local>) -> Self {
+        // Safety: `JClass` is `repr(transparent)` around `JObject`.
+        unsafe { &*(other as *const JObject<'local> as *const JClass<'local>) }
+    }
+}
+
+impl<'local> std::default::Default for JClass<'local> {
     fn default() -> Self {
         Self(JObject::null())
     }
 }
 
-impl<'a> JClass<'a> {
+impl<'local> JClass<'local> {
     /// Creates a [`JClass`] that wraps the given `raw` [`jclass`]
     ///
     /// # Safety

--- a/src/wrapper/objects/jfieldid.rs
+++ b/src/wrapper/objects/jfieldid.rs
@@ -46,3 +46,15 @@ impl JFieldID {
         self.internal
     }
 }
+
+impl AsRef<JFieldID> for JFieldID {
+    fn as_ref(&self) -> &JFieldID {
+        self
+    }
+}
+
+impl AsMut<JFieldID> for JFieldID {
+    fn as_mut(&mut self) -> &mut JFieldID {
+        self
+    }
+}

--- a/src/wrapper/objects/jlist.rs
+++ b/src/wrapper/objects/jlist.rs
@@ -1,46 +1,53 @@
 use crate::{
     errors::*,
-    objects::{JMethodID, JObject, JValue},
+    objects::{AutoLocal, JClass, JMethodID, JObject, JValue},
     signature::{Primitive, ReturnType},
     sys::jint,
     JNIEnv,
 };
+
+use std::marker::PhantomData;
 
 /// Wrapper for JObjects that implement `java/util/List`. Provides methods to get,
 /// add, and remove elements.
 ///
 /// Looks up the class and method ids on creation rather than for every method
 /// call.
-pub struct JList<'a: 'b, 'b> {
-    internal: JObject<'a>,
+pub struct JList<'local, 'other_local_1: 'obj_ref, 'obj_ref> {
+    internal: &'obj_ref JObject<'other_local_1>,
+    _phantom_class: PhantomData<AutoLocal<'local, JClass<'local>>>,
     get: JMethodID,
     add: JMethodID,
     add_idx: JMethodID,
     remove: JMethodID,
     size: JMethodID,
-    env: &'b JNIEnv<'a>,
 }
 
-impl<'a: 'b, 'b> ::std::ops::Deref for JList<'a, 'b> {
-    type Target = JObject<'a>;
-
-    fn deref(&self) -> &Self::Target {
-        &self.internal
+impl<'local, 'other_local_1: 'obj_ref, 'obj_ref> AsRef<JList<'local, 'other_local_1, 'obj_ref>>
+    for JList<'local, 'other_local_1, 'obj_ref>
+{
+    fn as_ref(&self) -> &JList<'local, 'other_local_1, 'obj_ref> {
+        self
     }
 }
 
-impl<'a: 'b, 'b> From<JList<'a, 'b>> for JObject<'a> {
-    fn from(other: JList<'a, 'b>) -> JObject<'a> {
-        other.internal
+impl<'local, 'other_local_1: 'obj_ref, 'obj_ref> AsRef<JObject<'other_local_1>>
+    for JList<'local, 'other_local_1, 'obj_ref>
+{
+    fn as_ref(&self) -> &JObject<'other_local_1> {
+        self.internal
     }
 }
 
-impl<'a: 'b, 'b> JList<'a, 'b> {
+impl<'local, 'other_local_1: 'obj_ref, 'obj_ref> JList<'local, 'other_local_1, 'obj_ref> {
     /// Create a map from the environment and an object. This looks up the
     /// necessary class and method ids to call all of the methods on it so that
     /// exra work doesn't need to be done on every method call.
-    pub fn from_env(env: &'b JNIEnv<'a>, obj: JObject<'a>) -> Result<JList<'a, 'b>> {
-        let class = env.auto_local(env.find_class("java/util/List")?);
+    pub fn from_env(
+        env: &mut JNIEnv<'local>,
+        obj: &'obj_ref JObject<'other_local_1>,
+    ) -> Result<JList<'local, 'other_local_1, 'obj_ref>> {
+        let class = AutoLocal::new(env.find_class("java/util/List")?, env);
 
         let get = env.get_method_id(&class, "get", "(I)Ljava/lang/Object;")?;
         let add = env.get_method_id(&class, "add", "(Ljava/lang/Object;)Z")?;
@@ -50,26 +57,30 @@ impl<'a: 'b, 'b> JList<'a, 'b> {
 
         Ok(JList {
             internal: obj,
+            _phantom_class: PhantomData,
             get,
             add,
             add_idx,
             remove,
             size,
-            env,
         })
     }
 
     /// Look up the value for a key. Returns `Some` if it's found and `None` if
     /// a null pointer would be returned.
-    pub fn get(&self, idx: jint) -> Result<Option<JObject<'a>>> {
+    pub fn get<'other_local_2>(
+        &self,
+        env: &mut JNIEnv<'other_local_2>,
+        idx: jint,
+    ) -> Result<Option<JObject<'other_local_2>>> {
         // SAFETY: We keep the class loaded, and fetched the method ID for this function.
         // Provided argument is statically known as a JObject/null, rather than another primitive type.
         let result = unsafe {
-            self.env.call_method_unchecked(
+            env.call_method_unchecked(
                 self.internal,
                 self.get,
                 ReturnType::Object,
-                &[JValue::from(idx).to_jni()],
+                &[JValue::from(idx).as_jni()],
             )
         };
 
@@ -83,15 +94,15 @@ impl<'a: 'b, 'b> JList<'a, 'b> {
     }
 
     /// Append an element to the list
-    pub fn add(&self, value: JObject<'a>) -> Result<()> {
+    pub fn add(&self, env: &mut JNIEnv, value: &JObject) -> Result<()> {
         // SAFETY: We keep the class loaded, and fetched the method ID for this function.
         // Provided argument is statically known as a JObject/null, rather than another primitive type.
         let result = unsafe {
-            self.env.call_method_unchecked(
+            env.call_method_unchecked(
                 self.internal,
                 self.add,
                 ReturnType::Primitive(Primitive::Boolean),
-                &[JValue::from(value).to_jni()],
+                &[JValue::from(value).as_jni()],
             )
         };
 
@@ -100,15 +111,15 @@ impl<'a: 'b, 'b> JList<'a, 'b> {
     }
 
     /// Insert an element at a specific index
-    pub fn insert(&self, idx: jint, value: JObject<'a>) -> Result<()> {
+    pub fn insert(&self, env: &mut JNIEnv, idx: jint, value: &JObject) -> Result<()> {
         // SAFETY: We keep the class loaded, and fetched the method ID for this function.
         // Provided argument is statically known as a JObject/null, rather than another primitive type.
         let result = unsafe {
-            self.env.call_method_unchecked(
+            env.call_method_unchecked(
                 self.internal,
                 self.add_idx,
                 ReturnType::Primitive(Primitive::Void),
-                &[JValue::from(idx).to_jni(), JValue::from(value).to_jni()],
+                &[JValue::from(idx).as_jni(), JValue::from(value).as_jni()],
             )
         };
 
@@ -117,15 +128,19 @@ impl<'a: 'b, 'b> JList<'a, 'b> {
     }
 
     /// Remove an element from the list by index
-    pub fn remove(&self, idx: jint) -> Result<Option<JObject<'a>>> {
+    pub fn remove<'other_local_2>(
+        &self,
+        env: &mut JNIEnv<'other_local_2>,
+        idx: jint,
+    ) -> Result<Option<JObject<'other_local_2>>> {
         // SAFETY: We keep the class loaded, and fetched the method ID for this function.
         // Provided argument is statically known as a int, rather than any other java type.
         let result = unsafe {
-            self.env.call_method_unchecked(
+            env.call_method_unchecked(
                 self.internal,
                 self.remove,
                 ReturnType::Object,
-                &[JValue::from(idx).to_jni()],
+                &[JValue::from(idx).as_jni()],
             )
         };
 
@@ -139,10 +154,10 @@ impl<'a: 'b, 'b> JList<'a, 'b> {
     }
 
     /// Get the size of the list
-    pub fn size(&self) -> Result<jint> {
+    pub fn size(&self, env: &mut JNIEnv) -> Result<jint> {
         // SAFETY: We keep the class loaded, and fetched the method ID for this function.
         let result = unsafe {
-            self.env.call_method_unchecked(
+            env.call_method_unchecked(
                 self.internal,
                 self.size,
                 ReturnType::Primitive(Primitive::Int),
@@ -156,8 +171,11 @@ impl<'a: 'b, 'b> JList<'a, 'b> {
     /// Pop the last element from the list
     ///
     /// Note that this calls `size()` to determine the last index.
-    pub fn pop(&self) -> Result<Option<JObject<'a>>> {
-        let size = self.size()?;
+    pub fn pop<'other_local_2>(
+        &self,
+        env: &mut JNIEnv<'other_local_2>,
+    ) -> Result<Option<JObject<'other_local_2>>> {
+        let size = self.size(env)?;
         if size == 0 {
             return Ok(None);
         }
@@ -165,11 +183,11 @@ impl<'a: 'b, 'b> JList<'a, 'b> {
         // SAFETY: We keep the class loaded, and fetched the method ID for this function.
         // Provided argument is statically known as a int.
         let result = unsafe {
-            self.env.call_method_unchecked(
+            env.call_method_unchecked(
                 self.internal,
                 self.remove,
                 ReturnType::Object,
-                &[JValue::from(size - 1).to_jni()],
+                &[JValue::from(size - 1).as_jni()],
             )
         };
 
@@ -184,42 +202,98 @@ impl<'a: 'b, 'b> JList<'a, 'b> {
 
     /// Get key/value iterator for the map. This is done by getting the
     /// `EntrySet` from java and iterating over it.
-    pub fn iter(&self) -> Result<JListIter<'a, 'b, '_>> {
+    ///
+    /// The returned iterator does not implement [`std::iter::Iterator`] and
+    /// cannot be used with a `for` loop. This is because its `next` method
+    /// uses a `&mut JNIEnv` to call the Java iterator. Use a `while let` loop
+    /// instead:
+    ///
+    /// ```rust,no_run
+    /// # use jni::{errors::Result, JNIEnv, objects::{AutoLocal, JList, JObject}};
+    /// #
+    /// # fn example(env: &mut JNIEnv, list: JList) -> Result<()> {
+    /// let mut iterator = list.iter(env)?;
+    ///
+    /// while let Some(obj) = iterator.next(env)? {
+    ///     let obj: AutoLocal<JObject> = env.auto_local(obj);
+    ///
+    ///     // Do something with `obj` here.
+    /// }
+    /// # Ok(())
+    /// # }
+    /// ```
+    ///
+    /// Each call to `next` creates a new local reference. To prevent excessive
+    /// memory usage or overflow error, the local reference should be deleted
+    /// using [`JNIEnv::delete_local_ref`] or [`JNIEnv::auto_local`] before the
+    /// next loop iteration. Alternatively, if the list is known to have a
+    /// small, predictable size, the loop could be wrapped in
+    /// [`JNIEnv::with_local_frame`] to delete all of the local references at
+    /// once.
+    pub fn iter<'list>(
+        &'list self,
+        env: &mut JNIEnv,
+    ) -> Result<JListIter<'list, 'local, 'obj_ref, 'other_local_1>> {
         Ok(JListIter {
             list: self,
             current: 0,
-            size: self.size()?,
+            size: self.size(env)?,
         })
     }
 }
 
-/// An iterator over the keys and values in a map.
+/// An iterator over the keys and values in a `java.util.List`. See
+/// [`JList::iter`] for more information.
 ///
 /// TODO: make the iterator implementation for java iterators its own thing
 /// and generic enough to use elsewhere.
-pub struct JListIter<'a: 'b, 'b: 'c, 'c> {
-    list: &'c JList<'a, 'b>,
+pub struct JListIter<'list, 'local, 'other_local_1: 'obj_ref, 'obj_ref> {
+    list: &'list JList<'local, 'other_local_1, 'obj_ref>,
     current: jint,
     size: jint,
 }
 
-impl<'a: 'b, 'b: 'c, 'c> Iterator for JListIter<'a, 'b, 'c> {
-    type Item = JObject<'a>;
-
-    fn next(&mut self) -> Option<Self::Item> {
+impl<'list, 'local, 'other_local_1: 'obj_ref, 'obj_ref>
+    JListIter<'list, 'local, 'other_local_1, 'obj_ref>
+{
+    /// Advances the iterator and returns the next object in the
+    /// `java.util.List`, or `None` if there are no more objects.
+    ///
+    /// See [`JList::iter`] for more information.
+    ///
+    /// This method creates a new local reference. To prevent excessive memory
+    /// usage or overflow error, the local reference should be deleted using
+    /// [`JNIEnv::delete_local_ref`] or [`JNIEnv::auto_local`] before the next
+    /// loop iteration. Alternatively, if the list is known to have a small,
+    /// predictable size, the loop could be wrapped in
+    /// [`JNIEnv::with_local_frame`] to delete all of the local references at
+    /// once.
+    ///
+    /// This method returns:
+    ///
+    /// * `Ok(Some(_))`: if there was another object in the list.
+    /// * `Ok(None)`: if there are no more objects in the list.
+    /// * `Err(_)`: if there was an error calling the Java method to
+    ///   get the next object.
+    ///
+    /// This is like [`std::iter::Iterator::next`], but requires a parameter of
+    /// type `&mut JNIEnv` in order to call into Java.
+    pub fn next<'other_local_2>(
+        &mut self,
+        env: &mut JNIEnv<'other_local_2>,
+    ) -> Result<Option<JObject<'other_local_2>>> {
         if self.current == self.size {
-            return None;
+            return Ok(None);
         }
-        let res = self.list.get(self.current);
-        match res {
-            Ok(elem) => {
-                self.current += 1;
-                elem
-            }
-            Err(_) => {
-                self.current = self.size;
-                None
-            }
-        }
+
+        let res = self.list.get(env, self.current);
+
+        self.current = match &res {
+            Ok(Some(_)) => self.current + 1,
+            Ok(None) => self.current,
+            Err(_) => self.size,
+        };
+
+        res
     }
 }

--- a/src/wrapper/objects/jmap.rs
+++ b/src/wrapper/objects/jmap.rs
@@ -1,44 +1,50 @@
 use crate::{
     errors::*,
-    objects::{AutoLocal, JMethodID, JObject, JValue},
+    objects::{AutoLocal, JClass, JMethodID, JObject, JValue},
     signature::{Primitive, ReturnType},
     JNIEnv,
 };
+
+use std::marker::PhantomData;
 
 /// Wrapper for JObjects that implement `java/util/Map`. Provides methods to get
 /// and set entries and a way to iterate over key/value pairs.
 ///
 /// Looks up the class and method ids on creation rather than for every method
 /// call.
-pub struct JMap<'a: 'b, 'b> {
-    internal: JObject<'a>,
-    class: AutoLocal<'a, 'b>,
+pub struct JMap<'local, 'other_local_1: 'obj_ref, 'obj_ref> {
+    internal: &'obj_ref JObject<'other_local_1>,
+    class: AutoLocal<'local, JClass<'local>>,
     get: JMethodID,
     put: JMethodID,
     remove: JMethodID,
-    env: &'b JNIEnv<'a>,
 }
 
-impl<'a: 'b, 'b> ::std::ops::Deref for JMap<'a, 'b> {
-    type Target = JObject<'a>;
-
-    fn deref(&self) -> &Self::Target {
-        &self.internal
+impl<'local, 'other_local_1: 'obj_ref, 'obj_ref> AsRef<JMap<'local, 'other_local_1, 'obj_ref>>
+    for JMap<'local, 'other_local_1, 'obj_ref>
+{
+    fn as_ref(&self) -> &JMap<'local, 'other_local_1, 'obj_ref> {
+        self
     }
 }
 
-impl<'a: 'b, 'b> From<JMap<'a, 'b>> for JObject<'a> {
-    fn from(other: JMap<'a, 'b>) -> JObject<'a> {
-        other.internal
+impl<'local, 'other_local_1: 'obj_ref, 'obj_ref> AsRef<JObject<'other_local_1>>
+    for JMap<'local, 'other_local_1, 'obj_ref>
+{
+    fn as_ref(&self) -> &JObject<'other_local_1> {
+        self.internal
     }
 }
 
-impl<'a: 'b, 'b> JMap<'a, 'b> {
+impl<'local, 'other_local_1: 'obj_ref, 'obj_ref> JMap<'local, 'other_local_1, 'obj_ref> {
     /// Create a map from the environment and an object. This looks up the
     /// necessary class and method ids to call all of the methods on it so that
     /// exra work doesn't need to be done on every method call.
-    pub fn from_env(env: &'b JNIEnv<'a>, obj: JObject<'a>) -> Result<JMap<'a, 'b>> {
-        let class = env.auto_local(env.find_class("java/util/Map")?);
+    pub fn from_env(
+        env: &mut JNIEnv<'local>,
+        obj: &'obj_ref JObject<'other_local_1>,
+    ) -> Result<JMap<'local, 'other_local_1, 'obj_ref>> {
+        let class = AutoLocal::new(env.find_class("java/util/Map")?, env);
 
         let get = env.get_method_id(&class, "get", "(Ljava/lang/Object;)Ljava/lang/Object;")?;
         let put = env.get_method_id(
@@ -57,21 +63,24 @@ impl<'a: 'b, 'b> JMap<'a, 'b> {
             get,
             put,
             remove,
-            env,
         })
     }
 
     /// Look up the value for a key. Returns `Some` if it's found and `None` if
     /// a null pointer would be returned.
-    pub fn get(&self, key: JObject<'a>) -> Result<Option<JObject<'a>>> {
+    pub fn get<'other_local_2>(
+        &self,
+        env: &mut JNIEnv<'other_local_2>,
+        key: &JObject,
+    ) -> Result<Option<JObject<'other_local_2>>> {
         // SAFETY: We keep the class loaded, and fetched the method ID for this function.
         // Provided argument is statically known as a JObject/null, rather than another primitive type.
         let result = unsafe {
-            self.env.call_method_unchecked(
+            env.call_method_unchecked(
                 self.internal,
                 self.get,
                 ReturnType::Object,
-                &[JValue::from(key).to_jni()],
+                &[JValue::from(key).as_jni()],
             )
         };
 
@@ -86,15 +95,20 @@ impl<'a: 'b, 'b> JMap<'a, 'b> {
 
     /// Look up the value for a key. Returns `Some` with the old value if the
     /// key already existed and `None` if it's a new key.
-    pub fn put(&self, key: JObject<'a>, value: JObject<'a>) -> Result<Option<JObject<'a>>> {
+    pub fn put<'other_local_2>(
+        &self,
+        env: &mut JNIEnv<'other_local_2>,
+        key: &JObject,
+        value: &JObject,
+    ) -> Result<Option<JObject<'other_local_2>>> {
         // SAFETY: We keep the class loaded, and fetched the method ID for this function.
         // Provided argument is statically known as a JObject/null, rather than another primitive type.
         let result = unsafe {
-            self.env.call_method_unchecked(
+            env.call_method_unchecked(
                 self.internal,
                 self.put,
                 ReturnType::Object,
-                &[JValue::from(key).to_jni(), JValue::from(value).to_jni()],
+                &[JValue::from(key).as_jni(), JValue::from(value).as_jni()],
             )
         };
 
@@ -109,15 +123,19 @@ impl<'a: 'b, 'b> JMap<'a, 'b> {
 
     /// Remove a value from the map. Returns `Some` with the removed value and
     /// `None` if there was no value for the key.
-    pub fn remove(&self, key: JObject<'a>) -> Result<Option<JObject<'a>>> {
+    pub fn remove<'other_local_2>(
+        &self,
+        env: &mut JNIEnv<'other_local_2>,
+        key: &JObject,
+    ) -> Result<Option<JObject<'other_local_2>>> {
         // SAFETY: We keep the class loaded, and fetched the method ID for this function.
         // Provided argument is statically known as a JObject/null, rather than another primitive type.
         let result = unsafe {
-            self.env.call_method_unchecked(
+            env.call_method_unchecked(
                 self.internal,
                 self.remove,
                 ReturnType::Object,
-                &[JValue::from(key).to_jni()],
+                &[JValue::from(key).as_jni()],
             )
         };
 
@@ -132,36 +150,58 @@ impl<'a: 'b, 'b> JMap<'a, 'b> {
 
     /// Get key/value iterator for the map. This is done by getting the
     /// `EntrySet` from java and iterating over it.
-    pub fn iter(&self) -> Result<JMapIter<'a, 'b, '_>> {
-        let iter_class = self
-            .env
-            .auto_local(self.env.find_class("java/util/Iterator")?);
+    ///
+    /// The returned iterator does not implement [`std::iter::Iterator`] and
+    /// cannot be used with a `for` loop. This is because its `next` method
+    /// uses a `&mut JNIEnv` to call the Java iterator. Use a `while let` loop
+    /// instead:
+    ///
+    /// ```rust,no_run
+    /// # use jni::{errors::Result, JNIEnv, objects::{AutoLocal, JMap, JObject}};
+    /// #
+    /// # fn example(env: &mut JNIEnv, map: JMap) -> Result<()> {
+    /// let mut iterator = map.iter(env)?;
+    ///
+    /// while let Some((key, value)) = iterator.next(env)? {
+    ///     let key: AutoLocal<JObject> = env.auto_local(key);
+    ///     let value: AutoLocal<JObject> = env.auto_local(value);
+    ///
+    ///     // Do something with `key` and `value` here.
+    /// }
+    /// # Ok(())
+    /// # }
+    /// ```
+    ///
+    /// Each call to `next` creates two new local references. To prevent
+    /// excessive memory usage or overflow error, the local references should
+    /// be deleted using [`JNIEnv::delete_local_ref`] or [`JNIEnv::auto_local`]
+    /// before the next loop iteration. Alternatively, if the map is known to
+    /// have a small, predictable size, the loop could be wrapped in
+    /// [`JNIEnv::with_local_frame`] to delete all of the local references at
+    /// once.
+    pub fn iter<'map, 'iter_local>(
+        &'map self,
+        env: &mut JNIEnv<'iter_local>,
+    ) -> Result<JMapIter<'map, 'local, 'other_local_1, 'obj_ref, 'iter_local>> {
+        let iter_class = AutoLocal::new(env.find_class("java/util/Iterator")?, env);
 
-        let has_next = self.env.get_method_id(&iter_class, "hasNext", "()Z")?;
+        let has_next = env.get_method_id(&iter_class, "hasNext", "()Z")?;
 
-        let next = self
-            .env
-            .get_method_id(&iter_class, "next", "()Ljava/lang/Object;")?;
+        let next = env.get_method_id(&iter_class, "next", "()Ljava/lang/Object;")?;
 
-        let entry_class = self
-            .env
-            .auto_local(self.env.find_class("java/util/Map$Entry")?);
+        let entry_class = AutoLocal::new(env.find_class("java/util/Map$Entry")?, env);
 
-        let get_key = self
-            .env
-            .get_method_id(&entry_class, "getKey", "()Ljava/lang/Object;")?;
+        let get_key = env.get_method_id(&entry_class, "getKey", "()Ljava/lang/Object;")?;
 
-        let get_value = self
-            .env
-            .get_method_id(&entry_class, "getValue", "()Ljava/lang/Object;")?;
+        let get_value = env.get_method_id(&entry_class, "getValue", "()Ljava/lang/Object;")?;
 
         // Get the iterator over Map entries.
         // Use the local frame till #109 is resolved, so that implicitly looked-up
         // classes are freed promptly.
-        let iter = self.env.with_local_frame(16, || {
+        let iter = env.with_local_frame(16, |env| {
             // SAFETY: We keep the class loaded, and fetched the method ID for this function. Arg list is known empty.
             let entry_set = unsafe {
-                self.env.call_method_unchecked(
+                env.call_method_unchecked(
                     self.internal,
                     (&self.class, "entrySet", "()Ljava/util/Set;"),
                     ReturnType::Object,
@@ -172,7 +212,7 @@ impl<'a: 'b, 'b> JMap<'a, 'b> {
 
             // SAFETY: We keep the class loaded, and fetched the method ID for this function. Arg list is known empty.
             let iter = unsafe {
-                self.env.call_method_unchecked(
+                env.call_method_unchecked(
                     entry_set,
                     ("java/util/Set", "iterator", "()Ljava/util/Iterator;"),
                     ReturnType::Object,
@@ -183,10 +223,10 @@ impl<'a: 'b, 'b> JMap<'a, 'b> {
 
             Ok(iter)
         })?;
-        let iter = self.env.auto_local(iter);
+        let iter = env.auto_local(iter);
 
         Ok(JMapIter {
-            map: self,
+            _phantom_map: PhantomData,
             has_next,
             next,
             get_key,
@@ -196,27 +236,54 @@ impl<'a: 'b, 'b> JMap<'a, 'b> {
     }
 }
 
-/// An iterator over the keys and values in a map.
+/// An iterator over the keys and values in a map. See [`JMap::iter`] for more
+/// information.
 ///
 /// TODO: make the iterator implementation for java iterators its own thing
 /// and generic enough to use elsewhere.
-pub struct JMapIter<'a, 'b, 'c> {
-    map: &'c JMap<'a, 'b>,
+pub struct JMapIter<'map, 'local, 'other_local_1: 'obj_ref, 'obj_ref, 'iter_local> {
+    _phantom_map: PhantomData<&'map JMap<'local, 'other_local_1, 'obj_ref>>,
     has_next: JMethodID,
     next: JMethodID,
     get_key: JMethodID,
     get_value: JMethodID,
-    iter: AutoLocal<'a, 'b>,
+    iter: AutoLocal<'iter_local, JObject<'iter_local>>,
 }
 
-impl<'a: 'b, 'b: 'c, 'c> JMapIter<'a, 'b, 'c> {
-    fn get_next(&self) -> Result<Option<(JObject<'a>, JObject<'a>)>> {
+impl<'map, 'local, 'other_local_1: 'obj_ref, 'obj_ref, 'iter_local>
+    JMapIter<'map, 'local, 'other_local_1, 'obj_ref, 'iter_local>
+{
+    /// Advances the iterator and returns the next key-value pair in the
+    /// `java.util.Map`, or `None` if there are no more objects.
+    ///
+    /// See [`JMap::iter`] for more information.
+    ///
+    /// This method creates two new local references. To prevent excessive
+    /// memory usage or overflow error, the local references should be deleted
+    /// using [`JNIEnv::delete_local_ref`] or [`JNIEnv::auto_local`] before the
+    /// next loop iteration. Alternatively, if the map is known to have a
+    /// small, predictable size, the loop could be wrapped in
+    /// [`JNIEnv::with_local_frame`] to delete all of the local references at
+    /// once.
+    ///
+    /// This method returns:
+    ///
+    /// * `Ok(Some(_))`: if there was another key-value pair in the map.
+    /// * `Ok(None)`: if there are no more key-value pairs in the map.
+    /// * `Err(_)`: if there was an error calling the Java method to
+    ///   get the next key-value pair.
+    ///
+    /// This is like [`std::iter::Iterator::next`], but requires a parameter of
+    /// type `&mut JNIEnv` in order to call into Java.
+    pub fn next<'other_local_2>(
+        &mut self,
+        env: &mut JNIEnv<'other_local_2>,
+    ) -> Result<Option<(JObject<'other_local_2>, JObject<'other_local_2>)>> {
         // SAFETY: We keep the class loaded, and fetched the method ID for these functions. We know none expect args.
 
-        let iter = self.iter.as_obj();
         let has_next = unsafe {
-            self.map.env.call_method_unchecked(
-                iter,
+            env.call_method_unchecked(
+                &self.iter,
                 self.has_next,
                 ReturnType::Primitive(Primitive::Boolean),
                 &[],
@@ -227,38 +294,19 @@ impl<'a: 'b, 'b: 'c, 'c> JMapIter<'a, 'b, 'c> {
         if !has_next {
             return Ok(None);
         }
-        let next = unsafe {
-            self.map
-                .env
-                .call_method_unchecked(iter, self.next, ReturnType::Object, &[])
-        }?
-        .l()?;
+        let next =
+            unsafe { env.call_method_unchecked(&self.iter, self.next, ReturnType::Object, &[]) }?
+                .l()?;
+        let next = env.auto_local(next);
 
-        let key = unsafe {
-            self.map
-                .env
-                .call_method_unchecked(next, self.get_key, ReturnType::Object, &[])
-        }?
-        .l()?;
+        let key =
+            unsafe { env.call_method_unchecked(&next, self.get_key, ReturnType::Object, &[]) }?
+                .l()?;
 
-        let value = unsafe {
-            self.map
-                .env
-                .call_method_unchecked(next, self.get_value, ReturnType::Object, &[])
-        }?
-        .l()?;
+        let value =
+            unsafe { env.call_method_unchecked(&next, self.get_value, ReturnType::Object, &[]) }?
+                .l()?;
 
         Ok(Some((key, value)))
-    }
-}
-
-impl<'a: 'b, 'b: 'c, 'c> Iterator for JMapIter<'a, 'b, 'c> {
-    type Item = (JObject<'a>, JObject<'a>);
-
-    fn next(&mut self) -> Option<Self::Item> {
-        match self.get_next() {
-            Ok(Some(n)) => Some(n),
-            _ => None,
-        }
     }
 }

--- a/src/wrapper/objects/jmethodid.rs
+++ b/src/wrapper/objects/jmethodid.rs
@@ -46,3 +46,15 @@ impl JMethodID {
         self.internal
     }
 }
+
+impl AsRef<JMethodID> for JMethodID {
+    fn as_ref(&self) -> &JMethodID {
+        self
+    }
+}
+
+impl AsMut<JMethodID> for JMethodID {
+    fn as_mut(&mut self) -> &mut JMethodID {
+        self
+    }
+}

--- a/src/wrapper/objects/jobject.rs
+++ b/src/wrapper/objects/jobject.rs
@@ -2,6 +2,9 @@ use std::marker::PhantomData;
 
 use crate::sys::jobject;
 
+#[cfg(doc)]
+use crate::{objects::GlobalRef, JNIEnv};
+
 /// Wrapper around `sys::jobject` that adds a lifetime. This prevents it from
 /// outliving the context in which it was acquired and getting GC'd out from
 /// under us. It matches C's representation of the raw pointer, so it can be
@@ -10,14 +13,44 @@ use crate::sys::jobject;
 ///
 /// Most other types in the `objects` module deref to this, as they do in the C
 /// representation.
+///
+/// The lifetime `'local` represents the local reference frame that this
+/// reference belongs to. See the [`JNIEnv`] documentation for more information
+/// about local reference frames. If `'local` is `'static`, then this reference
+/// does not belong to a local reference frame, that is, it is either null or a
+/// [global reference][GlobalRef].
+///
+/// Note that an *owned* `JObject` is always a local reference and will never
+/// have the `'static` lifetime. [`GlobalRef`] does implement
+/// <code>[AsRef]&lt;JObject&lt;'static>></code>, but this only yields a
+/// *borrowed* `&JObject<'static>`, never an owned `JObject<'static>`.
+///
+/// Local references belong to a single thread and are not safe to share across
+/// threads. This type implements [`Send`] and [`Sync`] if and only if the
+/// lifetime `'local` is `'static`.
 #[repr(transparent)]
-#[derive(Clone, Copy, Debug)]
-pub struct JObject<'a> {
+#[derive(Debug)]
+pub struct JObject<'local> {
     internal: jobject,
-    lifetime: PhantomData<&'a ()>,
+    lifetime: PhantomData<&'local ()>,
 }
 
-impl<'a> ::std::ops::Deref for JObject<'a> {
+unsafe impl Send for JObject<'static> {}
+unsafe impl Sync for JObject<'static> {}
+
+impl<'local> AsRef<JObject<'local>> for JObject<'local> {
+    fn as_ref(&self) -> &JObject<'local> {
+        self
+    }
+}
+
+impl<'local> AsMut<JObject<'local>> for JObject<'local> {
+    fn as_mut(&mut self) -> &mut JObject<'local> {
+        self
+    }
+}
+
+impl<'local> ::std::ops::Deref for JObject<'local> {
     type Target = jobject;
 
     fn deref(&self) -> &Self::Target {
@@ -25,12 +58,17 @@ impl<'a> ::std::ops::Deref for JObject<'a> {
     }
 }
 
-impl<'a> JObject<'a> {
+impl<'local> JObject<'local> {
     /// Creates a [`JObject`] that wraps the given `raw` [`jobject`]
     ///
     /// # Safety
     ///
-    /// Expects a valid pointer or `null`
+    /// `raw` may be a null pointer. If `raw` is not a null pointer, then:
+    ///
+    /// * `raw` must be a valid raw JNI local reference.
+    /// * There must not be any other `JObject` representing the same local reference.
+    /// * The lifetime `'local` must not outlive the local reference frame that the local reference
+    ///   was created in.
     pub unsafe fn from_raw(raw: jobject) -> Self {
         Self {
             internal: raw,
@@ -38,18 +76,26 @@ impl<'a> JObject<'a> {
         }
     }
 
+    /// Returns the raw JNI pointer.
+    pub fn as_raw(&self) -> jobject {
+        self.internal
+    }
+
     /// Unwrap to the internal jni type.
     pub fn into_raw(self) -> jobject {
         self.internal
     }
 
-    /// Creates a new null object
-    pub fn null() -> JObject<'a> {
-        unsafe { Self::from_raw(std::ptr::null_mut() as jobject) }
+    /// Creates a new null reference.
+    ///
+    /// Null references are always valid and do not belong to a local reference frame. Therefore,
+    /// the returned `JObject` always has the `'static` lifetime.
+    pub fn null() -> JObject<'static> {
+        unsafe { JObject::from_raw(std::ptr::null_mut() as jobject) }
     }
 }
 
-impl<'a> std::default::Default for JObject<'a> {
+impl<'local> std::default::Default for JObject<'local> {
     fn default() -> Self {
         Self::null()
     }

--- a/src/wrapper/objects/jstaticfieldid.rs
+++ b/src/wrapper/objects/jstaticfieldid.rs
@@ -46,3 +46,15 @@ impl JStaticFieldID {
         self.internal
     }
 }
+
+impl AsRef<JStaticFieldID> for JStaticFieldID {
+    fn as_ref(&self) -> &JStaticFieldID {
+        self
+    }
+}
+
+impl AsMut<JStaticFieldID> for JStaticFieldID {
+    fn as_mut(&mut self) -> &mut JStaticFieldID {
+        self
+    }
+}

--- a/src/wrapper/objects/jstaticmethodid.rs
+++ b/src/wrapper/objects/jstaticmethodid.rs
@@ -46,3 +46,15 @@ impl JStaticMethodID {
         self.internal
     }
 }
+
+impl AsRef<JStaticMethodID> for JStaticMethodID {
+    fn as_ref(&self) -> &JStaticMethodID {
+        self
+    }
+}
+
+impl AsMut<JStaticMethodID> for JStaticMethodID {
+    fn as_mut(&mut self) -> &mut JStaticMethodID {
+        self
+    }
+}

--- a/src/wrapper/objects/jstring.rs
+++ b/src/wrapper/objects/jstring.rs
@@ -6,36 +6,54 @@ use crate::{
 /// Lifetime'd representation of a `jstring`. Just a `JObject` wrapped in a new
 /// class.
 #[repr(transparent)]
-#[derive(Clone, Copy)]
-pub struct JString<'a>(JObject<'a>);
+pub struct JString<'local>(JObject<'local>);
 
-impl<'a> ::std::ops::Deref for JString<'a> {
-    type Target = JObject<'a>;
+impl<'local> AsRef<JString<'local>> for JString<'local> {
+    fn as_ref(&self) -> &JString<'local> {
+        self
+    }
+}
+
+impl<'local> AsRef<JObject<'local>> for JString<'local> {
+    fn as_ref(&self) -> &JObject<'local> {
+        self
+    }
+}
+
+impl<'local> ::std::ops::Deref for JString<'local> {
+    type Target = JObject<'local>;
 
     fn deref(&self) -> &Self::Target {
         &self.0
     }
 }
 
-impl<'a> From<JString<'a>> for JObject<'a> {
+impl<'local> From<JString<'local>> for JObject<'local> {
     fn from(other: JString) -> JObject {
         other.0
     }
 }
 
-impl<'a> From<JObject<'a>> for JString<'a> {
+impl<'local> From<JObject<'local>> for JString<'local> {
     fn from(other: JObject) -> Self {
         unsafe { Self::from_raw(other.into_raw()) }
     }
 }
 
-impl<'a> std::default::Default for JString<'a> {
+impl<'local, 'obj_ref> From<&'obj_ref JObject<'local>> for &'obj_ref JString<'local> {
+    fn from(other: &'obj_ref JObject<'local>) -> Self {
+        // Safety: `JString` is `repr(transparent)` around `JObject`.
+        unsafe { &*(other as *const JObject<'local> as *const JString<'local>) }
+    }
+}
+
+impl<'local> std::default::Default for JString<'local> {
     fn default() -> Self {
         Self(JObject::null())
     }
 }
 
-impl<'a> JString<'a> {
+impl<'local> JString<'local> {
     /// Creates a [`JString`] that wraps the given `raw` [`jstring`]
     ///
     /// # Safety

--- a/src/wrapper/objects/jthrowable.rs
+++ b/src/wrapper/objects/jthrowable.rs
@@ -6,36 +6,54 @@ use crate::{
 /// Lifetime'd representation of a `jthrowable`. Just a `JObject` wrapped in a
 /// new class.
 #[repr(transparent)]
-#[derive(Clone, Copy)]
-pub struct JThrowable<'a>(JObject<'a>);
+pub struct JThrowable<'local>(JObject<'local>);
 
-impl<'a> ::std::ops::Deref for JThrowable<'a> {
-    type Target = JObject<'a>;
+impl<'local> AsRef<JThrowable<'local>> for JThrowable<'local> {
+    fn as_ref(&self) -> &JThrowable<'local> {
+        self
+    }
+}
+
+impl<'local> AsRef<JObject<'local>> for JThrowable<'local> {
+    fn as_ref(&self) -> &JObject<'local> {
+        self
+    }
+}
+
+impl<'local> ::std::ops::Deref for JThrowable<'local> {
+    type Target = JObject<'local>;
 
     fn deref(&self) -> &Self::Target {
         &self.0
     }
 }
 
-impl<'a> From<JThrowable<'a>> for JObject<'a> {
+impl<'local> From<JThrowable<'local>> for JObject<'local> {
     fn from(other: JThrowable) -> JObject {
         other.0
     }
 }
 
-impl<'a> From<JObject<'a>> for JThrowable<'a> {
+impl<'local> From<JObject<'local>> for JThrowable<'local> {
     fn from(other: JObject) -> Self {
         unsafe { Self::from_raw(other.into_raw()) }
     }
 }
 
-impl<'a> std::default::Default for JThrowable<'a> {
+impl<'local, 'obj_ref> From<&'obj_ref JObject<'local>> for &'obj_ref JThrowable<'local> {
+    fn from(other: &'obj_ref JObject<'local>) -> Self {
+        // Safety: `JThrowable` is `repr(transparent)` around `JObject`.
+        unsafe { &*(other as *const JObject<'local> as *const JThrowable<'local>) }
+    }
+}
+
+impl<'local> std::default::Default for JThrowable<'local> {
     fn default() -> Self {
         Self(JObject::null())
     }
 }
 
-impl<'a> JThrowable<'a> {
+impl<'local> JThrowable<'local> {
     /// Creates a [`JThrowable`] that wraps the given `raw` [`jthrowable`]
     ///
     /// # Safety

--- a/src/wrapper/strings/ffi_str.rs
+++ b/src/wrapper/strings/ffi_str.rs
@@ -50,8 +50,8 @@ where
     }
 }
 
-impl<'a> From<&'a JNIStr> for Cow<'a, str> {
-    fn from(other: &'a JNIStr) -> Cow<'a, str> {
+impl<'str_ref> From<&'str_ref JNIStr> for Cow<'str_ref, str> {
+    fn from(other: &'str_ref JNIStr) -> Cow<'str_ref, str> {
         let bytes = other.to_bytes();
         match from_java_cesu8(bytes) {
             Ok(s) => s,
@@ -84,7 +84,7 @@ impl JNIStr {
     ///
     /// Expects a valid pointer to a null-terminated C string and does not perform any lifetime
     /// checks for the resulting value.
-    pub unsafe fn from_ptr<'a>(ptr: *const c_char) -> &'a JNIStr {
+    pub unsafe fn from_ptr<'jni_str>(ptr: *const c_char) -> &'jni_str JNIStr {
         &*(ffi::CStr::from_ptr(ptr) as *const ffi::CStr as *const ffi_str::JNIStr)
     }
 }

--- a/tests/java_integers.rs
+++ b/tests/java_integers.rs
@@ -7,17 +7,17 @@ use util::{attach_current_thread, print_exception};
 
 #[test]
 fn test_java_integers() {
-    let env = attach_current_thread();
+    let mut env = attach_current_thread();
 
     let array_length = 50;
 
     for value in -10..10 {
-        env.with_local_frame(16, || {
+        env.with_local_frame(16, |env| {
             let integer_value =
                 env.new_object("java/lang/Integer", "(I)V", &[JValue::Int(value)])?;
 
             let values_array =
-                env.new_object_array(array_length, "java/lang/Integer", integer_value)?;
+                env.new_object_array(array_length, "java/lang/Integer", &integer_value)?;
             let values_array = unsafe { JObject::from_raw(values_array) };
 
             let result = env
@@ -25,7 +25,10 @@ fn test_java_integers() {
                     "java/util/Arrays",
                     "binarySearch",
                     "([Ljava/lang/Object;Ljava/lang/Object;)I",
-                    &[JValue::Object(values_array), JValue::Object(integer_value)],
+                    &[
+                        JValue::Object(&values_array),
+                        JValue::Object(&integer_value),
+                    ],
                 )?
                 .i()?;
 

--- a/tests/jni_api.rs
+++ b/tests/jni_api.rs
@@ -33,74 +33,74 @@ static TESTING_OBJECT_STR: &str = "TESTING OBJECT";
 
 #[test]
 pub fn call_method_returning_null() {
-    let env = attach_current_thread();
+    let mut env = attach_current_thread();
     // Create an Exception with no message
     let obj = AutoLocal::new(
+        unwrap(env.new_object(EXCEPTION_CLASS, "()V", &[]), &env),
         &env,
-        unwrap(&env, env.new_object(EXCEPTION_CLASS, "()V", &[])),
     );
     // Call Throwable#getMessage must return null
     let message = unwrap(
-        &env,
         env.call_method(&obj, "getMessage", "()Ljava/lang/String;", &[]),
+        &env,
     );
-    let message_ref = env.auto_local(unwrap(&env, message.l()));
+    let message_ref = env.auto_local(unwrap(message.l(), &env));
 
-    assert!(message_ref.as_obj().is_null());
+    assert!(message_ref.is_null());
 }
 
 #[test]
 pub fn is_instance_of_same_class() {
-    let env = attach_current_thread();
+    let mut env = attach_current_thread();
     let obj = AutoLocal::new(
+        unwrap(env.new_object(EXCEPTION_CLASS, "()V", &[]), &env),
         &env,
-        unwrap(&env, env.new_object(EXCEPTION_CLASS, "()V", &[])),
     );
-    assert!(unwrap(&env, env.is_instance_of(&obj, EXCEPTION_CLASS)));
+    assert!(unwrap(env.is_instance_of(&obj, EXCEPTION_CLASS), &env));
 }
 
 #[test]
 pub fn is_instance_of_superclass() {
-    let env = attach_current_thread();
+    let mut env = attach_current_thread();
     let obj = AutoLocal::new(
+        unwrap(env.new_object(ARITHMETIC_EXCEPTION_CLASS, "()V", &[]), &env),
         &env,
-        unwrap(&env, env.new_object(ARITHMETIC_EXCEPTION_CLASS, "()V", &[])),
     );
-    assert!(unwrap(&env, env.is_instance_of(&obj, EXCEPTION_CLASS)));
+    assert!(unwrap(env.is_instance_of(&obj, EXCEPTION_CLASS), &env));
 }
 
 #[test]
 pub fn is_instance_of_subclass() {
-    let env = attach_current_thread();
+    let mut env = attach_current_thread();
     let obj = AutoLocal::new(
+        unwrap(env.new_object(EXCEPTION_CLASS, "()V", &[]), &env),
         &env,
-        unwrap(&env, env.new_object(EXCEPTION_CLASS, "()V", &[])),
     );
     assert!(!unwrap(
+        env.is_instance_of(&obj, ARITHMETIC_EXCEPTION_CLASS),
         &env,
-        env.is_instance_of(&obj, ARITHMETIC_EXCEPTION_CLASS)
     ));
 }
 
 #[test]
 pub fn is_instance_of_not_superclass() {
-    let env = attach_current_thread();
+    let mut env = attach_current_thread();
     let obj = AutoLocal::new(
+        unwrap(env.new_object(ARITHMETIC_EXCEPTION_CLASS, "()V", &[]), &env),
         &env,
-        unwrap(&env, env.new_object(ARITHMETIC_EXCEPTION_CLASS, "()V", &[])),
     );
-    assert!(!unwrap(&env, env.is_instance_of(&obj, ARRAYLIST_CLASS)));
+    assert!(!unwrap(env.is_instance_of(&obj, ARRAYLIST_CLASS), &env));
 }
 
 #[test]
 pub fn is_instance_of_null() {
-    let env = attach_current_thread();
+    let mut env = attach_current_thread();
     let obj = JObject::null();
-    assert!(unwrap(&env, env.is_instance_of(obj, ARRAYLIST_CLASS)));
-    assert!(unwrap(&env, env.is_instance_of(obj, EXCEPTION_CLASS)));
+    assert!(unwrap(env.is_instance_of(&obj, ARRAYLIST_CLASS), &env));
+    assert!(unwrap(env.is_instance_of(&obj, EXCEPTION_CLASS), &env));
     assert!(unwrap(
+        env.is_instance_of(&obj, ARITHMETIC_EXCEPTION_CLASS),
         &env,
-        env.is_instance_of(obj, ARITHMETIC_EXCEPTION_CLASS)
     ));
 }
 
@@ -108,16 +108,16 @@ pub fn is_instance_of_null() {
 pub fn is_same_object_diff_references() {
     let env = attach_current_thread();
     let string = env.new_string(TESTING_OBJECT_STR).unwrap();
-    let ref_from_string = unwrap(&env, env.new_local_ref::<JObject>(string.into()));
-    assert!(unwrap(&env, env.is_same_object(string, ref_from_string)));
-    unwrap(&env, env.delete_local_ref(ref_from_string));
+    let ref_from_string = unwrap(env.new_local_ref(&string), &env);
+    assert!(unwrap(env.is_same_object(&string, &ref_from_string), &env));
+    unwrap(env.delete_local_ref(ref_from_string), &env);
 }
 
 #[test]
 pub fn is_same_object_same_reference() {
     let env = attach_current_thread();
     let string = env.new_string(TESTING_OBJECT_STR).unwrap();
-    assert!(unwrap(&env, env.is_same_object(string, string)));
+    assert!(unwrap(env.is_same_object(&string, &string), &env));
 }
 
 #[test]
@@ -125,21 +125,21 @@ pub fn is_not_same_object() {
     let env = attach_current_thread();
     let string = env.new_string(TESTING_OBJECT_STR).unwrap();
     let same_src_str = env.new_string(TESTING_OBJECT_STR).unwrap();
-    assert!(!unwrap(&env, env.is_same_object(string, same_src_str)));
+    assert!(!unwrap(env.is_same_object(string, same_src_str), &env));
 }
 
 #[test]
 pub fn is_not_same_object_null() {
     let env = attach_current_thread();
     assert!(unwrap(
+        env.is_same_object(JObject::null(), JObject::null()),
         &env,
-        env.is_same_object(JObject::null(), JObject::null())
     ));
 }
 
 #[test]
 pub fn get_static_public_field() {
-    let env = attach_current_thread();
+    let mut env = attach_current_thread();
 
     let min_int_value = env
         .get_static_field(INTEGER_CLASS, "MIN_VALUE", "I")
@@ -152,7 +152,7 @@ pub fn get_static_public_field() {
 
 #[test]
 pub fn get_static_public_field_by_id() {
-    let env = attach_current_thread();
+    let mut env = attach_current_thread();
 
     // One can't pass a JavaType::Primitive(Primitive::Int) to
     //   `get_static_field_id` unfortunately: #137
@@ -173,7 +173,7 @@ pub fn get_static_public_field_by_id() {
 
 #[test]
 pub fn pop_local_frame_pending_exception() {
-    let env = attach_current_thread();
+    let mut env = attach_current_thread();
 
     env.push_local_frame(16).unwrap();
 
@@ -181,7 +181,7 @@ pub fn pop_local_frame_pending_exception() {
         .unwrap();
 
     // Pop the local frame with a pending exception
-    env.pop_local_frame(JObject::null())
+    unsafe { env.pop_local_frame(&JObject::null()) }
         .expect("JNIEnv#pop_local_frame must work in case of pending exception");
 
     env.exception_clear().unwrap();
@@ -189,7 +189,7 @@ pub fn pop_local_frame_pending_exception() {
 
 #[test]
 pub fn push_local_frame_pending_exception() {
-    let env = attach_current_thread();
+    let mut env = attach_current_thread();
 
     env.throw_new(RUNTIME_EXCEPTION_CLASS, "Test Exception")
         .unwrap();
@@ -200,7 +200,7 @@ pub fn push_local_frame_pending_exception() {
 
     env.exception_clear().unwrap();
 
-    env.pop_local_frame(JObject::null()).unwrap();
+    unsafe { env.pop_local_frame(&JObject::null()) }.unwrap();
 }
 
 #[test]
@@ -212,35 +212,36 @@ pub fn push_local_frame_too_many_refs() {
     env.push_local_frame(frame_size)
         .expect_err("push_local_frame(2B) must Err");
 
-    env.pop_local_frame(JObject::null()).unwrap();
+    unsafe { env.pop_local_frame(&JObject::null()) }.unwrap();
 }
 
 #[test]
 pub fn with_local_frame() {
-    let env = attach_current_thread();
+    let mut env = attach_current_thread();
 
     let s = env
-        .with_local_frame(16, || {
+        .with_local_frame(16, |env| {
             let res = env.new_string("Test").unwrap();
             Ok(res.into())
         })
-        .unwrap();
+        .unwrap()
+        .into();
 
     let s = env
-        .get_string(s.into())
+        .get_string(&s)
         .expect("The object returned from the local frame must remain valid");
     assert_eq!(s.to_str().unwrap(), "Test");
 }
 
 #[test]
 pub fn with_local_frame_pending_exception() {
-    let env = attach_current_thread();
+    let mut env = attach_current_thread();
 
     env.throw_new(RUNTIME_EXCEPTION_CLASS, "Test Exception")
         .unwrap();
 
     // Try to allocate a frame of locals
-    env.with_local_frame(16, || Ok(JObject::null()))
+    env.with_local_frame(16, |_| Ok(JObject::null()))
         .expect("JNIEnv#with_local_frame must work in case of pending exception");
 
     env.exception_clear().unwrap();
@@ -248,7 +249,7 @@ pub fn with_local_frame_pending_exception() {
 
 #[test]
 pub fn call_method_ok() {
-    let env = attach_current_thread();
+    let mut env = attach_current_thread();
 
     let s = env.new_string(TESTING_OBJECT_STR).unwrap();
 
@@ -263,12 +264,17 @@ pub fn call_method_ok() {
 
 #[test]
 pub fn call_method_with_bad_args_errs() {
-    let env = attach_current_thread();
+    let mut env = attach_current_thread();
 
     let s = env.new_string(TESTING_OBJECT_STR).unwrap();
 
     let is_bad_typ = env
-        .call_method(s, "indexOf", "(I)I", &[JValue::Float(std::f32::consts::PI)])
+        .call_method(
+            &s,
+            "indexOf",
+            "(I)I",
+            &[JValue::Float(std::f32::consts::PI)],
+        )
         .map_err(|error| matches!(error, Error::InvalidArgList(_)))
         .expect_err("JNIEnv#callmethod with bad arg type should err");
 
@@ -279,7 +285,7 @@ pub fn call_method_with_bad_args_errs() {
 
     let is_bad_len = env
         .call_method(
-            s,
+            &s,
             "indexOf",
             "(I)I",
             &[JValue::Int('S' as i32), JValue::Long(3)],
@@ -295,7 +301,7 @@ pub fn call_method_with_bad_args_errs() {
 
 #[test]
 pub fn call_static_method_ok() {
-    let env = attach_current_thread();
+    let mut env = attach_current_thread();
 
     let x = JValue::from(-10);
     let val: jint = env
@@ -309,19 +315,19 @@ pub fn call_static_method_ok() {
 
 #[test]
 pub fn call_static_method_unchecked_ok() {
-    let env = attach_current_thread();
+    let mut env = attach_current_thread();
 
     let x = JValue::from(-10);
     let math_class = env.find_class(MATH_CLASS).unwrap();
     let abs_method_id = env
-        .get_static_method_id(math_class, MATH_ABS_METHOD_NAME, MATH_ABS_SIGNATURE)
+        .get_static_method_id(&math_class, MATH_ABS_METHOD_NAME, MATH_ABS_SIGNATURE)
         .unwrap();
     let val: jint = unsafe {
         env.call_static_method_unchecked(
-            math_class,
+            &math_class,
             abs_method_id,
             ReturnType::Primitive(Primitive::Int),
-            &[x.into()],
+            &[x.as_jni()],
         )
     }
     .expect("JNIEnv#call_static_method_unchecked should return JValue")
@@ -333,37 +339,37 @@ pub fn call_static_method_unchecked_ok() {
 
 #[test]
 pub fn call_new_object_unchecked_ok() {
-    let env = attach_current_thread();
+    let mut env = attach_current_thread();
 
     let test_str = env.new_string(TESTING_OBJECT_STR).unwrap();
     let string_class = env.find_class(STRING_CLASS).unwrap();
 
     let ctor_method_id = env
-        .get_method_id(string_class, "<init>", "(Ljava/lang/String;)V")
+        .get_method_id(&string_class, "<init>", "(Ljava/lang/String;)V")
         .unwrap();
     let val: JObject = unsafe {
         env.new_object_unchecked(
-            string_class,
+            &string_class,
             ctor_method_id,
-            &[JValue::from(test_str).into()],
+            &[JValue::from(&test_str).as_jni()],
         )
     }
     .expect("JNIEnv#new_object_unchecked should return JValue");
 
     let jstr = JString::try_from(val).expect("asd");
-    let javastr = env.get_string(jstr).unwrap();
+    let javastr = env.get_string(&jstr).unwrap();
     let rstr = javastr.to_str().unwrap();
     assert_eq!(rstr, TESTING_OBJECT_STR);
 }
 
 #[test]
 pub fn call_new_object_with_bad_args_errs() {
-    let env = attach_current_thread();
+    let mut env = attach_current_thread();
 
     let string_class = env.find_class(STRING_CLASS).unwrap();
 
     let is_bad_typ = env
-        .new_object(string_class, "(Ljava/lang/String;)V", &[JValue::Int(2)])
+        .new_object(&string_class, "(Ljava/lang/String;)V", &[JValue::Int(2)])
         .map_err(|error| matches!(error, Error::InvalidArgList(_)))
         .expect_err("JNIEnv#new_object with bad arg type should err");
 
@@ -376,9 +382,9 @@ pub fn call_new_object_with_bad_args_errs() {
 
     let is_bad_len = env
         .new_object(
-            string_class,
+            &string_class,
             "(Ljava/lang/String;)V",
-            &[JValue::from(s), JValue::Int(2)],
+            &[JValue::from(&s), JValue::Int(2)],
         )
         .map_err(|error| matches!(error, Error::InvalidArgList(_)))
         .expect_err("JNIEnv#new_object with bad arg type should err");
@@ -391,7 +397,7 @@ pub fn call_new_object_with_bad_args_errs() {
 
 #[test]
 pub fn call_static_method_throws() {
-    let env = attach_current_thread();
+    let mut env = attach_current_thread();
 
     let x = JValue::Long(4_000_000_000);
     let is_java_exception = env
@@ -409,12 +415,12 @@ pub fn call_static_method_throws() {
         is_java_exception,
         "ErrorKind::JavaException expected as error"
     );
-    assert_pending_java_exception(&env);
+    assert_pending_java_exception(&mut env);
 }
 
 #[test]
 pub fn call_static_method_with_bad_args_errs() {
-    let env = attach_current_thread();
+    let mut env = attach_current_thread();
 
     let x = JValue::Double(4.567_891_23);
     let is_bad_typ = env
@@ -455,9 +461,9 @@ pub fn java_byte_array_from_slice() {
     let java_array = env
         .byte_array_from_slice(buf)
         .expect("JNIEnv#byte_array_from_slice must create a java array from slice");
-    let obj = AutoLocal::new(&env, unsafe { JObject::from_raw(java_array) });
+    let obj = AutoLocal::new(unsafe { JObject::from_raw(java_array) }, &env);
 
-    assert!(!obj.as_obj().is_null());
+    assert!(!obj.is_null());
     let mut res: [i8; 3] = [0; 3];
     env.get_byte_array_region(java_array, 0, &mut res).unwrap();
     assert_eq!(res[0], 1);
@@ -486,7 +492,7 @@ macro_rules! test_get_array_elements {
                 let auto_ptr: AutoArray<$jni_type> = {
                     // Make sure the lifetime is tied to the environment,
                     // not the particular JNIEnv reference
-                    let temporary_env: JNIEnv = *env;
+                    let mut temporary_env: JNIEnv = unsafe { env.unsafe_clone() };
                     temporary_env.$jni_get(java_array, ReleaseMode::CopyBack).unwrap()
                 };
 
@@ -604,7 +610,7 @@ test_get_array_elements!(
 #[test]
 #[ignore] // Disabled until issue #283 is resolved
 pub fn get_long_array_elements_commit() {
-    let env = attach_current_thread();
+    let mut env = attach_current_thread();
 
     // Create original Java array
     let buf: &[i64] = &[1, 2, 3];
@@ -616,7 +622,7 @@ pub fn get_long_array_elements_commit() {
     let _ = env.set_long_array_region(java_array, 0, buf);
 
     // Get long array elements auto wrapper
-    let auto_ptr = env
+    let mut auto_ptr = env
         .get_long_array_elements(java_array, ReleaseMode::CopyBack)
         .unwrap();
 
@@ -654,7 +660,7 @@ pub fn get_long_array_elements_commit() {
 
 #[test]
 pub fn get_primitive_array_critical() {
-    let env = attach_current_thread();
+    let mut env = attach_current_thread();
 
     // Create original Java array
     let buf: &[u8] = &[1, 2, 3];
@@ -725,7 +731,7 @@ pub fn get_object_class_null_arg() {
 
 #[test]
 pub fn new_direct_byte_buffer() {
-    let env = attach_current_thread();
+    let mut env = attach_current_thread();
     let vec: Vec<u8> = vec![0, 1, 2, 3];
     let (addr, len) = {
         // (would use buf.into_raw_parts() on nightly)
@@ -739,14 +745,14 @@ pub fn new_direct_byte_buffer() {
 
 #[test]
 pub fn new_direct_byte_buffer_invalid_addr() {
-    let env = attach_current_thread();
+    let mut env = attach_current_thread();
     let result = unsafe { env.new_direct_byte_buffer(std::ptr::null_mut(), 5) };
     assert!(result.is_err());
 }
 
 #[test]
 pub fn get_direct_buffer_capacity_ok() {
-    let env = attach_current_thread();
+    let mut env = attach_current_thread();
     let vec: Vec<u8> = vec![0, 1, 2, 3];
     let (addr, len) = {
         // (would use buf.into_raw_parts() on nightly)
@@ -756,7 +762,7 @@ pub fn get_direct_buffer_capacity_ok() {
     let result = unsafe { env.new_direct_byte_buffer(addr, len) }.unwrap();
     assert!(!result.is_null());
 
-    let capacity = env.get_direct_buffer_capacity(result).unwrap();
+    let capacity = env.get_direct_buffer_capacity(&result).unwrap();
     assert_eq!(capacity, 4);
 }
 
@@ -764,20 +770,20 @@ pub fn get_direct_buffer_capacity_ok() {
 pub fn get_direct_buffer_capacity_wrong_arg() {
     let env = attach_current_thread();
     let wrong_obj = unsafe { JByteBuffer::from_raw(env.new_string("wrong").unwrap().into_raw()) };
-    let capacity = env.get_direct_buffer_capacity(wrong_obj);
+    let capacity = env.get_direct_buffer_capacity(&wrong_obj);
     assert!(capacity.is_err());
 }
 
 #[test]
 pub fn get_direct_buffer_capacity_null_arg() {
     let env = attach_current_thread();
-    let result = env.get_direct_buffer_capacity(JObject::null().into());
+    let result = env.get_direct_buffer_capacity(&JObject::null().into());
     assert!(result.is_err());
 }
 
 #[test]
 pub fn get_direct_buffer_address_ok() {
-    let env = attach_current_thread();
+    let mut env = attach_current_thread();
     let vec: Vec<u8> = vec![0, 1, 2, 3];
     let (addr, len) = {
         // (would use buf.into_raw_parts() on nightly)
@@ -787,7 +793,7 @@ pub fn get_direct_buffer_address_ok() {
     let result = unsafe { env.new_direct_byte_buffer(addr, len) }.unwrap();
     assert!(!result.is_null());
 
-    let dest_buffer = env.get_direct_buffer_address(result).unwrap();
+    let dest_buffer = env.get_direct_buffer_address(&result).unwrap();
     assert_eq!(addr, dest_buffer);
 }
 
@@ -795,14 +801,14 @@ pub fn get_direct_buffer_address_ok() {
 pub fn get_direct_buffer_address_wrong_arg() {
     let env = attach_current_thread();
     let wrong_obj: JObject = env.new_string("wrong").unwrap().into();
-    let result = env.get_direct_buffer_address(wrong_obj.into());
+    let result = env.get_direct_buffer_address(&wrong_obj.into());
     assert!(result.is_err());
 }
 
 #[test]
 pub fn get_direct_buffer_address_null_arg() {
     let env = attach_current_thread();
-    let result = env.get_direct_buffer_address(JObject::null().into());
+    let result = env.get_direct_buffer_address(&JObject::null().into());
     assert!(result.is_err());
 }
 
@@ -848,45 +854,45 @@ pub fn new_primitive_array_ok() {
 // Group test for testing the family of new_PRIMITIVE_array functions with wrong arguments
 #[test]
 pub fn new_primitive_array_wrong() {
-    let env = attach_current_thread();
+    let mut env = attach_current_thread();
     const WRONG_SIZE: jsize = -1;
 
     let result = env.new_boolean_array(WRONG_SIZE);
     assert_exception(&result, "JNIEnv#new_boolean_array should throw exception");
-    assert_pending_java_exception(&env);
+    assert_pending_java_exception(&mut env);
 
     let result = env.new_byte_array(WRONG_SIZE);
     assert_exception(&result, "JNIEnv#new_byte_array should throw exception");
-    assert_pending_java_exception(&env);
+    assert_pending_java_exception(&mut env);
 
     let result = env.new_char_array(WRONG_SIZE);
     assert_exception(&result, "JNIEnv#new_char_array should throw exception");
-    assert_pending_java_exception(&env);
+    assert_pending_java_exception(&mut env);
 
     let result = env.new_short_array(WRONG_SIZE);
     assert_exception(&result, "JNIEnv#new_short_array should throw exception");
-    assert_pending_java_exception(&env);
+    assert_pending_java_exception(&mut env);
 
     let result = env.new_int_array(WRONG_SIZE);
     assert_exception(&result, "JNIEnv#new_int_array should throw exception");
-    assert_pending_java_exception(&env);
+    assert_pending_java_exception(&mut env);
 
     let result = env.new_long_array(WRONG_SIZE);
     assert_exception(&result, "JNIEnv#new_long_array should throw exception");
-    assert_pending_java_exception(&env);
+    assert_pending_java_exception(&mut env);
 
     let result = env.new_float_array(WRONG_SIZE);
     assert_exception(&result, "JNIEnv#new_float_array should throw exception");
-    assert_pending_java_exception(&env);
+    assert_pending_java_exception(&mut env);
 
     let result = env.new_double_array(WRONG_SIZE);
     assert_exception(&result, "JNIEnv#new_double_array should throw exception");
-    assert_pending_java_exception(&env);
+    assert_pending_java_exception(&mut env);
 }
 
 #[test]
 fn get_super_class_ok() {
-    let env = attach_current_thread();
+    let mut env = attach_current_thread();
     let result = env.get_superclass(ARRAYLIST_CLASS);
     assert!(result.is_ok());
     assert!(result.unwrap().is_some());
@@ -894,7 +900,7 @@ fn get_super_class_ok() {
 
 #[test]
 fn get_super_class_null() {
-    let env = attach_current_thread();
+    let mut env = attach_current_thread();
     let result = env.get_superclass("java/lang/Object");
     assert!(result.is_ok());
     assert!(result.unwrap().is_none());
@@ -916,7 +922,7 @@ fn local_ref_null() {
     let env = attach_current_thread();
     let null_obj = JObject::null();
 
-    let result = env.new_local_ref::<JObject>(null_obj);
+    let result = env.new_local_ref::<&JObject>(&null_obj);
     assert!(result.is_ok());
     assert!(result.unwrap().is_null());
 
@@ -931,14 +937,14 @@ fn new_global_ref_null() {
     let null_obj = JObject::null();
     let result = env.new_global_ref(null_obj);
     assert!(result.is_ok());
-    assert!(result.unwrap().as_obj().is_null());
+    assert!(result.unwrap().is_null());
 }
 
 #[test]
 fn new_weak_ref_null() {
     let env = attach_current_thread();
     let null_obj = JObject::null();
-    let result = unwrap(&env, env.new_weak_ref(null_obj));
+    let result = unwrap(env.new_weak_ref(null_obj), &env);
     assert!(result.is_none());
 }
 
@@ -947,51 +953,55 @@ fn auto_local_null() {
     let env = attach_current_thread();
     let null_obj = JObject::null();
     {
-        let auto_ref = AutoLocal::new(&env, null_obj);
-        assert!(auto_ref.as_obj().is_null());
+        let auto_ref = AutoLocal::new(null_obj, &env);
+        assert!(auto_ref.is_null());
     }
-    assert!(null_obj.is_null());
 }
 
 #[test]
 fn short_lifetime_with_local_frame() {
-    let env = attach_current_thread();
-    let object = short_lifetime_with_local_frame_sub_fn(&env);
+    let mut env = attach_current_thread();
+    let object = short_lifetime_with_local_frame_sub_fn(&mut env);
     assert!(object.is_ok());
 }
 
-fn short_lifetime_with_local_frame_sub_fn<'a>(env: &'_ JNIEnv<'a>) -> Result<JObject<'a>, Error> {
-    env.with_local_frame(16, || {
+fn short_lifetime_with_local_frame_sub_fn<'local>(
+    env: &'_ mut JNIEnv<'local>,
+) -> Result<JObject<'local>, Error> {
+    env.with_local_frame(16, |env| {
         env.new_object(INTEGER_CLASS, "(I)V", &[JValue::from(5)])
     })
 }
 
 #[test]
 fn short_lifetime_list() {
-    let env = attach_current_thread();
-    let first_list_object = short_lifetime_list_sub_fn(&env).unwrap();
+    let mut env = attach_current_thread();
+    let first_list_object = short_lifetime_list_sub_fn(&mut env).unwrap();
     let value = env.call_method(first_list_object, "intValue", "()I", &[]);
     assert_eq!(value.unwrap().i().unwrap(), 1);
 }
 
-fn short_lifetime_list_sub_fn<'a>(env: &'_ JNIEnv<'a>) -> Result<JObject<'a>, Error> {
+fn short_lifetime_list_sub_fn<'local>(
+    env: &'_ mut JNIEnv<'local>,
+) -> Result<JObject<'local>, Error> {
     let list_object = env.new_object(ARRAYLIST_CLASS, "()V", &[])?;
-    let list = JList::from_env(env, list_object)?;
+    let list = JList::from_env(env, &list_object)?;
     let element = env.new_object(INTEGER_CLASS, "(I)V", &[JValue::from(1)])?;
-    list.add(element)?;
-    short_lifetime_list_sub_fn_get_first_element(&list)
+    list.add(env, &element)?;
+    short_lifetime_list_sub_fn_get_first_element(env, &list)
 }
 
-fn short_lifetime_list_sub_fn_get_first_element<'a>(
-    list: &'_ JList<'a, '_>,
-) -> Result<JObject<'a>, Error> {
-    let mut iterator = list.iter()?;
-    Ok(iterator.next().unwrap())
+fn short_lifetime_list_sub_fn_get_first_element<'local>(
+    env: &'_ mut JNIEnv<'local>,
+    list: &'_ JList<'local, '_, '_>,
+) -> Result<JObject<'local>, Error> {
+    let mut iterator = list.iter(env)?;
+    Ok(iterator.next(env)?.unwrap())
 }
 
 #[test]
 fn get_object_array_element() {
-    let env = attach_current_thread();
+    let mut env = attach_current_thread();
     let array = env
         .new_object_array(1, STRING_CLASS, JObject::null())
         .unwrap();
@@ -1004,12 +1014,12 @@ fn get_object_array_element() {
 
 #[test]
 pub fn throw_new() {
-    let env = attach_current_thread();
+    let mut env = attach_current_thread();
 
     let result = env.throw_new(RUNTIME_EXCEPTION_CLASS, "Test Exception");
     assert!(result.is_ok());
     assert_pending_java_exception_detailed(
-        &env,
+        &mut env,
         Some(RUNTIME_EXCEPTION_CLASS),
         Some("Test Exception"),
     );
@@ -1017,21 +1027,21 @@ pub fn throw_new() {
 
 #[test]
 pub fn throw_new_fail() {
-    let env = attach_current_thread();
+    let mut env = attach_current_thread();
 
     let result = env.throw_new("java/lang/NonexistentException", "Test Exception");
     assert!(result.is_err());
     // Just to clear the java.lang.NoClassDefFoundError
-    assert_pending_java_exception(&env);
+    assert_pending_java_exception(&mut env);
 }
 
 #[test]
 pub fn throw_defaults() {
-    let env = attach_current_thread();
+    let mut env = attach_current_thread();
 
-    test_throwable_descriptor_with_default_type(&env, TEST_EXCEPTION_MESSAGE);
-    test_throwable_descriptor_with_default_type(&env, TEST_EXCEPTION_MESSAGE.to_owned());
-    test_throwable_descriptor_with_default_type(&env, JNIString::from(TEST_EXCEPTION_MESSAGE));
+    test_throwable_descriptor_with_default_type(&mut env, TEST_EXCEPTION_MESSAGE);
+    test_throwable_descriptor_with_default_type(&mut env, TEST_EXCEPTION_MESSAGE.to_owned());
+    test_throwable_descriptor_with_default_type(&mut env, JNIString::from(TEST_EXCEPTION_MESSAGE));
 }
 
 #[test]
@@ -1039,46 +1049,52 @@ pub fn test_conversion() {
     let env = attach_current_thread();
     let orig_obj: JObject = env.new_string("Hello, world!").unwrap().into();
 
-    let string = JString::from(orig_obj);
+    let obj: JObject = unwrap(env.new_local_ref(&orig_obj), &env);
+    let string = JString::from(obj);
     let actual = JObject::from(string);
-    assert!(unwrap(&env, env.is_same_object(orig_obj, actual)));
+    assert!(unwrap(env.is_same_object(&orig_obj, actual), &env));
 
-    let global_ref = env.new_global_ref(orig_obj).unwrap();
-    let actual = JObject::from(&global_ref);
-    assert!(unwrap(&env, env.is_same_object(orig_obj, actual)));
+    let global_ref = env.new_global_ref(&orig_obj).unwrap();
+    assert!(unwrap(env.is_same_object(&orig_obj, global_ref), &env));
 
-    let weak_ref = unwrap(&env, env.new_weak_ref(orig_obj)).expect("weak ref should not be null");
+    let weak_ref = unwrap(env.new_weak_ref(&orig_obj), &env).expect("weak ref should not be null");
     let actual =
-        unwrap(&env, weak_ref.upgrade_local(&env)).expect("weak ref should not have been GC'd");
-    assert!(unwrap(&env, env.is_same_object(orig_obj, actual)));
+        unwrap(weak_ref.upgrade_local(&env), &env).expect("weak ref should not have been GC'd");
+    assert!(unwrap(env.is_same_object(&orig_obj, actual), &env));
 
-    let auto_local = env.auto_local(orig_obj);
-    let actual = JObject::from(&auto_local);
-    assert!(unwrap(&env, env.is_same_object(orig_obj, actual)));
+    let obj: JObject = unwrap(env.new_local_ref(&orig_obj), &env);
+    let auto_local = env.auto_local(obj);
+    assert!(unwrap(env.is_same_object(&orig_obj, auto_local), &env));
 }
 
 #[test]
 pub fn test_null_get_string() {
-    let env = attach_current_thread();
-    let ret = env.get_string(unsafe { JString::from_raw(std::ptr::null_mut() as _) });
+    let mut env = attach_current_thread();
+    let s = unsafe { JString::from_raw(std::ptr::null_mut() as _) };
+    let ret = env.get_string(&s);
     assert!(ret.is_err());
 }
 
 #[test]
 pub fn test_invalid_list_get_string() {
-    let env = attach_current_thread();
-    let class = env.auto_local(env.find_class("java/util/List").unwrap());
-    let ret = env.get_string(class.as_obj().into());
+    let mut env = attach_current_thread();
+
+    let class = env.find_class("java/util/List").unwrap();
+    let class = JString::from(JObject::from(class));
+    let class = env.auto_local(class);
+
+    let ret = env.get_string(&class);
     assert!(ret.is_err());
 }
 
-fn test_throwable_descriptor_with_default_type<'a, D>(env: &JNIEnv<'a>, descriptor: D)
+fn test_throwable_descriptor_with_default_type<'local, D>(env: &mut JNIEnv<'local>, descriptor: D)
 where
-    D: Desc<'a, JThrowable<'a>>,
+    D: Desc<'local, JThrowable<'local>>,
 {
     let result = descriptor.lookup(env);
     assert!(result.is_ok());
     let exception = result.unwrap();
+    let exception = exception.as_ref();
 
     assert_exception_type(env, exception, RUNTIME_EXCEPTION_CLASS);
     assert_exception_message(env, exception, TEST_EXCEPTION_MESSAGE);
@@ -1095,14 +1111,14 @@ fn assert_exception(res: &Result<jobject, Error>, expect_message: &str) {
 
 // Shortcut to `assert_pending_java_exception_detailed()` without checking for expected  type and
 // message of exception.
-fn assert_pending_java_exception(env: &JNIEnv) {
+fn assert_pending_java_exception(env: &mut JNIEnv) {
     assert_pending_java_exception_detailed(env, None, None)
 }
 
 // Helper method that asserts there is a pending Java exception of `expected_type` with
 // `expected_message` and clears it if any.
 fn assert_pending_java_exception_detailed(
-    env: &JNIEnv,
+    env: &mut JNIEnv,
     expected_type: Option<&str>,
     expected_message: Option<&str>,
 ) {
@@ -1111,26 +1127,26 @@ fn assert_pending_java_exception_detailed(
     env.exception_clear().unwrap();
 
     if let Some(expected_type) = expected_type {
-        assert_exception_type(env, exception, expected_type);
+        assert_exception_type(env, &exception, expected_type);
     }
 
     if let Some(expected_message) = expected_message {
-        assert_exception_message(env, exception, expected_message);
+        assert_exception_message(env, &exception, expected_message);
     }
 }
 
 // Asserts that exception is of `expected_type` type.
-fn assert_exception_type(env: &JNIEnv, exception: JThrowable, expected_type: &str) {
+fn assert_exception_type(env: &mut JNIEnv, exception: &JThrowable, expected_type: &str) {
     assert!(env.is_instance_of(exception, expected_type).unwrap());
 }
 
 // Asserts that exception's message is `expected_message`.
-fn assert_exception_message(env: &JNIEnv, exception: JThrowable, expected_message: &str) {
+fn assert_exception_message(env: &mut JNIEnv, exception: &JThrowable, expected_message: &str) {
     let message = env
         .call_method(exception, "getMessage", "()Ljava/lang/String;", &[])
         .unwrap()
         .l()
         .unwrap();
-    let msg_rust: String = env.get_string(message.into()).unwrap().into();
+    let msg_rust: String = env.get_string(&message.into()).unwrap().into();
     assert_eq!(msg_rust, expected_message);
 }

--- a/tests/jni_weak_refs.rs
+++ b/tests/jni_weak_refs.rs
@@ -18,22 +18,22 @@ use util::{attach_current_thread, unwrap};
 pub fn weak_ref_works_in_other_threads() {
     const ITERS_PER_THREAD: usize = 10_000;
 
-    let env = attach_current_thread();
+    let mut env = attach_current_thread();
     let mut join_handlers = Vec::new();
 
     let atomic_integer_local = AutoLocal::new(
-        &env,
         unwrap(
-            &env,
             env.new_object(
                 "java/util/concurrent/atomic/AtomicInteger",
                 "(I)V",
                 &[JValue::from(0)],
             ),
+            &env,
         ),
+        &env,
     );
     let atomic_integer =
-        unwrap(&env, env.new_weak_ref(&atomic_integer_local)).expect("weak ref should not be null");
+        unwrap(env.new_weak_ref(&atomic_integer_local), &env).expect("weak ref should not be null");
 
     // Test with a different number of threads (from 2 to 8)
     for thread_num in 2..9 {
@@ -44,20 +44,20 @@ pub fn weak_ref_works_in_other_threads() {
             let atomic_integer = atomic_integer.clone();
 
             let jh = spawn(move || {
-                let env = attach_current_thread();
+                let mut env = attach_current_thread();
                 barrier.wait();
                 for _ in 0..ITERS_PER_THREAD {
                     let atomic_integer = env.auto_local(
-                        unwrap(&env, atomic_integer.upgrade_local(&env))
+                        unwrap(atomic_integer.upgrade_local(&env), &env)
                             .expect("AtomicInteger shouldn't have been GC'd yet"),
                     );
                     unwrap(
-                        &env,
                         unwrap(
-                            &env,
                             env.call_method(&atomic_integer, "incrementAndGet", "()I", &[]),
+                            &env,
                         )
                         .i(),
+                        &env,
                     );
                 }
             });
@@ -72,17 +72,17 @@ pub fn weak_ref_works_in_other_threads() {
         assert_eq!(
             expected,
             unwrap(
-                &env,
                 unwrap(
-                    &env,
                     env.call_method(
                         &atomic_integer_local,
                         "getAndSet",
                         "(I)I",
                         &[JValue::from(0)]
-                    )
+                    ),
+                    &env,
                 )
-                .i()
+                .i(),
+                &env,
             )
         );
     }
@@ -90,78 +90,79 @@ pub fn weak_ref_works_in_other_threads() {
 
 #[test]
 fn weak_ref_is_actually_weak() {
-    let env = attach_current_thread();
+    let mut env = attach_current_thread();
 
     // This test uses `with_local_frame` to work around issue #109.
 
-    fn run_gc(env: &JNIEnv) {
+    fn run_gc(env: &mut JNIEnv) {
         unwrap(
-            env,
-            env.with_local_frame(1, || {
+            env.with_local_frame(1, |env| {
                 env.call_static_method("java/lang/System", "gc", "()V", &[])?;
                 Ok(JObject::null())
             }),
+            env,
         );
     }
 
     for _ in 0..100 {
-        let obj_local = env.auto_local(unwrap(
+        let obj_local = unwrap(
+            env.with_local_frame(2, |env| env.new_object("java/lang/Object", "()V", &[])),
             &env,
-            env.with_local_frame(2, || env.new_object("java/lang/Object", "()V", &[])),
-        ));
+        );
+        let obj_local = env.auto_local(obj_local);
 
         let obj_weak =
-            unwrap(&env, env.new_weak_ref(&obj_local)).expect("weak ref should not be null");
+            unwrap(env.new_weak_ref(&obj_local), &env).expect("weak ref should not be null");
 
         let obj_weak2 =
-            unwrap(&env, obj_weak.clone_in_jvm(&env)).expect("weak ref should not be null");
+            unwrap(obj_weak.clone_in_jvm(&env), &env).expect("weak ref should not be null");
 
-        run_gc(&env);
+        run_gc(&mut env);
 
         for obj_weak in &[&obj_weak, &obj_weak2] {
             {
                 let obj_local_from_weak = env.auto_local(
-                    unwrap(&env, obj_weak.upgrade_local(&env))
+                    unwrap(obj_weak.upgrade_local(&env), &env)
                         .expect("object shouldn't have been GC'd yet"),
                 );
 
-                assert!(!obj_local_from_weak.as_obj().is_null());
+                assert!(!obj_local_from_weak.is_null());
                 assert!(unwrap(
+                    env.is_same_object(&obj_local_from_weak, &obj_local),
                     &env,
-                    env.is_same_object(&obj_local_from_weak, &obj_local)
                 ));
             }
 
             {
-                let obj_global_from_weak = unwrap(&env, obj_weak.upgrade_global(&env))
+                let obj_global_from_weak = unwrap(obj_weak.upgrade_global(&env), &env)
                     .expect("object shouldn't have been GC'd yet");
 
-                assert!(!obj_global_from_weak.as_obj().is_null());
+                assert!(!obj_global_from_weak.is_null());
                 assert!(unwrap(
+                    env.is_same_object(&obj_global_from_weak, &obj_local),
                     &env,
-                    env.is_same_object(&obj_global_from_weak, &obj_local)
                 ));
             }
 
-            assert!(unwrap(&env, obj_weak.is_same_object(&env, &obj_local)));
+            assert!(unwrap(obj_weak.is_same_object(&env, &obj_local), &env));
 
             assert!(
-                !unwrap(&env, obj_weak.is_garbage_collected(&env)),
+                !unwrap(obj_weak.is_garbage_collected(&env), &env),
                 "`is_garbage_collected` returned incorrect value"
             );
         }
 
         assert!(unwrap(
+            obj_weak.is_weak_ref_to_same_object(&env, &obj_weak2),
             &env,
-            obj_weak.is_weak_ref_to_same_object(&env, &obj_weak2)
         ));
 
         drop(obj_local);
-        run_gc(&env);
+        run_gc(&mut env);
 
         for obj_weak in &[&obj_weak, &obj_weak2] {
             {
-                let obj_local_from_weak = unwrap(&env, obj_weak.upgrade_local(&env));
+                let obj_local_from_weak = unwrap(obj_weak.upgrade_local(&env), &env);
 
                 assert!(
                     obj_local_from_weak.is_none(),
@@ -170,7 +171,7 @@ fn weak_ref_is_actually_weak() {
             }
 
             {
-                let obj_global_from_weak = unwrap(&env, obj_weak.upgrade_global(&env));
+                let obj_global_from_weak = unwrap(obj_weak.upgrade_global(&env), &env);
 
                 assert!(
                     obj_global_from_weak.is_none(),
@@ -179,14 +180,14 @@ fn weak_ref_is_actually_weak() {
             }
 
             assert!(
-                unwrap(&env, obj_weak.is_garbage_collected(&env)),
+                unwrap(obj_weak.is_garbage_collected(&env), &env),
                 "`is_garbage_collected` returned incorrect value"
             );
         }
 
         assert!(unwrap(
+            obj_weak.is_weak_ref_to_same_object(&env, &obj_weak2),
             &env,
-            obj_weak.is_weak_ref_to_same_object(&env, &obj_weak2)
         ));
     }
 }

--- a/tests/threads_attach_guard.rs
+++ b/tests/threads_attach_guard.rs
@@ -7,9 +7,9 @@ use util::{attach_current_thread, call_java_abs, jvm};
 fn thread_attach_guard_detaches_on_drop() {
     assert_eq!(jvm().threads_attached(), 0);
     {
-        let guard = attach_current_thread();
+        let mut guard = attach_current_thread();
         assert_eq!(jvm().threads_attached(), 1);
-        let val = call_java_abs(&guard, -1);
+        let val = call_java_abs(&mut guard, -1);
         assert_eq!(val, 1);
     }
     assert_eq!(jvm().threads_attached(), 0);

--- a/tests/threads_detach.rs
+++ b/tests/threads_detach.rs
@@ -8,8 +8,8 @@ use util::{attach_current_thread_permanently, call_java_abs, jvm};
 #[test]
 fn thread_detaches_when_finished() {
     let thread = spawn(|| {
-        let env = attach_current_thread_permanently();
-        let val = call_java_abs(&env, -2);
+        let mut env = attach_current_thread_permanently();
+        let val = call_java_abs(&mut env, -2);
         assert_eq!(val, 2);
         assert_eq!(jvm().threads_attached(), 1);
     });

--- a/tests/threads_detach_daemon.rs
+++ b/tests/threads_detach_daemon.rs
@@ -8,8 +8,8 @@ use util::{attach_current_thread_as_daemon, call_java_abs, jvm};
 #[test]
 fn daemon_thread_detaches_when_finished() {
     let thread = spawn(|| {
-        let env = attach_current_thread_as_daemon();
-        let val = call_java_abs(&env, -3);
+        let mut env = attach_current_thread_as_daemon();
+        let val = call_java_abs(&mut env, -3);
         assert_eq!(val, 3);
         assert_eq!(jvm().threads_attached(), 1);
     });

--- a/tests/threads_explicit_detach.rs
+++ b/tests/threads_explicit_detach.rs
@@ -6,8 +6,8 @@ use util::{attach_current_thread, call_java_abs, detach_current_thread, jvm};
 #[test]
 pub fn explicit_detach_detaches_thread_attached_locally() {
     assert_eq!(jvm().threads_attached(), 0);
-    let guard = attach_current_thread();
-    let val = call_java_abs(&guard, -1);
+    let mut guard = attach_current_thread();
+    let val = call_java_abs(&mut guard, -1);
     assert_eq!(val, 1);
     assert_eq!(jvm().threads_attached(), 1);
 

--- a/tests/threads_explicit_detach_daemon.rs
+++ b/tests/threads_explicit_detach_daemon.rs
@@ -6,8 +6,8 @@ use util::{attach_current_thread_as_daemon, call_java_abs, detach_current_thread
 #[test]
 pub fn explicit_detach_detaches_thread_attached_as_daemon() {
     assert_eq!(jvm().threads_attached(), 0);
-    let guard = attach_current_thread_as_daemon();
-    let val = call_java_abs(&guard, -1);
+    let mut guard = attach_current_thread_as_daemon();
+    let val = call_java_abs(&mut guard, -1);
     assert_eq!(val, 1);
     assert_eq!(jvm().threads_attached(), 1);
 

--- a/tests/threads_explicit_detach_permanent.rs
+++ b/tests/threads_explicit_detach_permanent.rs
@@ -6,8 +6,8 @@ use util::{attach_current_thread_permanently, call_java_abs, detach_current_thre
 #[test]
 pub fn explicit_detach_detaches_thread_attached_permanently() {
     assert_eq!(jvm().threads_attached(), 0);
-    let guard = attach_current_thread_permanently();
-    let val = call_java_abs(&guard, -1);
+    let mut guard = attach_current_thread_permanently();
+    let val = call_java_abs(&mut guard, -1);
     assert_eq!(val, 1);
     assert_eq!(jvm().threads_attached(), 1);
 

--- a/tests/threads_nested_attach_daemon.rs
+++ b/tests/threads_nested_attach_daemon.rs
@@ -9,29 +9,29 @@ use util::{
 #[test]
 pub fn nested_attaches_should_not_detach_daemon_thread() {
     assert_eq!(jvm().threads_attached(), 0);
-    let env = attach_current_thread_as_daemon();
-    let val = call_java_abs(&env, -1);
+    let mut env = attach_current_thread_as_daemon();
+    let val = call_java_abs(&mut env, -1);
     assert_eq!(val, 1);
     assert_eq!(jvm().threads_attached(), 1);
 
     // Create nested AttachGuard.
     {
-        let env_nested = attach_current_thread();
-        let val = call_java_abs(&env_nested, -2);
+        let mut env_nested = attach_current_thread();
+        let val = call_java_abs(&mut env_nested, -2);
         assert_eq!(val, 2);
         assert_eq!(jvm().threads_attached(), 1);
     }
 
     // Call a Java method after nested guard has been dropped to check that
     // this thread has not been detached.
-    let val = call_java_abs(&env, -3);
+    let val = call_java_abs(&mut env, -3);
     assert_eq!(val, 3);
     assert_eq!(jvm().threads_attached(), 1);
 
     // Nested attach_permanently is a no-op.
     {
-        let env_nested = attach_current_thread_permanently();
-        let val = call_java_abs(&env_nested, -4);
+        let mut env_nested = attach_current_thread_permanently();
+        let val = call_java_abs(&mut env_nested, -4);
         assert_eq!(val, 4);
         assert_eq!(jvm().threads_attached(), 1);
     }
@@ -39,8 +39,8 @@ pub fn nested_attaches_should_not_detach_daemon_thread() {
 
     // Nested attach_as_daemon is a no-op.
     {
-        let env_nested = attach_current_thread_as_daemon();
-        let val = call_java_abs(&env_nested, -5);
+        let mut env_nested = attach_current_thread_as_daemon();
+        let val = call_java_abs(&mut env_nested, -5);
         assert_eq!(val, 5);
         assert_eq!(jvm().threads_attached(), 1);
     }

--- a/tests/threads_nested_attach_guard.rs
+++ b/tests/threads_nested_attach_guard.rs
@@ -9,29 +9,29 @@ use util::{
 #[test]
 pub fn nested_attaches_should_not_detach_guarded_thread() {
     assert_eq!(jvm().threads_attached(), 0);
-    let env = attach_current_thread();
-    let val = call_java_abs(&env, -1);
+    let mut env = attach_current_thread();
+    let val = call_java_abs(&mut env, -1);
     assert_eq!(val, 1);
     assert_eq!(jvm().threads_attached(), 1);
 
     // Create nested AttachGuard.
     {
-        let env_nested = attach_current_thread();
-        let val = call_java_abs(&env_nested, -2);
+        let mut env_nested = attach_current_thread();
+        let val = call_java_abs(&mut env_nested, -2);
         assert_eq!(val, 2);
         assert_eq!(jvm().threads_attached(), 1);
     }
 
     // Call a Java method after nested guard has been dropped to check that
     // this thread has not been detached.
-    let val = call_java_abs(&env, -3);
+    let val = call_java_abs(&mut env, -3);
     assert_eq!(val, 3);
     assert_eq!(jvm().threads_attached(), 1);
 
     // Nested attach_permanently is a no-op.
     {
-        let env_nested = attach_current_thread_permanently();
-        let val = call_java_abs(&env_nested, -4);
+        let mut env_nested = attach_current_thread_permanently();
+        let val = call_java_abs(&mut env_nested, -4);
         assert_eq!(val, 4);
         assert_eq!(jvm().threads_attached(), 1);
     }
@@ -39,8 +39,8 @@ pub fn nested_attaches_should_not_detach_guarded_thread() {
 
     // Nested attach_as_daemon is a no-op.
     {
-        let env_nested = attach_current_thread_as_daemon();
-        let val = call_java_abs(&env_nested, -5);
+        let mut env_nested = attach_current_thread_as_daemon();
+        let val = call_java_abs(&mut env_nested, -5);
         assert_eq!(val, 5);
         assert_eq!(jvm().threads_attached(), 1);
     }

--- a/tests/threads_nested_attach_permanently.rs
+++ b/tests/threads_nested_attach_permanently.rs
@@ -9,29 +9,29 @@ use util::{
 #[test]
 pub fn nested_attaches_should_not_detach_permanent_thread() {
     assert_eq!(jvm().threads_attached(), 0);
-    let env = attach_current_thread_permanently();
-    let val = call_java_abs(&env, -1);
+    let mut env = attach_current_thread_permanently();
+    let val = call_java_abs(&mut env, -1);
     assert_eq!(val, 1);
     assert_eq!(jvm().threads_attached(), 1);
 
     // Create nested AttachGuard.
     {
-        let env_nested = attach_current_thread();
-        let val = call_java_abs(&env_nested, -2);
+        let mut env_nested = attach_current_thread();
+        let val = call_java_abs(&mut env_nested, -2);
         assert_eq!(val, 2);
         assert_eq!(jvm().threads_attached(), 1);
     }
 
     // Call a Java method after nested guard has been dropped to check that
     // this thread has not been detached.
-    let val = call_java_abs(&env, -3);
+    let val = call_java_abs(&mut env, -3);
     assert_eq!(val, 3);
     assert_eq!(jvm().threads_attached(), 1);
 
     // Nested attach_permanently is a no-op.
     {
-        let env_nested = attach_current_thread_permanently();
-        let val = call_java_abs(&env_nested, -4);
+        let mut env_nested = attach_current_thread_permanently();
+        let val = call_java_abs(&mut env_nested, -4);
         assert_eq!(val, 4);
         assert_eq!(jvm().threads_attached(), 1);
     }
@@ -39,8 +39,8 @@ pub fn nested_attaches_should_not_detach_permanent_thread() {
 
     // Nested attach_as_daemon is a no-op.
     {
-        let env_nested = attach_current_thread_as_daemon();
-        let val = call_java_abs(&env_nested, -5);
+        let mut env_nested = attach_current_thread_as_daemon();
+        let val = call_java_abs(&mut env_nested, -5);
         assert_eq!(val, 5);
         assert_eq!(jvm().threads_attached(), 1);
     }

--- a/tests/util/example_proxy.rs
+++ b/tests/util/example_proxy.rs
@@ -17,12 +17,13 @@ pub struct AtomicIntegerProxy {
 impl AtomicIntegerProxy {
     /// Creates a new instance of `AtomicIntegerProxy`
     pub fn new(exec: Executor, init_value: jint) -> Result<Self> {
-        let obj = exec.with_attached(|env: &JNIEnv| {
-            env.new_global_ref(env.new_object(
+        let obj = exec.with_attached(|env: &mut JNIEnv| {
+            let i = env.new_object(
                 "java/util/concurrent/atomic/AtomicInteger",
                 "(I)V",
                 &[JValue::from(init_value)],
-            )?)
+            )?;
+            env.new_global_ref(i)
         })?;
         Ok(AtomicIntegerProxy { exec, obj })
     }

--- a/tests/util/mod.rs
+++ b/tests/util/mod.rs
@@ -30,7 +30,7 @@ pub fn jvm() -> &'static Arc<JavaVM> {
 }
 
 #[allow(dead_code)]
-pub fn call_java_abs(env: &JNIEnv, value: i32) -> i32 {
+pub fn call_java_abs(env: &mut JNIEnv, value: i32) -> i32 {
     env.call_static_method(
         "java/lang/Math",
         "abs",
@@ -77,7 +77,7 @@ pub fn print_exception(env: &JNIEnv) {
 }
 
 #[allow(dead_code)]
-pub fn unwrap<T>(env: &JNIEnv, res: Result<T>) -> T {
+pub fn unwrap<T>(res: Result<T>, env: &JNIEnv) -> T {
     res.unwrap_or_else(|e| {
         print_exception(env);
         panic!("{:#?}", e);


### PR DESCRIPTION
## Overview

The over-arching change here is that local reference types (like JObject) are !Copy and any APIs that may allocate new local references must take a mutable reference on the `JNIEnv`.

These rules then mean you can no longer easily access a copy of a local reference after it has been deleted and also mean you can't easily copy local references outside of a local reference frame created using `with_local_frame` (where they would be invalid)

An inter-related change also addresses the leak described in #109 as the Desc trait was updated to account for non-Copy reference types.

This PR has the changes discussed in #392.

This PR is the result of squashing a branch into a single commit. [Here is the original, unsquashed branch.](https://github.com/jni-rs/jni-rs/compare/master...argv-minus-one:jni-rs:safe-refs-unsquashed)

Closes https://github.com/jni-rs/jni-rs/issues/392
Closes https://github.com/jni-rs/jni-rs/issues/384
Closes https://github.com/jni-rs/jni-rs/issues/381
Closes https://github.com/jni-rs/jni-rs/issues/109

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Change is covered by [automated tests](https://github.com/jni-rs/jni-rs/blob/master/CONTRIBUTING.md#tests)
- [x] The [coding guidelines](https://github.com/jni-rs/jni-rs/blob/master/CONTRIBUTING.md#the-code-style) are followed
- [x] Public API has documentation
- [x] User-visible changes are mentioned in the Changelog
- [x] The continuous integration build passes
