### PR TITLE
Add a migration guide for 0.21 to the changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+This release makes extensive breaking changes in order to improve safety. Most projects that use this library will need to be changed. Please see [the migration guide](docs/0.21-MIGRATION.md).
+
 ### Added
 - `JavaStr::into_raw()` which drops the `JavaStr` and releases ownership of the raw string pointer ([#374](https://github.com/jni-rs/jni-rs/pull/374))
 - `JavaStr::from_raw()` which takes ownership of a raw string pointer to create a `JavaStr` ([#374](https://github.com/jni-rs/jni-rs/pull/374))
@@ -30,7 +32,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - The `get_superclass` function now returns an Option instead of a null pointer if the class has no superclass ([#151](https://github.com/jni-rs/jni-rs/issues/151))
 - The `invocation` feature now locates the JVM implementation dynamically at runtime (via the `java-locator` crate by default) instead of linking with the JVM at build time ([#293](https://github.com/jni-rs/jni-rs/pull/293))
 - Most `JNIEnv` methods now require `&mut self`. This improves safety by preventing `JObject`s from getting an invalid lifetime. Most native method implementations (that is, `#[no_mangle] extern "system" fn`s) must now make the `JNIEnv` parameter `mut`. See the example on the crate documentation. ([#392](https://github.com/jni-rs/jni-rs/issues/392))
-- `JByteBuffer`, `JClass`, `JNIEnv`, `JObject`, `JString`, and `JThrowable` no longer have the `Clone` or `Copy` traits. This improves safety by preventing object references from being used after the JVM deletes them. Most functions that take one of these types as a parameter should now borrow it instead, e.g. `&JObject` instead of `JObject`. ([#392](https://github.com/jni-rs/jni-rs/issues/392))
+- `JByteBuffer`, `JClass`, `JNIEnv`, `JObject`, `JString`, and `JThrowable` no longer have the `Clone` or `Copy` traits. This improves safety by preventing object references from being used after the JVM deletes them. Most functions that take one of these types as a parameter (except `extern fn`s that are directly called by the JVM) should now borrow it instead, e.g. `&JObject` instead of `JObject`. ([#392](https://github.com/jni-rs/jni-rs/issues/392))
 - `AutoLocal` is now generic in the type of object reference (`JString`, etc). ([#392](https://github.com/jni-rs/jni-rs/issues/392))
 - The closure passed to `JNIEnv::with_local_frame` must now take a `&mut JNIEnv` parameter, which has a different lifetime. This improves safety by preventing local references from escaping the closure, which would cause a use-after-free bug. `Executor::with_attached` and `Executor::with_attached_capacity` have been similarly changed. ([#392](https://github.com/jni-rs/jni-rs/issues/392))
 - `Desc`, `JNIEnv::pop_local_frame`, and `TypeArray` are now `unsafe`. ([#392](https://github.com/jni-rs/jni-rs/issues/392))

--- a/docs/0.21-MIGRATION.md
+++ b/docs/0.21-MIGRATION.md
@@ -1,0 +1,211 @@
+# Migrating to 0.21
+
+Version 0.21 makes extensive breaking changes in order to improve safety. Most projects that use this library will need to be changed accordingly.
+
+This is a guide for migrating to 0.21. For a full list of changes in this release, please see the [changelog](../CHANGELOG.md).
+
+Most of these changes are needed to ensure that all local references (`JObject` and the like) have the correct lifetime and can't be used after they're deleted, which would cause undefined behavior. See [issue #392](https://github.com/jni-rs/jni-rs/issues/392) for a discussion of the problem these changes solve.
+
+
+## `JNIEnv` parameter of `extern fn`s should now be `mut`
+
+In `extern fn`s that are directly called by the JVM, the `JNIEnv` parameter will usually need to be `mut`.
+
+```rust
+#[no_mangle]
+pub extern "system" fn Java_HelloWorld_hello<'local>(mut env: JNIEnv<'local>,
+                                                     class: JClass<'local>,
+                                                     input: JString<'local>)
+                                                     -> jstring {
+    …
+}
+```
+
+This is needed because most `JNIEnv` methods now take a `&mut self` parameter.
+
+
+## `JNIEnv`, `JObject`, etc are now `!Copy` and should be borrowed
+
+Functions that are *not* directly called by the JVM should, in most cases, borrow local references (`JObject`, `JString`, and so on) and mutably borrow `JNIEnv`s.
+
+```rust
+pub fn print_string(env: &mut JNIEnv,
+                    string: &JString)
+                    -> Result<()> {
+    println!("{}", env.get_string(string)?.to_string_lossy());
+    Ok(())
+}
+```
+
+This is needed because these types no longer have the `Copy` or `Clone` traits.
+
+
+## `JNIEnv::with_local_frame` closure now takes a `&mut JNIEnv` parameter
+
+When using `JNIEnv::with_local_frame`, `Executor::with_attached`, or `Executor::with_attached_capacity`, the closure must now take a parameter of type `&mut JNIEnv`.
+
+```rust
+env.with_local_frame(16, |env| {
+    …
+})
+```
+
+The closure must only use the `JNIEnv` passed to it in that parameter, and not the `JNIEnv` that `with_local_frame` was called on.
+
+
+## Passing object reference parameters to Java methods
+
+When passing an object reference as a parameter to a Java method or constructor, it needs to be explicitly borrowed, as in `(&obj).into()`, instead of simply `obj.into()`.
+
+```rust
+env.call_static_method(
+    "com/example/SomeClass",
+    "someStaticMethod",
+    "(Ljava/lang/Object;)V",
+    &[
+        (&obj).into(),
+    ],
+)
+```
+
+
+## `JList` and `JMap` methods all take a `&mut JNIEnv` parameter
+
+All methods of `JList` and `JMap` now require a parameter of type `&mut JNIEnv`. They no longer store the `JNIEnv` that was used to construct them.
+
+This is needed because most `JNIEnv` methods now take a `&mut self` parameter, and if the `JList` or `JMap` did store a `&mut JNIEnv`, then the caller would be unable to use the `JNIEnv` for anything else without first dropping the `JList` or `JMap`.
+
+
+## `JList` and `JMap` iterators no longer implement `Iterator`
+
+Just like the methods of `JList` and `JMap`, their iterator now also requires a `&mut JNIEnv` in order to get the next element.
+
+For this reason, the iterator returned by `JList::iter` and `JMap::iter` no longer implements `std::iter::Iterator` and can no longer be used with a `for` loop. Instead, it has a `next` method that takes a `&mut JNIEnv` parameter, and can be used with a `while let` loop.
+
+```rust
+let mut iterator = list.iter(env)?;
+
+while let Some(obj) = iterator.next(env)? {
+    let obj: AutoLocal<JObject> = env.auto_local(obj);
+    // Do something with `obj` here.
+}
+```
+
+
+## Local references no longer leak
+
+`JNIEnv` methods that look up Java classes no longer leak local references ([#109](https://github.com/jni-rs/jni-rs/issues/109)), so it is no longer necessary to wrap calls to these methods inside `JNIEnv::with_local_frame`.
+
+
+## `cannot borrow as mutable`
+
+If your project has a function that takes two or more parameters, one of them is `JNIEnv`, and another is something returned by a `JNIEnv` method (like `JObject`), then calls to that function may not compile.
+
+```rust
+fn example_function(
+    env: &mut JNIEnv,
+    obj: &JObject,
+) {
+    // …
+}
+
+example_function(
+    env,
+    // ERROR: cannot borrow `*env` as mutable more than once at a time
+    &env.new_object(
+        "com/example/SomeClass",
+        "()V",
+        &[],
+    )?,
+)
+```
+
+To fix this, the `JNIEnv` parameter needs to come *last*.
+
+```rust
+fn example_function(
+    obj: &JObject,
+    env: &mut JNIEnv,
+) {
+    // …
+}
+
+example_function(
+    &env.new_object(
+        "com/example/SomeClass",
+        "()V",
+        &[],
+    )?,
+    env,
+);
+```
+
+
+## `invocation` feature now finds and loads the JVM dynamically; `JavaVM::new` returns different error
+
+The `invocation` feature has been changed to locate and load the Java Virtual Machine at run time, using the [java-locator](https://crates.io/crates/java-locator) and [libloading](https://crates.io/crates/libloading) libraries.
+
+`JavaVM::new` now returns a different error type, `StartJvmError`, when it fails. This new error type covers failures to locate and load the JVM library as well as failures to initialize the JVM.
+
+If you need to load a specific JVM library instead of automatically discovering one, use `JavaVM::with_libjvm` instead.
+
+On non-Windows platforms, it is no longer necessary for the Java runtime's `lib` folder to be on the shared library search path (`LD_LIBRARY_PATH` or equivalent). Unfortunately, this is *not* true on Windows, where the Java runtime's DLLs must still be on the `PATH` (or added to the DLL search path with [`SetDllDirectory`](https://learn.microsoft.com/en-us/windows/win32/api/winbase/nf-winbase-setdlldirectoryw)).
+
+
+## `Desc` has been redesigned
+
+The `Desc` trait has been redesigned. If your project contains any implementations of `Desc` and/or calls to `Desc::lookup`, they will need to be updated.
+
+If your project uses `Desc` directly like this, please post a comment on [issue #403](https://github.com/jni-rs/jni-rs/issues/403) explaining your situation. We view `Desc` as an implementation detail, and are considering sealing it and hiding its contents in a future release.
+
+Changes to `Desc` in this release are as follows:
+
+- `Desc` is now an `unsafe trait`. The safety requirements haven't actually changed, but they were undocumented until now.
+
+- `Desc` now has an associated type, `Output`, which is now the type returned by the `lookup` method.
+
+Please see the documentation for the `Desc` trait for more information.
+
+
+## `JNIEnv::call_*method_unchecked` is now `unsafe`
+
+The `JNIEnv::call_*method_unchecked` methods are now `unsafe`. Their safety requirements haven't changed, but they were undocumented until now.
+
+
+## `AutoLocal` type and lifetime parameters changed
+
+`AutoLocal` now has one lifetime parameter, representing the local reference frame it belongs to, and one type parameter, representing the type of object reference it contains (`JObject`, `JClass`, and so on).
+
+This means that the object reference stored in an `AutoLocal` no longer has its type erased. If it was a `JClass` before wrapping it in `AutoLocal`, it will still be a `JClass` after.
+
+```rust
+// `AutoLocal` type parameters now include the type of object reference…
+let auto_local: AutoLocal<'local, JClass<'local>>;
+
+// …so the type of the object reference is now kept instead of being erased.
+let local: &JClass<'local> = &*auto_local;
+```
+
+
+## `JObject` no longer implements `From<&AutoLocal> + From<&GlobalRef>`
+
+It is no longer possible to directly convert an `&AutoLocal` or `&GlobalRef` into a `JObject`. Instead, a `JObject` can be *borrowed* from `AutoLocal` or `GlobalRef` through their implementations of `Deref` and/or `AsRef<JObject>`.
+
+```rust
+let global_ref: GlobalRef;
+
+// You can get a `JObject` from a `GlobalRef` two ways:
+let object_ref: &JObject<'static> = &*global_ref;
+let object_ref: &JObject<'static> = global_ref.as_ref();
+```
+
+
+
+## `JNIEnv::get_superclass` now returns `Option`
+
+The `JNIEnv::get_superclass` method previously returned a `JClass`, which would be null if the class in question doesn't have a superclass. It now returns `Option<JClass>` instead, and when it's `Some`, the `JClass` inside is never null.
+
+
+## `JNIEnv::{get,release}_string_utf_chars` removed
+
+The methods `JNIEnv::get_string_utf_chars` and `JNIEnv::release_string_utf_chars` have been removed. These methods have been replaced with `JavaStr::into_raw` and `JavaStr::from_raw`. To get a `JavaStr`, use `JNIEnv::get_string` or `JNIEnv::get_string_unchecked`. See [issue #372](https://github.com/jni-rs/jni-rs/pull/372) for discussion.


### PR DESCRIPTION
## Overview

This PR adds a migration guide to the changelog for 0.21, as discussed in https://github.com/jni-rs/jni-rs/pull/398#issuecomment-1385959005.

It is pretty big, though. Should it be moved to a separate file and linked from the changelog?

This PR also adds a section to the `JNIEnv` documentation about the [nested `mut` calls problem](https://github.com/jni-rs/jni-rs/issues/392#issuecomment-1340247632) and how to deal with it. The same content also appears in the migration guide.

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Change is covered by [automated tests](https://github.com/jni-rs/jni-rs/blob/master/CONTRIBUTING.md#tests)
- [x] The [coding guidelines](https://github.com/jni-rs/jni-rs/blob/master/CONTRIBUTING.md#the-code-style) are followed
- [x] Public API has documentation
- [x] User-visible changes are mentioned in the Changelog
- [x] The continuous integration build passes
