### PR TITLE
Add Array wrapper types with lifetimes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,7 @@ This release makes extensive breaking changes in order to improve safety. Most p
 - `JavaVM::detach_current_thread()` (unsafe) as a way to explicitly detach a thread (normally this is automatic on thread exit). Needed to detach daemon threads manually if using `JavaVM::destroy()` ([#391](https://github.com/jni-rs/jni-rs/issues/391))
 - `JPrimitiveArray<T: TypeArray>` and type-specific aliases like `JByteArray`, `JIntArray` etc now provide safe, reference wrappers for the `sys` types `jarray` and `jbyteArray` etc with a lifetime like `JObject` ([#400](https://github.com/jni-rs/jni-rs/pull/400))
 - `JObjectArray` provides a reference wrapper for a `jobjectArray` with a lifetime like `JObject`. ([#400](https://github.com/jni-rs/jni-rs/pull/400))
-- `AutoElements` and `AutoElementsCritical` (previously `AutoArray`/`AutoPrimitiveArray`) implement `Deref<Target=[T]>` and `DerefMut` so array elements can be accessed via slices without needing `unsafe` code. ([#400](https://github.com/jni-rs/jni-rs/pull/400))
+- `AutoElements` and `AutoElementsCritical` (previously `AutoArray`/`AutoPrimitiveArray`) implement `Deref<Target=[T]>` and `DerefMut` so array elements can be accessed via slices without needing additional `unsafe` code. ([#400](https://github.com/jni-rs/jni-rs/pull/400))
 - `AsJArrayRaw` trait which enables `JNIEnv::get_array_length()` to work with `JPrimitiveArray` or `JObjectArray` types ([#400](https://github.com/jni-rs/jni-rs/pull/400))
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,10 +22,14 @@ This release makes extensive breaking changes in order to improve safety. Most p
 - `JavaStr::from_raw()` which takes ownership of a raw string pointer to create a `JavaStr` ([#374](https://github.com/jni-rs/jni-rs/pull/374))
 - `JNIEnv::get_string_unchecked` is a cheaper, `unsafe` alternative to `get_string` that doesn't check the given object is a `java.lang.String` instance. ([#328](https://github.com/jni-rs/jni-rs/issues/328))
 - `WeakRef` and `JNIEnv#new_weak_ref`. ([#304](https://github.com/jni-rs/jni-rs/pull/304))
-- `define_class_bytearray` method that takes an `AutoArray<jbyte>` rather than a `&[u8]`
+- `define_class_bytearray` method that takes an `AutoElements<jbyte>` rather than a `&[u8]` ([#244](https://github.com/jni-rs/jni-rs/pull/244))
 - `JObject` now has an `as_raw` method that borrows the `JObject` instead of taking ownership like `into_raw`. Needed because `JObject` no longer has the `Copy` trait. ([#392](https://github.com/jni-rs/jni-rs/issues/392))
 - `JavaVM::destroy()` (unsafe) as a way to try and unload a `JavaVM` on supported platforms ([#391](https://github.com/jni-rs/jni-rs/issues/391))
 - `JavaVM::detach_current_thread()` (unsafe) as a way to explicitly detach a thread (normally this is automatic on thread exit). Needed to detach daemon threads manually if using `JavaVM::destroy()` ([#391](https://github.com/jni-rs/jni-rs/issues/391))
+- `JPrimitiveArray<T: TypeArray>` and type-specific aliases like `JByteArray`, `JIntArray` etc now provide safe, reference wrappers for the `sys` types `jarray` and `jbyteArray` etc with a lifetime like `JObject` ([#400](https://github.com/jni-rs/jni-rs/pull/400))
+- `JObjectArray` provides a reference wrapper for a `jobjectArray` with a lifetime like `JObject`. ([#400](https://github.com/jni-rs/jni-rs/pull/400))
+- `AutoElements` and `AutoElementsCritical` (previously `AutoArray`/`AutoPrimitiveArray`) implement `Deref<Target=[T]>` and `DerefMut` so array elements can be accessed via slices without needing `unsafe` code. ([#400](https://github.com/jni-rs/jni-rs/pull/400))
+- `AsJArrayRaw` trait which enables `JNIEnv::get_array_length()` to work with `JPrimitiveArray` or `JObjectArray` types ([#400](https://github.com/jni-rs/jni-rs/pull/400))
 
 ### Changed
 - `JNIEnv::get_string` checks that the given object is a `java.lang.String` instance to avoid undefined behaviour from the JNI implementation potentially aborting the program. ([#328](https://github.com/jni-rs/jni-rs/issues/328))
@@ -51,6 +55,13 @@ This release makes extensive breaking changes in order to improve safety. Most p
     - `JValueOwned` does not have the `Copy` trait.
     - The `to_jni` method is now named `as_jni`, and it borrows the `JValueGen` instead of taking ownership.
     - `JObject` can no longer be converted directly to `JValue`, which was commonly done when calling Java methods or constructors. Instead of `obj.into()`, use `(&obj).into()`.
+- All `JNIEnv` array APIs now work in terms of `JPrimitiveArray` and `JObjectArray` (reference wrappers with a lifetime) instead of `sys` types like `jarray` and `jbyteArray` ([#400](https://github.com/jni-rs/jni-rs/pull/400))
+- `AutoArray` and `AutoPrimitiveArray` have been renamed `AutoElements` and `AutoElementsCritical` to show their connection and differentiate from new `JPrimitiveArray` API ([#400](https://github.com/jni-rs/jni-rs/pull/400))
+- `get_primitive_array_critical` is now `unsafe` and has been renamed to `get_array_elements_critical` (consistent with the rename of `AutoPrimitiveArray`) with more detailed safety documentation ([#400](https://github.com/jni-rs/jni-rs/pull/400))
+- `get_array_elements` is now also `unsafe` (for many of the same reasons as `get_array_elements_critical`) and has detailed safety documentation ([#400](https://github.com/jni-rs/jni-rs/pull/400))
+- `AutoArray/AutoArrayCritical::size()` has been replaced with `.len()` which can't fail and returns a `usize` ([#400](https://github.com/jni-rs/jni-rs/pull/400))
+- The `TypeArray` trait is now a private / sealed trait, that is considered to be an implementation detail for the `AutoArray` API.
+
 
 ### Fixed
 - Trying to use an object reference after it has been deleted now causes a compile error instead of undefined behavior. As a result, it is now safe to use `AutoLocal`, `JNIEnv::delete_local_ref`, and `JNIEnv::with_local_frame`. (Most of the limitations added in #392, listed above, were needed to make this work.) ([#381](https://github.com/jni-rs/jni-rs/issues/381), [#392](https://github.com/jni-rs/jni-rs/issues/392))
@@ -58,6 +69,7 @@ This release makes extensive breaking changes in order to improve safety. Most p
 
 ### Removed
 - `get_string_utf_chars` and `release_string_utf_chars` from `JNIEnv` (See `JavaStr::into_raw()` and `JavaStr::from_raw()` instead) ([#372](https://github.com/jni-rs/jni-rs/pull/372))
+- All `JNIEnv::get_<type>_array_elements()` methods have been removed as redundant since they would all be equivalent to `get_array_elements()` with the introduction of `JPrimitiveArray` ([#400](https://github.com/jni-rs/jni-rs/pull/400))
 
 ## [0.20.0] — 2022-10-17
 

--- a/docs/0.21-MIGRATION.md
+++ b/docs/0.21-MIGRATION.md
@@ -274,7 +274,7 @@ There are the following type-specific aliases for `JPrimitiveArray<T>`:
 
 This rename was done to:
 1. Clarify the connection between these APIs (they both provide temporary access to the elements of an array)
-2. Clarify their differences (`AutoElementsCritical` is an `unsafe` alternative that defines a restricted "critical" section that helps JNI avoid the need to copy the data for the array)
+2. Clarify their differences (`AutoElementsCritical` is an alternative that defines a restricted "critical" section that helps JNI avoid the need to copy the data for the array)
 3. Differentiate these from the new `JPrimitiveArray`/`JObjectArray` types and aliases like `JByteArray` that represent the array itself (not the elements)
 
 

--- a/docs/0.21-MIGRATION.md
+++ b/docs/0.21-MIGRATION.md
@@ -288,7 +288,7 @@ It's now possible to read and write elements via the `Deref` and `DerefMut` trai
 let byte_array = env.new_byte_array(100)?;
 
 {
-    let mut elements = env.get_array_elements(&byte_array, ReleaseMode::CopyBack)?;
+    let mut elements = unsafe { env.get_array_elements(&byte_array, ReleaseMode::CopyBack) }?;
 
     elements[0] = 0xff;
     assert_eq!(elements[0], 0xff);

--- a/docs/0.21-MIGRATION.md
+++ b/docs/0.21-MIGRATION.md
@@ -227,7 +227,6 @@ let object_ref: &JObject<'static> = global_ref.as_ref();
 ```
 
 
-
 ## `JNIEnv::get_superclass` now returns `Option`
 
 The `JNIEnv::get_superclass` method previously returned a `JClass`, which would be null if the class in question doesn't have a superclass. It now returns `Option<JClass>` instead, and when it's `Some`, the `JClass` inside is never null.
@@ -236,3 +235,92 @@ The `JNIEnv::get_superclass` method previously returned a `JClass`, which would 
 ## `JNIEnv::{get,release}_string_utf_chars` removed
 
 The methods `JNIEnv::get_string_utf_chars` and `JNIEnv::release_string_utf_chars` have been removed. These methods have been replaced with `JavaStr::into_raw` and `JavaStr::from_raw`. To get a `JavaStr`, use `JNIEnv::get_string` or `JNIEnv::get_string_unchecked`. See [issue #372](https://github.com/jni-rs/jni-rs/pull/372) for discussion.
+
+
+## `JPrimitiveArray<T>` and `JObjectArray` provide safe reference wrappers (like `JObject`) for `jarray`
+
+This affects all `JNIEnv` array APIs including:
+- `new_<type>_array`
+- `get_array_length`
+- `get_object_array_element`
+- `set_object_array_element`
+- `get_<type>_array_region`
+- `set_<type>_array_region`
+- `get_array_elements`
+- `get_<type>_array_elements` (all removed)
+- `get_primitive_array_elements` (also renamed to `get_array_elements_critical`)
+
+With the exception of `get_array_length` these APIs now take or return a
+reference to a `JPrimitiveArray` or a `JObjectArray` instead of a `sys` type
+like `jarray` or `jbyteArray`. This improves safety since the sys types can be
+copied and easily read as invalid pointers after a reference has been deleted.
+
+`get_array_length` will accept a reference to a `JPrimitiveArray` or a `JObjectArray`
+since these both implement the `AsJArrayRaw` trait. You can also query the `.len()`
+of an array via the `AutoElements`/`AutoElementsCritical` APIs if you use those.
+
+There are the following type-specific aliases for `JPrimitiveArray<T>`:
+- `JBooleanArray`
+- `JByteArray`
+- `JCharArray`
+- `JShortArray`
+- `JIntArray`
+- `JLongArray`
+- `JFloatArray`
+- `JDoubleArray`
+
+
+## `AutoArray` and `AutoPrimitiveArray` renamed to `AutoElements` and `AutoElementsCritical` respectively
+
+This rename was done to:
+1. Clarify the connection between these APIs (they both provide temporary access to the elements of an array)
+2. Clarify their differences (`AutoElementsCritical` is an `unsafe` alternative that defines a restricted "critical" section that helps JNI avoid the need to copy the data for the array)
+3. Differentiate these from the new `JPrimitiveArray`/`JObjectArray` types and aliases like `JByteArray` that represent the array itself (not the elements)
+
+
+## `AutoElements<T>` and `AutoElementsCritical<T>` now implement `Deref<Target=[T]>` and `DerefMut`
+
+Previously accessing array elements required the use of `unsafe` code to access array elements via `AutoArray::as_ptr()` after acquiring an `AutoArray` guard.
+
+It's now possible to read and write elements via the `Deref` and `DerefMut` traits that will deref into a `[T]` slice like:
+
+```rust
+let byte_array = env.new_byte_array(100)?;
+
+{
+    let mut elements = env.get_array_elements(&byte_array, ReleaseMode::CopyBack)?;
+
+    elements[0] = 0xff;
+    assert_eq!(elements[0], 0xff);
+
+    // elements released (copied back to Java) here on Drop
+}
+```
+
+If you are accessing a `JPrimitiveArray<jbyte>`/`JByteArray` you may find it helpful
+to utilize the [bytemuck](https://crates.io/crates/bytemuck) crate in case you
+need to access the elements as `u8` unsigned bytes instead of `i8`.
+
+Although this hasn't changed, it seems worth highlighting that if you are
+accessing a `JPrimitiveArray<jboolean>`/`JBooleanArray` you are responsible for
+only storing values of `0` or `1`, since other values could lead to undefined
+behaviour for the JVM.
+
+
+## `AutoArray/AutoPrimitiveArray::size()` replace by `AutoElements/AutoElementsCritical::len()`
+
+Previously `AutoArray::size()` was a wrapper for calling `JNIEnv::get_array_length()` which could
+fail, where as `AutoElements` and `AutoElementsCritical` now need to know the array length to
+be constructed, and this constant is accessible via the `.len()` method.
+
+This change was required to support being able to `Deref` to a `[T]` slice.
+
+
+## `get_array_elements[_critical]` are `unsafe`
+
+Previously `get_array_elements` and `get_primitive_array_critical` could be called by safe code
+but there were multiple ways in which these APIs could quite easily lead to undefined behaviour.
+
+Since it is only possible to acquire an `AutoElements` and `AutoElementsCritical` instance via
+`get_array_elements` and `get_primitive_array_critical`, that's where we now document
+the safety rules that need to be followed to avoid any undefined behaviour.

--- a/example/mylib/Cargo.toml
+++ b/example/mylib/Cargo.toml
@@ -2,7 +2,7 @@
 name = "mylib"
 version = "0.1.0"
 authors = ["Josh Chase <josh@prevoty.com>"]
-edition = "2018"
+edition = "2021"
 
 [dependencies]
 jni = { path = "../../" }

--- a/src/wrapper/jnienv.rs
+++ b/src/wrapper/jnienv.rs
@@ -299,7 +299,7 @@ impl<'local> JNIEnv<'local> {
             name.as_ptr(),
             loader.as_raw(),
             buf.as_ptr(),
-            buf.size()?
+            buf.len() as _
         );
         Ok(unsafe { JClass::from_raw(class) })
     }

--- a/src/wrapper/objects/auto_array.rs
+++ b/src/wrapper/objects/auto_array.rs
@@ -162,7 +162,7 @@ impl<'local, 'other_local, 'array, T: TypeArray> AutoArray<'local, 'other_local,
         array: &'array JPrimitiveArray<'other_local, T>,
         mode: ReleaseMode,
     ) -> Result<Self> {
-        let len = env.get_array_length(array.as_raw())? as usize;
+        let len = env.get_array_length(array)? as usize;
         unsafe { Self::new_with_len(env, array, len, mode) }
     }
 

--- a/src/wrapper/objects/auto_elements_critical.rs
+++ b/src/wrapper/objects/auto_elements_critical.rs
@@ -15,7 +15,7 @@ use super::JByteArray;
 ///
 /// This type is used to wrap pointers returned by `GetPrimitiveArrayCritical`
 /// and ensure the pointer is released via `ReleasePrimitiveArrayCritical` when dropped.
-pub struct AutoPrimitiveArray<'local, 'other_local, 'array, 'env, T: TypeArray> {
+pub struct AutoElementsCritical<'local, 'other_local, 'array, 'env, T: TypeArray> {
     array: &'array JPrimitiveArray<'other_local, T>,
     len: usize,
     ptr: NonNull<T>,
@@ -25,7 +25,7 @@ pub struct AutoPrimitiveArray<'local, 'other_local, 'array, 'env, T: TypeArray> 
 }
 
 impl<'local, 'other_local, 'array, 'env, T: TypeArray>
-    AutoPrimitiveArray<'local, 'other_local, 'array, 'env, T>
+    AutoElementsCritical<'local, 'other_local, 'array, 'env, T>
 {
     /// # Safety
     ///
@@ -49,7 +49,7 @@ impl<'local, 'other_local, 'array, 'env, T: TypeArray>
             &mut is_copy
         ) as *mut T;
 
-        Ok(AutoPrimitiveArray {
+        Ok(AutoElementsCritical {
             array,
             len,
             ptr: NonNull::new(ptr).ok_or(Error::NullPtr("Non-null ptr expected"))?,
@@ -119,16 +119,16 @@ impl<'local, 'other_local, 'array, 'env, T: TypeArray>
 }
 
 impl<'local, 'other_local, 'array, 'env, T: TypeArray>
-    AsRef<AutoPrimitiveArray<'local, 'other_local, 'array, 'env, T>>
-    for AutoPrimitiveArray<'local, 'other_local, 'array, 'env, T>
+    AsRef<AutoElementsCritical<'local, 'other_local, 'array, 'env, T>>
+    for AutoElementsCritical<'local, 'other_local, 'array, 'env, T>
 {
-    fn as_ref(&self) -> &AutoPrimitiveArray<'local, 'other_local, 'array, 'env, T> {
+    fn as_ref(&self) -> &AutoElementsCritical<'local, 'other_local, 'array, 'env, T> {
         self
     }
 }
 
 impl<'local, 'other_local, 'array, 'env, T: TypeArray> Drop
-    for AutoPrimitiveArray<'local, 'other_local, 'array, 'env, T>
+    for AutoElementsCritical<'local, 'other_local, 'array, 'env, T>
 {
     fn drop(&mut self) {
         // Safety: `self.mode` is valid and the array has not yet been released.
@@ -142,15 +142,15 @@ impl<'local, 'other_local, 'array, 'env, T: TypeArray> Drop
 }
 
 impl<'local, 'other_local, 'array, 'env, T: TypeArray>
-    From<&AutoPrimitiveArray<'local, 'other_local, 'array, 'env, T>> for *mut T
+    From<&AutoElementsCritical<'local, 'other_local, 'array, 'env, T>> for *mut T
 {
-    fn from(other: &AutoPrimitiveArray<T>) -> *mut T {
+    fn from(other: &AutoElementsCritical<T>) -> *mut T {
         other.as_ptr()
     }
 }
 
 impl<'local, 'other_local, 'array, 'env, T: TypeArray> std::ops::Deref
-    for AutoPrimitiveArray<'local, 'other_local, 'array, 'env, T>
+    for AutoElementsCritical<'local, 'other_local, 'array, 'env, T>
 {
     type Target = [T];
 
@@ -160,7 +160,7 @@ impl<'local, 'other_local, 'array, 'env, T: TypeArray> std::ops::Deref
 }
 
 impl<'local, 'other_local, 'array, 'env, T: TypeArray> std::ops::DerefMut
-    for AutoPrimitiveArray<'local, 'other_local, 'array, 'env, T>
+    for AutoElementsCritical<'local, 'other_local, 'array, 'env, T>
 {
     fn deref_mut(&mut self) -> &mut Self::Target {
         unsafe { std::slice::from_raw_parts_mut(self.ptr.as_mut(), self.len) }

--- a/src/wrapper/objects/auto_primitive_array.rs
+++ b/src/wrapper/objects/auto_primitive_array.rs
@@ -64,7 +64,7 @@ impl<'local, 'other_local, 'array, 'env, T: TypeArray>
         array: &'array JPrimitiveArray<'other_local, T>,
         mode: ReleaseMode,
     ) -> Result<Self> {
-        let len = env.get_array_length(array.as_raw())? as usize;
+        let len = env.get_array_length(array)? as usize;
         unsafe { Self::new_with_len(env, array, len, mode) }
     }
 

--- a/src/wrapper/objects/jobject.rs
+++ b/src/wrapper/objects/jobject.rs
@@ -5,11 +5,12 @@ use crate::sys::jobject;
 #[cfg(doc)]
 use crate::{objects::GlobalRef, JNIEnv};
 
-/// Wrapper around `sys::jobject` that adds a lifetime. This prevents it from
-/// outliving the context in which it was acquired and getting GC'd out from
-/// under us. It matches C's representation of the raw pointer, so it can be
-/// used in any of the extern function argument positions that would take a
-/// `jobject`.
+/// Wrapper around [`sys::jobject`] that adds a lifetime to ensure that
+/// the underlying JNI pointer won't be accessible to safe Rust code if the
+/// object reference is released.
+///
+/// It matches C's representation of the raw pointer, so it can be used in any
+/// of the extern function argument positions that would take a `jobject`.
 ///
 /// Most other types in the `objects` module deref to this, as they do in the C
 /// representation.

--- a/src/wrapper/objects/jobject_array.rs
+++ b/src/wrapper/objects/jobject_array.rs
@@ -1,27 +1,26 @@
 use crate::{
     objects::JObject,
-    sys::{jclass, jobject},
+    sys::{jobject, jobjectArray},
 };
 
-/// Lifetime'd representation of a `jclass`. Just a `JObject` wrapped in a new
-/// class.
+/// Lifetime'd representation of a [`jobjectArray`] which wraps a [`JObject`] reference
 #[repr(transparent)]
 #[derive(Debug)]
-pub struct JClass<'local>(JObject<'local>);
+pub struct JObjectArray<'local>(JObject<'local>);
 
-impl<'local> AsRef<JClass<'local>> for JClass<'local> {
-    fn as_ref(&self) -> &JClass<'local> {
+impl<'local> AsRef<JObjectArray<'local>> for JObjectArray<'local> {
+    fn as_ref(&self) -> &JObjectArray<'local> {
         self
     }
 }
 
-impl<'local> AsRef<JObject<'local>> for JClass<'local> {
+impl<'local> AsRef<JObject<'local>> for JObjectArray<'local> {
     fn as_ref(&self) -> &JObject<'local> {
         self
     }
 }
 
-impl<'local> ::std::ops::Deref for JClass<'local> {
+impl<'local> ::std::ops::Deref for JObjectArray<'local> {
     type Target = JObject<'local>;
 
     fn deref(&self) -> &Self::Target {
@@ -29,35 +28,35 @@ impl<'local> ::std::ops::Deref for JClass<'local> {
     }
 }
 
-impl<'local> From<JClass<'local>> for JObject<'local> {
-    fn from(other: JClass) -> JObject {
+impl<'local> From<JObjectArray<'local>> for JObject<'local> {
+    fn from(other: JObjectArray) -> JObject {
         other.0
     }
 }
 
 /// This conversion assumes that the `JObject` is a pointer to a class object.
-impl<'local> From<JObject<'local>> for JClass<'local> {
+impl<'local> From<JObject<'local>> for JObjectArray<'local> {
     fn from(other: JObject) -> Self {
         unsafe { Self::from_raw(other.into_raw()) }
     }
 }
 
 /// This conversion assumes that the `JObject` is a pointer to a class object.
-impl<'local, 'obj_ref> From<&'obj_ref JObject<'local>> for &'obj_ref JClass<'local> {
+impl<'local, 'obj_ref> From<&'obj_ref JObject<'local>> for &'obj_ref JObjectArray<'local> {
     fn from(other: &'obj_ref JObject<'local>) -> Self {
-        // Safety: `JClass` is `repr(transparent)` around `JObject`.
-        unsafe { &*(other as *const JObject<'local> as *const JClass<'local>) }
+        // Safety: `JObjectArray` is `repr(transparent)` around `JObject`.
+        unsafe { &*(other as *const JObject<'local> as *const JObjectArray<'local>) }
     }
 }
 
-impl<'local> std::default::Default for JClass<'local> {
+impl<'local> std::default::Default for JObjectArray<'local> {
     fn default() -> Self {
         Self(JObject::null())
     }
 }
 
-impl<'local> JClass<'local> {
-    /// Creates a [`JClass`] that wraps the given `raw` [`jclass`]
+impl<'local> JObjectArray<'local> {
+    /// Creates a [`JObjectArray`] that wraps the given `raw` [`jobjectArray`]
     ///
     /// # Safety
     ///
@@ -67,17 +66,12 @@ impl<'local> JClass<'local> {
     /// * There must not be any other `JObject` representing the same local reference.
     /// * The lifetime `'local` must not outlive the local reference frame that the local reference
     ///   was created in.
-    pub unsafe fn from_raw(raw: jclass) -> Self {
+    pub unsafe fn from_raw(raw: jobjectArray) -> Self {
         Self(JObject::from_raw(raw as jobject))
     }
 
-    /// Returns the raw JNI pointer.
-    pub fn as_raw(&self) -> jclass {
-        self.0.as_raw() as jclass
-    }
-
     /// Unwrap to the raw jni type.
-    pub fn into_raw(self) -> jclass {
-        self.0.into_raw() as jclass
+    pub fn into_raw(self) -> jobjectArray {
+        self.0.into_raw() as jobjectArray
     }
 }

--- a/src/wrapper/objects/jobject_array.rs
+++ b/src/wrapper/objects/jobject_array.rs
@@ -3,6 +3,8 @@ use crate::{
     sys::{jobject, jobjectArray},
 };
 
+use super::AsJArrayRaw;
+
 /// Lifetime'd representation of a [`jobjectArray`] which wraps a [`JObject`] reference
 #[repr(transparent)]
 #[derive(Debug)]
@@ -54,6 +56,8 @@ impl<'local> std::default::Default for JObjectArray<'local> {
         Self(JObject::null())
     }
 }
+
+unsafe impl<'local> AsJArrayRaw<'local> for JObjectArray<'local> {}
 
 impl<'local> JObjectArray<'local> {
     /// Creates a [`JObjectArray`] that wraps the given `raw` [`jobjectArray`]

--- a/src/wrapper/objects/jprimitive_array.rs
+++ b/src/wrapper/objects/jprimitive_array.rs
@@ -126,3 +126,19 @@ pub type JFloatArray<'local> = JPrimitiveArray<'local, crate::sys::jfloat>;
 
 /// Lifetime'd representation of a [`crate::sys::jdoubleArray`] which wraps a [`JObject`] reference
 pub type JDoubleArray<'local> = JPrimitiveArray<'local, crate::sys::jdouble>;
+
+/// Trait to access the raw `jarray` pointer for types that wrap an array reference
+///
+/// # Safety
+///
+/// Implementing this trait will allow a type to be passed to [`JNIEnv::get_array_length()`]
+/// or other JNI APIs that only work with a valid reference to an array (or `null`)
+///
+pub unsafe trait AsJArrayRaw<'local>: AsRef<JObject<'local>> {
+    /// Returns the raw JNI pointer as a `jarray`
+    fn as_jarray_raw(&self) -> jarray {
+        self.as_ref().as_raw() as jarray
+    }
+}
+
+unsafe impl<'local, T: TypeArray> AsJArrayRaw<'local> for JPrimitiveArray<'local, T> {}

--- a/src/wrapper/objects/jprimitive_array.rs
+++ b/src/wrapper/objects/jprimitive_array.rs
@@ -1,0 +1,128 @@
+use std::marker::PhantomData;
+
+use crate::{
+    objects::JObject,
+    sys::{jarray, jobject},
+};
+
+use super::TypeArray;
+
+#[cfg(doc)]
+use crate::JNIEnv;
+
+/// Lifetime'd representation of a [`jarray`] which wraps a [`JObject`] reference
+///
+/// This is a wrapper type for a [`JObject`] local reference that's used to
+/// differentiate JVM array types.
+#[repr(transparent)]
+#[derive(Debug)]
+pub struct JPrimitiveArray<'local, T: TypeArray> {
+    obj: JObject<'local>,
+    lifetime: PhantomData<&'local T>,
+}
+
+impl<'local, T: TypeArray> AsRef<JPrimitiveArray<'local, T>> for JPrimitiveArray<'local, T> {
+    fn as_ref(&self) -> &JPrimitiveArray<'local, T> {
+        self
+    }
+}
+
+impl<'local, T: TypeArray> AsMut<JPrimitiveArray<'local, T>> for JPrimitiveArray<'local, T> {
+    fn as_mut(&mut self) -> &mut JPrimitiveArray<'local, T> {
+        self
+    }
+}
+
+impl<'local, T: TypeArray> AsRef<JObject<'local>> for JPrimitiveArray<'local, T> {
+    fn as_ref(&self) -> &JObject<'local> {
+        &self.obj
+    }
+}
+
+impl<'local, T: TypeArray> ::std::ops::Deref for JPrimitiveArray<'local, T> {
+    type Target = JObject<'local>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.obj
+    }
+}
+
+impl<'local, T: TypeArray> From<JPrimitiveArray<'local, T>> for JObject<'local> {
+    fn from(other: JPrimitiveArray<'local, T>) -> JObject {
+        other.obj
+    }
+}
+
+/// This conversion assumes that the `JObject` is a pointer to a class object.
+impl<'local, T: TypeArray> From<JObject<'local>> for JPrimitiveArray<'local, T> {
+    fn from(other: JObject) -> Self {
+        unsafe { Self::from_raw(other.into_raw()) }
+    }
+}
+
+/// This conversion assumes that the `JObject` is a pointer to a class object.
+impl<'local, 'obj_ref, T: TypeArray> From<&'obj_ref JObject<'local>>
+    for &'obj_ref JPrimitiveArray<'local, T>
+{
+    fn from(other: &'obj_ref JObject<'local>) -> Self {
+        // Safety: `JPrimitiveArray` is `repr(transparent)` around `JObject`.
+        unsafe { &*(other as *const JObject<'local> as *const JPrimitiveArray<'local, T>) }
+    }
+}
+
+impl<'local, T: TypeArray> std::default::Default for JPrimitiveArray<'local, T> {
+    fn default() -> Self {
+        Self {
+            obj: JObject::null(),
+            lifetime: PhantomData,
+        }
+    }
+}
+
+impl<'local, T: TypeArray> JPrimitiveArray<'local, T> {
+    /// Creates a [`JPrimitiveArray`] that wraps the given `raw` [`jarray`]
+    ///
+    /// # Safety
+    ///
+    /// `raw` may be a null pointer. If `raw` is not a null pointer, then:
+    ///
+    /// * `raw` must be a valid raw JNI local reference.
+    /// * There must not be any other `JObject` representing the same local reference.
+    /// * The lifetime `'local` must not outlive the local reference frame that the local reference
+    ///   was created in.
+    pub unsafe fn from_raw(raw: jarray) -> Self {
+        Self {
+            obj: JObject::from_raw(raw as jobject),
+            lifetime: PhantomData,
+        }
+    }
+
+    /// Unwrap to the raw jni type.
+    pub fn into_raw(self) -> jarray {
+        self.obj.into_raw() as jarray
+    }
+}
+
+/// Lifetime'd representation of a [`crate::sys::jbooleanArray`] which wraps a [`JObject`] reference
+pub type JBooleanArray<'local> = JPrimitiveArray<'local, crate::sys::jboolean>;
+
+/// Lifetime'd representation of a [`crate::sys::jbyteArray`] which wraps a [`JObject`] reference
+pub type JByteArray<'local> = JPrimitiveArray<'local, crate::sys::jbyte>;
+
+/// Lifetime'd representation of a [`crate::sys::jcharArray`] which wraps a [`JObject`] reference
+pub type JCharArray<'local> = JPrimitiveArray<'local, crate::sys::jchar>;
+
+/// Lifetime'd representation of a [`crate::sys::jshortArray`] which wraps a [`JObject`] reference
+pub type JShortArray<'local> = JPrimitiveArray<'local, crate::sys::jshort>;
+
+/// Lifetime'd representation of a [`crate::sys::jintArray`] which wraps a [`JObject`] reference
+pub type JIntArray<'local> = JPrimitiveArray<'local, crate::sys::jint>;
+
+/// Lifetime'd representation of a [`crate::sys::jlongArray`] which wraps a [`JObject`] reference
+pub type JLongArray<'local> = JPrimitiveArray<'local, crate::sys::jlong>;
+
+/// Lifetime'd representation of a [`crate::sys::jfloatArray`] which wraps a [`JObject`] reference
+pub type JFloatArray<'local> = JPrimitiveArray<'local, crate::sys::jfloat>;
+
+/// Lifetime'd representation of a [`crate::sys::jdoubleArray`] which wraps a [`JObject`] reference
+pub type JDoubleArray<'local> = JPrimitiveArray<'local, crate::sys::jdouble>;

--- a/src/wrapper/objects/jstring.rs
+++ b/src/wrapper/objects/jstring.rs
@@ -58,7 +58,12 @@ impl<'local> JString<'local> {
     ///
     /// # Safety
     ///
-    /// Expects a valid pointer or `null`
+    /// `raw` may be a null pointer. If `raw` is not a null pointer, then:
+    ///
+    /// * `raw` must be a valid raw JNI local reference.
+    /// * There must not be any other `JObject` representing the same local reference.
+    /// * The lifetime `'local` must not outlive the local reference frame that the local reference
+    ///   was created in.
     pub unsafe fn from_raw(raw: jstring) -> Self {
         Self(JObject::from_raw(raw as jobject))
     }

--- a/src/wrapper/objects/jthrowable.rs
+++ b/src/wrapper/objects/jthrowable.rs
@@ -58,7 +58,12 @@ impl<'local> JThrowable<'local> {
     ///
     /// # Safety
     ///
-    /// Expects a valid pointer or `null`
+    /// `raw` may be a null pointer. If `raw` is not a null pointer, then:
+    ///
+    /// * `raw` must be a valid raw JNI local reference.
+    /// * There must not be any other `JObject` representing the same local reference.
+    /// * The lifetime `'local` must not outlive the local reference frame that the local reference
+    ///   was created in.
     pub unsafe fn from_raw(raw: jthrowable) -> Self {
         Self(JObject::from_raw(raw as jobject))
     }

--- a/src/wrapper/objects/mod.rs
+++ b/src/wrapper/objects/mod.rs
@@ -58,10 +58,9 @@ mod jprimitive_array;
 pub use self::jprimitive_array::*;
 
 // For automatic pointer-based generic array release
-mod auto_array;
-pub use self::auto_array::*;
+mod auto_elements;
+pub use self::auto_elements::*;
 
 // For automatic pointer-based primitive array release
-mod auto_primitive_array;
-
-pub use self::auto_primitive_array::*;
+mod auto_elements_critical;
+pub use self::auto_elements_critical::*;

--- a/src/wrapper/objects/mod.rs
+++ b/src/wrapper/objects/mod.rs
@@ -49,6 +49,14 @@ pub use self::auto_local::*;
 mod release_mode;
 pub use self::release_mode::*;
 
+/// Primitive Array types
+mod jobject_array;
+pub use self::jobject_array::*;
+
+/// Primitive Array types
+mod jprimitive_array;
+pub use self::jprimitive_array::*;
+
 // For automatic pointer-based generic array release
 mod auto_array;
 pub use self::auto_array::*;

--- a/src/wrapper/objects/release_mode.rs
+++ b/src/wrapper/objects/release_mode.rs
@@ -1,8 +1,11 @@
 use crate::sys::JNI_ABORT;
 
+#[cfg(doc)]
+use super::{AutoElements, AutoElementsCritical};
+
 /// ReleaseMode
 ///
-/// This defines the release mode of AutoArray (and AutoPrimitiveArray) resources, and
+/// This defines the release mode of [`AutoElements`] (and [`AutoElementsCritical`]) resources, and
 /// related release array functions.
 #[derive(Clone, Copy, Debug)]
 #[repr(i32)]

--- a/tests/java_integers.rs
+++ b/tests/java_integers.rs
@@ -1,6 +1,6 @@
 #![cfg(feature = "invocation")]
 
-use jni::{errors::Error, objects::JObject, objects::JValue};
+use jni::{errors::Error, objects::JValue};
 
 mod util;
 use util::{attach_current_thread, print_exception};
@@ -18,7 +18,6 @@ fn test_java_integers() {
 
             let values_array =
                 env.new_object_array(array_length, "java/lang/Integer", &integer_value)?;
-            let values_array = unsafe { JObject::from_raw(values_array) };
 
             let result = env
                 .call_static_method(

--- a/tests/jni_api.rs
+++ b/tests/jni_api.rs
@@ -5,8 +5,7 @@ use jni::{
     descriptors::Desc,
     errors::Error,
     objects::{
-        AutoArray, AutoLocal, JByteBuffer, JList, JObject, JPrimitiveArray, JString, JThrowable,
-        JValue, ReleaseMode,
+        AutoArray, AutoLocal, JByteBuffer, JList, JObject, JString, JThrowable, JValue, ReleaseMode,
     },
     signature::{JavaType, Primitive, ReturnType},
     strings::JNIString,
@@ -490,10 +489,10 @@ macro_rules! test_auto_array_read_write {
             // Use a scope to test Drop
             {
                 // Get byte array elements auto wrapper
-                let mut auto_ptr: AutoArray<$jni_type> = {
+                let mut auto_ptr: AutoArray<$jni_type> = unsafe {
                     // Make sure the lifetime is tied to the environment,
                     // not the particular JNIEnv reference
-                    let mut temporary_env: JNIEnv = unsafe { env.unsafe_clone() };
+                    let mut temporary_env: JNIEnv = env.unsafe_clone();
                     temporary_env.get_array_elements(&java_array, ReleaseMode::CopyBack).unwrap()
                 };
 
@@ -638,9 +637,10 @@ pub fn get_long_array_elements_commit() {
     let _ = env.set_long_array_region(&java_array, 0, buf);
 
     // Get long array elements auto wrapper
-    let mut auto_ptr = env
-        .get_array_elements(&java_array, ReleaseMode::CopyBack)
-        .unwrap();
+    let mut auto_ptr = unsafe {
+        env.get_array_elements(&java_array, ReleaseMode::CopyBack)
+            .unwrap()
+    };
 
     // Copying the array depends on the VM vendor/version/GC combinations.
     // If the wrapped array is not being copied, we can skip the test.
@@ -687,9 +687,10 @@ pub fn get_primitive_array_critical() {
     // Use a scope to test Drop
     {
         // Get primitive array elements auto wrapper
-        let mut auto_ptr = env
-            .get_primitive_array_critical(&java_array, ReleaseMode::CopyBack)
-            .unwrap();
+        let mut auto_ptr = unsafe {
+            env.get_primitive_array_critical(&java_array, ReleaseMode::CopyBack)
+                .unwrap()
+        };
 
         // Check array size
         assert_eq!(auto_ptr.len(), 3);

--- a/tests/jni_api.rs
+++ b/tests/jni_api.rs
@@ -5,7 +5,8 @@ use jni::{
     descriptors::Desc,
     errors::Error,
     objects::{
-        AutoArray, AutoLocal, JByteBuffer, JList, JObject, JString, JThrowable, JValue, ReleaseMode,
+        AutoElements, AutoLocal, JByteBuffer, JList, JObject, JString, JThrowable, JValue,
+        ReleaseMode,
     },
     signature::{JavaType, Primitive, ReturnType},
     strings::JNIString,
@@ -489,7 +490,7 @@ macro_rules! test_auto_array_read_write {
             // Use a scope to test Drop
             {
                 // Get byte array elements auto wrapper
-                let mut auto_ptr: AutoArray<$jni_type> = unsafe {
+                let mut auto_ptr: AutoElements<$jni_type> = unsafe {
                     // Make sure the lifetime is tied to the environment,
                     // not the particular JNIEnv reference
                     let mut temporary_env: JNIEnv = env.unsafe_clone();
@@ -675,7 +676,7 @@ pub fn get_long_array_elements_commit() {
 }
 
 #[test]
-pub fn get_primitive_array_critical() {
+pub fn get_array_elements_critical() {
     let mut env = attach_current_thread();
 
     // Create original Java array
@@ -688,7 +689,7 @@ pub fn get_primitive_array_critical() {
     {
         // Get primitive array elements auto wrapper
         let mut auto_ptr = unsafe {
-            env.get_primitive_array_critical(&java_array, ReleaseMode::CopyBack)
+            env.get_array_elements_critical(&java_array, ReleaseMode::CopyBack)
                 .unwrap()
         };
 


### PR DESCRIPTION
## Overview

Instead of all the array-based APIs being based on sys types like
`jbyteArray` (which can easily lead to the use of invalid local
references) this introduces types like `JByteArray<'local>` that
have a lifetime parameter to ensure the local reference can't
be read if it is deleted or goes out of scope.

`JByteArray` and `JIntArray` etc are based on a generic
`JPrimitiveArray<T>` which takes any of the primitive types that
may be put into arrays, like `jbyte` or `jint`.

`JObjectArray` is handled separately, considering that it can't be used
with `AutoArray` or `AutoPrimitiveArray`.

The implementations of `AutoArray` and `AutoPrimitiveArray` were updated
so they can be created based on a `JPrimitiveAarray`.

While updating the lifetime parameters to the `AutoArray` and
`AutoPrimitiveArray` APIs numerous implementation inconsistencies were
found, even though they should only really differ in how they acquire /
release the pointer to array elements. This patch also normalizes the
implementation of both of these APIs, so they are easily comparable. It
may even be possible to unify these at some point.

Closes: #396
Closes #41

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Change is covered by [automated tests](https://github.com/jni-rs/jni-rs/blob/master/CONTRIBUTING.md#tests)
- [x] The [coding guidelines](https://github.com/jni-rs/jni-rs/blob/master/CONTRIBUTING.md#the-code-style) are followed
- [x] Public API has documentation
- [x] User-visible changes are mentioned in the Changelog
- [x] The continuous integration build passes

