### PR TITLE
Generalize with_local_frame closure return value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ This release makes extensive breaking changes in order to improve safety. Most p
 - `WeakRef` and `JNIEnv#new_weak_ref`. ([#304](https://github.com/jni-rs/jni-rs/pull/304))
 - `define_class_bytearray` method that takes an `AutoArray<jbyte>` rather than a `&[u8]`
 - `JObject` now has an `as_raw` method that borrows the `JObject` instead of taking ownership like `into_raw`. Needed because `JObject` no longer has the `Copy` trait. ([#392](https://github.com/jni-rs/jni-rs/issues/392))
+- `JNIEnv::with_local_frame_returning_local` supports returning a single local ref from a new local frame, since this feature was removed from `with_local_frame` ([#399](https://github.com/jni-rs/jni-rs/issues/399))
 
 ### Changed
 - `JNIEnv::get_string` checks that the given object is a `java.lang.String` instance to avoid undefined behaviour from the JNI implementation potentially aborting the program. ([#328](https://github.com/jni-rs/jni-rs/issues/328))
@@ -35,6 +36,10 @@ This release makes extensive breaking changes in order to improve safety. Most p
 - `JByteBuffer`, `JClass`, `JNIEnv`, `JObject`, `JString`, and `JThrowable` no longer have the `Clone` or `Copy` traits. This improves safety by preventing object references from being used after the JVM deletes them. Most functions that take one of these types as a parameter (except `extern fn`s that are directly called by the JVM) should now borrow it instead, e.g. `&JObject` instead of `JObject`. ([#392](https://github.com/jni-rs/jni-rs/issues/392))
 - `AutoLocal` is now generic in the type of object reference (`JString`, etc). ([#392](https://github.com/jni-rs/jni-rs/issues/392))
 - The closure passed to `JNIEnv::with_local_frame` must now take a `&mut JNIEnv` parameter, which has a different lifetime. This improves safety by preventing local references from escaping the closure, which would cause a use-after-free bug. `Executor::with_attached` and `Executor::with_attached_capacity` have been similarly changed. ([#392](https://github.com/jni-rs/jni-rs/issues/392))
+- The closure passed to `JNIEnv::with_local_frame` can now return a generic `Result<T, E>` so long as the error implements `From<jni::errors::Error>` ([#399](https://github.com/jni-rs/jni-rs/issues/399))
+- `JNIEnv::with_local_frame` now returns the same type that the given closure returns ([#399](https://github.com/jni-rs/jni-rs/issues/399))
+- `JNIEnv::with_local_frame` no longer supports returning a local reference directly to the calling scope (see `with_local_frame_returning_local`) ([#399](https://github.com/jni-rs/jni-rs/issues/399))
+- `Executor::with_attached` and `Executor::with_attached_capacity` have been changed in the same way as `JNIEnv::with_local_frame` (they are thin wrappers) ([#399](https://github.com/jni-rs/jni-rs/issues/399))
 - `Desc`, `JNIEnv::pop_local_frame`, and `TypeArray` are now `unsafe`. ([#392](https://github.com/jni-rs/jni-rs/issues/392))
 - The `Desc` trait now has an associated type `Output`. Many implementations now return `AutoLocal`, so if you call `Desc::lookup` yourself and then call `as_raw` on the returned object, make sure the `AutoLocal` isn't dropped too soon (see the `Desc::lookup` documentation for examples). ([#392](https://github.com/jni-rs/jni-rs/issues/392))
 - Named lifetimes in the documentation have more descriptive names (like `'local` instead of `'a`). The new naming convention is explained in the `JNIEnv` documentation. ([#392](https://github.com/jni-rs/jni-rs/issues/392))

--- a/docs/0.21-MIGRATION.md
+++ b/docs/0.21-MIGRATION.md
@@ -53,6 +53,33 @@ env.with_local_frame(16, |env| {
 The closure must only use the `JNIEnv` passed to it in that parameter, and not the `JNIEnv` that `with_local_frame` was called on.
 
 
+## `JNIEnv::with_local_frame` closure can return a generic `Result`
+
+_Note: This also applies to `Executor::with_attached` and `Executor::with_attached_capacity` which are thin wrappers over `with_local_frame`_
+
+The closure passed to `with_local_frame` is now free to return a generic `Result` as long as the error type implements `From<jni::errors::Error>`.
+
+This can be particularly beneficial when running large amounts of code within a local frame in a crate that defines its own `Result` and `Error` types which need to be propagated to the caller.
+
+There are a few trade offs with this change though:
+1. Sometimes the compiler won't be able to infer the generic error type (E.g. for code that simply returns `Ok(())`) and so it has to be explicitly specified
+2. Since it's no longer assumed that code always wants to return a single local reference this special case has to be handled differently
+
+Two options for clarifying the error type for the compiler if it's ambiguous would be:
+
+1. Specify the type of the return value as part of an assignment:
+```rust
+let result: MyResult<()> = env.with_local_frame(10, |env| { Ok(()) });
+```
+
+2. Specify the generic `E` error parameter:
+```rust
+env.with_local_frame::<_, _, MyError>(10, |env| { Ok(()) })?;
+```
+
+Code that returns a local reference to the calling frame can either use `JNIEnv::with_local_frame_returning_local` (which is marginally optimized for that special case) or else return a `GlobalRef` instead. (This approach works reasonably well in Rust, compared to C, because a global reference will be automatically deleted once it is dropped so it doesn't introduce a memory leak hazard like it would in C)
+
+
 ## Passing object reference parameters to Java methods
 
 When passing an object reference as a parameter to a Java method or constructor, it needs to be explicitly borrowed, as in `(&obj).into()`, instead of simply `obj.into()`.

--- a/src/wrapper/executor.rs
+++ b/src/wrapper/executor.rs
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 
-use crate::{errors::*, objects::JObject, JNIEnv, JavaVM};
+use crate::{errors::*, JNIEnv, JavaVM};
 
 /// The capacity of local frames, allocated for attached threads by default. Same as the default
 /// value Hotspot uses when calling native Java methods.
@@ -39,9 +39,7 @@ pub const DEFAULT_LOCAL_FRAME_CAPACITY: i32 = 32;
 ///
 /// let val: jint = exec.with_attached(|env| {
 ///    let x = JValue::from(-10);
-///    let val: jint = env.call_static_method("java/lang/Math", "abs", "(I)I", &[x])?
-///      .i()?;
-///    Ok(val)
+///    env.call_static_method("java/lang/Math", "abs", "(I)I", &[x])?.i()
 /// })?;
 ///
 /// assert_eq!(val, 10);
@@ -68,20 +66,15 @@ impl Executor {
     /// call.
     ///
     /// Allocates a local frame with the specified capacity.
-    pub fn with_attached_capacity<F, R>(&self, capacity: i32, f: F) -> Result<R>
+    pub fn with_attached_capacity<F, T, E>(&self, capacity: i32, f: F) -> std::result::Result<T, E>
     where
-        F: FnOnce(&mut JNIEnv) -> Result<R>,
+        F: FnOnce(&mut JNIEnv) -> std::result::Result<T, E>,
+        E: From<Error>,
     {
         assert!(capacity > 0, "capacity should be a positive integer");
 
         let mut jni_env = self.vm.attach_current_thread_as_daemon()?;
-        let mut result = None;
-        jni_env.with_local_frame(capacity, |jni_env| {
-            result = Some(f(jni_env));
-            Ok(JObject::null())
-        })?;
-
-        result.expect("The result should be Some or this line shouldn't be reached")
+        jni_env.with_local_frame(capacity, |jni_env| f(jni_env))
     }
 
     /// Executes a provided closure, making sure that the current thread
@@ -90,9 +83,10 @@ impl Executor {
     ///
     /// Allocates a local frame with
     /// [the default capacity](constant.DEFAULT_LOCAL_FRAME_CAPACITY.html).
-    pub fn with_attached<F, R>(&self, f: F) -> Result<R>
+    pub fn with_attached<F, T, E>(&self, f: F) -> std::result::Result<T, E>
     where
-        F: FnOnce(&mut JNIEnv) -> Result<R>,
+        F: FnOnce(&mut JNIEnv) -> std::result::Result<T, E>,
+        E: From<Error>,
     {
         self.with_attached_capacity(DEFAULT_LOCAL_FRAME_CAPACITY, f)
     }

--- a/tests/executor_nested_attach.rs
+++ b/tests/executor_nested_attach.rs
@@ -31,9 +31,9 @@ fn nested_attach() {
 fn check_nested_attach(vm: &Arc<JavaVM>, executor: Executor) {
     check_detached(vm);
     executor
-        .with_attached(|_| {
+        .with_attached::<_, _, Error>(|_| {
             check_attached(vm);
-            executor.with_attached(|_| {
+            executor.with_attached::<_, _, Error>(|_| {
                 check_attached(vm);
                 Ok(())
             })?;

--- a/tests/java_integers.rs
+++ b/tests/java_integers.rs
@@ -1,6 +1,6 @@
 #![cfg(feature = "invocation")]
 
-use jni::{objects::JObject, objects::JValue};
+use jni::{errors::Error, objects::JObject, objects::JValue};
 
 mod util;
 use util::{attach_current_thread, print_exception};
@@ -12,7 +12,7 @@ fn test_java_integers() {
     let array_length = 50;
 
     for value in -10..10 {
-        env.with_local_frame(16, |env| {
+        env.with_local_frame(16, |env| -> Result<_, Error> {
             let integer_value =
                 env.new_object("java/lang/Integer", "(I)V", &[JValue::Int(value)])?;
 
@@ -34,11 +34,11 @@ fn test_java_integers() {
 
             assert!(0 <= result && result < array_length);
 
-            Ok(JObject::null())
+            Ok(())
         })
         .unwrap_or_else(|e| {
             print_exception(&env);
             panic!("{:#?}", e);
-        });
+        })
     }
 }

--- a/tests/jni_api.rs
+++ b/tests/jni_api.rs
@@ -220,8 +220,8 @@ pub fn with_local_frame() {
     let mut env = attach_current_thread();
 
     let s = env
-        .with_local_frame(16, |env| {
-            let res = env.new_string("Test").unwrap();
+        .with_local_frame_returning_local::<_, jni::errors::Error>(16, |env| {
+            let res = env.new_string("Test")?;
             Ok(res.into())
         })
         .unwrap()
@@ -241,7 +241,7 @@ pub fn with_local_frame_pending_exception() {
         .unwrap();
 
     // Try to allocate a frame of locals
-    env.with_local_frame(16, |_| Ok(JObject::null()))
+    env.with_local_frame(16, |_| -> Result<_, Error> { Ok(()) })
         .expect("JNIEnv#with_local_frame must work in case of pending exception");
 
     env.exception_clear().unwrap();
@@ -968,7 +968,7 @@ fn short_lifetime_with_local_frame() {
 fn short_lifetime_with_local_frame_sub_fn<'local>(
     env: &'_ mut JNIEnv<'local>,
 ) -> Result<JObject<'local>, Error> {
-    env.with_local_frame(16, |env| {
+    env.with_local_frame_returning_local(16, |env| {
         env.new_object(INTEGER_CLASS, "(I)V", &[JValue::from(5)])
     })
 }

--- a/tests/jni_weak_refs.rs
+++ b/tests/jni_weak_refs.rs
@@ -6,7 +6,7 @@ use std::{
 };
 
 use jni::{
-    objects::{AutoLocal, JObject, JValue},
+    objects::{AutoLocal, JValue},
     sys::jint,
     JNIEnv,
 };
@@ -98,7 +98,7 @@ fn weak_ref_is_actually_weak() {
         unwrap(
             env.with_local_frame(1, |env| {
                 env.call_static_method("java/lang/System", "gc", "()V", &[])?;
-                Ok(JObject::null())
+                Ok(())
             }),
             env,
         );
@@ -106,7 +106,9 @@ fn weak_ref_is_actually_weak() {
 
     for _ in 0..100 {
         let obj_local = unwrap(
-            env.with_local_frame(2, |env| env.new_object("java/lang/Object", "()V", &[])),
+            env.with_local_frame_returning_local(2, |env| {
+                env.new_object("java/lang/Object", "()V", &[])
+            }),
             &env,
         );
         let obj_local = env.auto_local(obj_local);


### PR DESCRIPTION
This updates with_local_frame to take a closure that may return any type of `Result`, so long as the error type implements
`From<jni::errors::Error>`

It also updates `Executor::with_attached_capacity` and `Executor::with_attached` (which are wrappers for `with_local_frame`) in the same way.

This removes the special-case ability to pass back a single local reference to the parent frame. (A new `with_local_frame_returning_local()` supports this case)

The main motivations here are:
- Consider that the closure is for user code that shouldn't be required to return a jni::errors::Result since the code may be doing a lot more than just calling a few JNI functions in crates that have their own Result types.
- Consider that it's often not necessary to return a local reference from a local frame and that feature is only really a modest optimization for one case that complicates other cases.

The fact that the closure was returning a `jni::errors::Result` before was convenient for in-tree tests but not convenient in crates that might wrap significant portions of code within a JNI local frame, and need to propagate crate-specific errors and arbitrary Ok() values.

One alternative that was considered was to make the closure return value completely generic and return that to the caller via a `jni::errors::Result`. This would typically imply returning nested `Result`s  - one outer `Result` for the Push/PopLocalFrame JNI calls, and then and inner `Result` for the closure.

The reason we chose this `E: From<jni::errors::Error>` approach is that it avoids the need to unwrap the return value twice in common cases.

The added use of generics may require callers to specify type parameters if they can't be inferred but it's also possible for applications to create their own ergonomic wrappers for crate-specific Result/Error types.

The documentation has been updated to highlight that it's possible to use a GlobalRef in situations you want to pass back an object reference to the calling scope.

This also adds a `with_local_frame_returning_local()` alternative where the closure returns a `std::result::Result<JObject, E>` (with the error being generic) that can return a local reference to the calling frame. Similar to `with_local_frame` the error must implement `From<jni::errors::Error>` which avoids the need to return nested `Result`s.

Micro benchmarks have been added to quantify the difference between:
- returning a `GlobalRef` from `with_local_frame` and then creating a local reference before dropping the global
- returning a local reference via `with_local_frame_returning_local`

On my machine I saw results like:
```
test tests::jni_with_local_frame_returning_global_to_local    ... bench:       2,104 ns/iter (+/- 181)
test tests::jni_with_local_frame_returning_local              ... bench:       1,669 ns/iter (+/- 99)
```
(So it was about %26 slower to return the global reference and create a local reference manually - but overall unlikely to be a notable difference for most code)

Co-authored-by: argv-minus-one <argv-minus-one@users.noreply.github.com>


### Definition of Done

- [x] There are no TODOs left in the code
- [x] Change is covered by [automated tests](https://github.com/jni-rs/jni-rs/blob/master/CONTRIBUTING.md#tests)
- [x] The [coding guidelines](https://github.com/jni-rs/jni-rs/blob/master/CONTRIBUTING.md#the-code-style) are followed
- [x] Public API has documentation
- [x] User-visible changes are mentioned in the Changelog
- [x] The continuous integration build passes

Closes: #399