### PR TITLE
Adds `JavaVM::destroy()` API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,8 @@ This release makes extensive breaking changes in order to improve safety. Most p
 - `WeakRef` and `JNIEnv#new_weak_ref`. ([#304](https://github.com/jni-rs/jni-rs/pull/304))
 - `define_class_bytearray` method that takes an `AutoArray<jbyte>` rather than a `&[u8]`
 - `JObject` now has an `as_raw` method that borrows the `JObject` instead of taking ownership like `into_raw`. Needed because `JObject` no longer has the `Copy` trait. ([#392](https://github.com/jni-rs/jni-rs/issues/392))
-- `JNIEnv::with_local_frame_returning_local` supports returning a single local ref from a new local frame, since this feature was removed from `with_local_frame` ([#399](https://github.com/jni-rs/jni-rs/issues/399))
+- `JavaVM::destroy()` (unsafe) as a way to try and unload a `JavaVM` on supported platforms ([#391](https://github.com/jni-rs/jni-rs/issues/391))
+- `JavaVM::detach_current_thread()` (unsafe) as a way to explicitly detach a thread (normally this is automatic on thread exit). Needed to detach daemon threads manually if using `JavaVM::destroy()` ([#391](https://github.com/jni-rs/jni-rs/issues/391))
 
 ### Changed
 - `JNIEnv::get_string` checks that the given object is a `java.lang.String` instance to avoid undefined behaviour from the JNI implementation potentially aborting the program. ([#328](https://github.com/jni-rs/jni-rs/issues/328))

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ walkdir = "2"
 
 [dev-dependencies]
 lazy_static = "1"
-
+rusty-fork = "0.3.0"
 
 [features]
 invocation = ["java-locator", "libloading"]

--- a/tests/executor.rs
+++ b/tests/executor.rs
@@ -1,11 +1,17 @@
 #![cfg(feature = "invocation")]
 
 use std::{
-    sync::{Arc, Barrier},
+    sync::{
+        atomic::{AtomicUsize, Ordering},
+        Arc, Barrier,
+    },
     thread::spawn,
+    time::Duration,
 };
 
-use jni::{sys::jint, Executor};
+use jni::{objects::AutoLocal, sys::jint, Executor};
+
+use rusty_fork::rusty_fork_test;
 
 mod util;
 use util::{jvm, AtomicIntegerProxy};
@@ -72,4 +78,134 @@ fn test_concurrent_threads(executor: Executor, thread_num: usize) {
     }
     let expected = (ITERS_PER_THREAD * thread_num) as jint;
     assert_eq!(expected, atomic.get().unwrap());
+}
+
+// We need to test `JavaVM::destroy()` in a separate process otherwise it will break
+// all the other tests
+rusty_fork_test! {
+#[test]
+fn test_destroy() {
+    const THREAD_NUM: usize = 2;
+    const DAEMON_THREAD_NUM: usize = 2;
+    static MATH_CLASS: &str = "java/lang/Math";
+
+    // We don't test this using an `Executor` because we don't want to
+    // attach all the threads as daemon threads.
+
+    let jvm = jvm().clone();
+
+    let atomic = Arc::new(AtomicUsize::new(0));
+
+    let attach_barrier = Arc::new(Barrier::new(THREAD_NUM + DAEMON_THREAD_NUM + 1));
+    let daemons_detached_barrier = Arc::new(Barrier::new(DAEMON_THREAD_NUM + 1));
+    let mut threads = Vec::new();
+
+    for _ in 0..THREAD_NUM {
+        let attach_barrier = Arc::clone(&attach_barrier);
+        let jvm = jvm.clone();
+        let atomic = atomic.clone();
+        let jh = spawn(move || {
+            let mut env = jvm.attach_current_thread().unwrap();
+            println!("java thread attach");
+            attach_barrier.wait();
+            println!("java thread run");
+            std::thread::sleep(Duration::from_millis(250));
+
+            println!("use before destroy...");
+            // Make some token JNI call
+            let _class = AutoLocal::new(env.find_class(MATH_CLASS).unwrap(), &env);
+
+            atomic.fetch_add(1, Ordering::SeqCst);
+
+            println!("java thread finished");
+        });
+        threads.push(jh);
+    }
+
+    for _ in 0..DAEMON_THREAD_NUM {
+        let attach_barrier = Arc::clone(&attach_barrier);
+        let daemons_detached_barrier = Arc::clone(&daemons_detached_barrier);
+        let jvm = jvm.clone();
+        let atomic = atomic.clone();
+        let jh = spawn(move || {
+            // We have to be _very_ careful to ensure we have finished accessing the
+            // JavaVM before it gets destroyed, including dropping the AutoLocal
+            // for the `MATH_CLASS`
+            {
+                let mut env = jvm.attach_current_thread_as_daemon().unwrap();
+                println!("daemon thread attach");
+                attach_barrier.wait();
+                println!("daemon thread run");
+
+                println!("daemon JVM use before destroy...");
+
+                let _class = AutoLocal::new(env.find_class(MATH_CLASS).unwrap(), &env);
+            }
+
+            // For it to be safe to call `JavaVM::destroy()` we need to ensure that
+            // daemon threads are detached from the JavaVM ahead of time because
+            // `JavaVM::destroy()` does not synchronize and wait for them to exit
+            // which means we would effectively trigger a use-after-free when daemon
+            // threads exit and they try to automatically detach from the `JavaVM`
+            //
+            // # Safety
+            // We won't be accessing any (invalid) `JNIEnv` once we have detached this
+            // thread
+            unsafe {
+                jvm.detach_current_thread();
+            }
+
+            daemons_detached_barrier.wait();
+
+            for _ in 0..10 {
+                std::thread::sleep(Duration::from_millis(100));
+                println!("daemon thread running");
+            }
+
+            atomic.fetch_add(1, Ordering::SeqCst);
+
+            println!("daemon thread finished");
+        });
+        threads.push(jh);
+    }
+
+    // At this point we at least know that all threads have been attached
+    // to the JVM
+    println!("MAIN: waiting for threads attached barrier");
+    attach_barrier.wait();
+
+    // Before we try and destroy the JavaVM we need to be sure that the daemon
+    // threads have finished using the VM since `jvm.destroy()` won't wait
+    // for daemon threads to exit.
+    println!("MAIN: waiting for daemon threads detached barrier");
+    daemons_detached_barrier.wait();
+
+    // # Safety
+    //
+    // We drop the `jvm` variable immediately after `destroy()` returns to avoid
+    // any use-after-free.
+    unsafe {
+        println!("MAIN: calling DestroyJavaVM()...");
+        jvm.destroy().unwrap();
+        drop(jvm);
+        println!("MAIN: jvm destroyed");
+    }
+
+    println!("MAIN: joining (waiting for) all threads");
+    let mut joined = 0;
+    for jh in threads {
+        jh.join().unwrap();
+        joined += 1;
+        println!(
+            "joined {joined} threads, atomic = {}",
+            atomic.load(Ordering::SeqCst)
+        );
+    }
+
+    assert_eq!(
+        atomic.load(Ordering::SeqCst),
+        THREAD_NUM + DAEMON_THREAD_NUM
+    );
+}
+
 }

--- a/tests/jni_api.rs
+++ b/tests/jni_api.rs
@@ -1,5 +1,4 @@
 #![cfg(feature = "invocation")]
-
 use std::{convert::TryFrom, str::FromStr};
 
 use jni::{

--- a/tests/threads_explicit_detach.rs
+++ b/tests/threads_explicit_detach.rs
@@ -11,7 +11,11 @@ pub fn explicit_detach_detaches_thread_attached_locally() {
     assert_eq!(val, 1);
     assert_eq!(jvm().threads_attached(), 1);
 
-    detach_current_thread();
+    // # Safety
+    // we won't be trying to use a pre-existing (invalid) `JNIEnv` after detaching
+    unsafe {
+        detach_current_thread();
+    }
     assert_eq!(jvm().threads_attached(), 0);
     assert!(jvm().get_env().is_err());
 }

--- a/tests/threads_explicit_detach_daemon.rs
+++ b/tests/threads_explicit_detach_daemon.rs
@@ -11,7 +11,11 @@ pub fn explicit_detach_detaches_thread_attached_as_daemon() {
     assert_eq!(val, 1);
     assert_eq!(jvm().threads_attached(), 1);
 
-    detach_current_thread();
+    // # Safety
+    // we won't be trying to use a pre-existing (invalid) `JNIEnv` after detaching
+    unsafe {
+        detach_current_thread();
+    }
     assert_eq!(jvm().threads_attached(), 0);
     assert!(jvm().get_env().is_err());
 }

--- a/tests/threads_explicit_detach_permanent.rs
+++ b/tests/threads_explicit_detach_permanent.rs
@@ -11,7 +11,11 @@ pub fn explicit_detach_detaches_thread_attached_permanently() {
     assert_eq!(val, 1);
     assert_eq!(jvm().threads_attached(), 1);
 
-    detach_current_thread();
+    // # Safety
+    // we won't be trying to use a pre-existing (invalid) `JNIEnv` after detaching
+    unsafe {
+        detach_current_thread();
+    }
     assert_eq!(jvm().threads_attached(), 0);
     assert!(jvm().get_env().is_err());
 }

--- a/tests/util/mod.rs
+++ b/tests/util/mod.rs
@@ -64,7 +64,7 @@ pub fn attach_current_thread_permanently() -> JNIEnv<'static> {
 }
 
 #[allow(dead_code)]
-pub fn detach_current_thread() {
+pub unsafe fn detach_current_thread() {
     jvm().detach_current_thread()
 }
 


### PR DESCRIPTION
This adds an (unsafe) `JavaVM::destroy()` API that can be used to try and unload the JavaVM on supported platforms.

This adds a `dev-dependency` on the `rusty-fork` crate to make it easy to test `JavaVM::destroy()` in a separate process, which is needed to avoid breaking other tests.

It's notable that the way in which `jni-rs` uses an `InternalAttachGuard` to automatically detach threads makes it particularly difficult to use `JavaVM::destroy()` safely due to the fact that daemon threads will automatically try and access an invalid `JavaVM` pointer if they exit after `JavaVM::destroy()` has been called.

This also exposes `JavaVM::detach_current_thread` (it was previously public but hidden from docs) since that provides a mechanism for daemon threads to potentially detach themselves from a `JavaVM` explicitly if they need to be able to continue running after `JavaVM::destroy()` has been called.

Closes: #391

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Change is covered by [automated tests](https://github.com/jni-rs/jni-rs/blob/master/CONTRIBUTING.md#tests)
- [x] The [coding guidelines](https://github.com/jni-rs/jni-rs/blob/master/CONTRIBUTING.md#the-code-style) are followed
- [x] Public API has documentation
- [x] User-visible changes are mentioned in the Changelog
- [x] The continuous integration build passes
