### PR TITLE
Removes deprecation attribute for GlobalRef::as_obj

### DIFF
--- a/src/wrapper/objects/global_ref.rs
+++ b/src/wrapper/objects/global_ref.rs
@@ -72,7 +72,6 @@ impl GlobalRef {
     ///
     /// This borrows the ref and prevents it from being dropped as long as the
     /// JObject sticks around.
-    #[deprecated(since = "0.21.0", note = "use `.as_ref()` instead")]
     pub fn as_obj(&self) -> &JObject<'static> {
         self.as_ref()
     }


### PR DESCRIPTION
This was recently marked as deprecated since landing #398 meant we could also get a reference to a JObject via an implementation of `AsRef<JObject>`.

Since there are multiple `AsRef<T>` implementations for `GlobalRef` there are times when the compiler isn't able to infer which implementation of `.as_ref()` you are trying to call, and so it's still convenient to have a less ambiguous `.as_obj()` API that can be used instead.

Closes: #408

## Overview

<!-- Please describe your changes here and list any open questions you might have. -->

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Change is covered by [automated tests](https://github.com/jni-rs/jni-rs/blob/master/CONTRIBUTING.md#tests)
- [x] The [coding guidelines](https://github.com/jni-rs/jni-rs/blob/master/CONTRIBUTING.md#the-code-style) are followed
- [x] Public API has documentation
- [x] User-visible changes are mentioned in the Changelog
- [x] The continuous integration build passes
