### PR TITLE
Correctly encode JVM option strings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ This release makes extensive breaking changes in order to improve safety. Most p
 - `JObjectArray` provides a reference wrapper for a `jobjectArray` with a lifetime like `JObject`. ([#400](https://github.com/jni-rs/jni-rs/pull/400))
 - `AutoElements` and `AutoElementsCritical` (previously `AutoArray`/`AutoPrimitiveArray`) implement `Deref<Target=[T]>` and `DerefMut` so array elements can be accessed via slices without needing additional `unsafe` code. ([#400](https://github.com/jni-rs/jni-rs/pull/400))
 - `AsJArrayRaw` trait which enables `JNIEnv::get_array_length()` to work with `JPrimitiveArray` or `JObjectArray` types ([#400](https://github.com/jni-rs/jni-rs/pull/400))
+- `InitArgsBuilder` now has `try_option` and `option_encoded` methods. ([#414](https://github.com/jni-rs/jni-rs/pull/414))
 
 ### Changed
 - `JNIEnv::get_string` checks that the given object is a `java.lang.String` instance to avoid undefined behaviour from the JNI implementation potentially aborting the program. ([#328](https://github.com/jni-rs/jni-rs/issues/328))
@@ -62,11 +63,13 @@ This release makes extensive breaking changes in order to improve safety. Most p
 - `get_array_elements` is now also `unsafe` (for many of the same reasons as `get_array_elements_critical`) and has detailed safety documentation ([#400](https://github.com/jni-rs/jni-rs/pull/400))
 - `AutoArray/AutoArrayCritical::size()` has been replaced with `.len()` which can't fail and returns a `usize` ([#400](https://github.com/jni-rs/jni-rs/pull/400))
 - The `TypeArray` trait is now a private / sealed trait, that is considered to be an implementation detail for the `AutoArray` API.
-
+- `JvmError` has several more variants and is now `non_exhaustive`. ([#414](https://github.com/jni-rs/jni-rs/pull/414))
+- `InitArgsBuilder::option` raises an error on Windows if the string is too long. The limit is currently 1048576 bytes. ([#414](https://github.com/jni-rs/jni-rs/pull/414))
 
 ### Fixed
 - Trying to use an object reference after it has been deleted now causes a compile error instead of undefined behavior. As a result, it is now safe to use `AutoLocal`, `JNIEnv::delete_local_ref`, and `JNIEnv::with_local_frame`. (Most of the limitations added in #392, listed above, were needed to make this work.) ([#381](https://github.com/jni-rs/jni-rs/issues/381), [#392](https://github.com/jni-rs/jni-rs/issues/392))
 - Class lookups via the `Desc` trait now return `AutoLocal`s, which prevents them from leaking. ([#109](https://github.com/jni-rs/jni-rs/issues/109), [#392](https://github.com/jni-rs/jni-rs/issues/392))
+- `InitArgsBuilder::option` properly encodes non-ASCII characters on Windows. ([#414](https://github.com/jni-rs/jni-rs/pull/414))
 
 ### Removed
 - `get_string_utf_chars` and `release_string_utf_chars` from `JNIEnv` (See `JavaStr::into_raw()` and `JavaStr::from_raw()` instead) ([#372](https://github.com/jni-rs/jni-rs/pull/372))

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ version = "0.21.0-alpha.0"
 edition = "2018"
 
 [dependencies]
+cfg-if = "1.0.0"
 cesu8 = "1.1.0"
 combine = "4.1.0"
 java-locator = { version = "0.1", optional = true }
@@ -29,8 +30,15 @@ thiserror = "1.0.20"
 walkdir = "2"
 
 [dev-dependencies]
+assert_matches = "1.5.0"
 lazy_static = "1"
 rusty-fork = "0.3.0"
+
+[target.'cfg(windows)'.dependencies]
+windows-sys = { version = "0.45.0", features = ["Win32_Globalization"] }
+
+[target.'cfg(windows)'.dev-dependencies]
+bytemuck = "1.13.0"
 
 [features]
 invocation = ["java-locator", "libloading"]

--- a/src/wrapper/java_vm/init_args.rs
+++ b/src/wrapper/java_vm/init_args.rs
@@ -1,4 +1,4 @@
-use std::{ffi::CString, os::raw::c_void};
+use std::{borrow::Cow, ffi::CStr, io, os::raw::c_void, ptr};
 
 use thiserror::Error;
 
@@ -7,56 +7,274 @@ use crate::{
     JNIVersion,
 };
 
+use cfg_if::cfg_if;
+
+mod char_encoding_generic;
+
+#[cfg(windows)]
+mod char_encoding_windows;
+
 /// Errors that can occur when invoking a [`JavaVM`](super::vm::JavaVM) with the
 /// [Invocation API](https://docs.oracle.com/en/java/javase/12/docs/specs/jni/invocation.html).
 #[derive(Debug, Error)]
+#[non_exhaustive]
 pub enum JvmError {
-    /// An internal `0` byte was found when constructing a string.
+    /// [`InitArgsBuilder::option`] or [`InitArgsBuilder::try_option`] was used, but the supplied
+    /// string contains a U+0000 code point (except at the end).
+    ///
+    /// This error is not raised if the string has a single U+0000 code point at the end.
+    ///
+    /// [`InitArgsBuilder::option_encoded`] never raises this error.
     #[error("internal null in option: {0}")]
     NullOptString(String),
+
+    /// [`InitArgsBuilder::option`] or [`InitArgsBuilder::try_option`] was used, but the option
+    /// string is too long.
+    ///
+    /// Currently, this error only occurs on Windows, where string length is limited to 1MB to
+    /// avoid overflow in [`WideCharToMultiByte`] (see [discussion]). String length is not
+    /// currently limited (other than by available memory) on other platforms.
+    ///
+    /// [`InitArgsBuilder::option_encoded`] never raises this error, regardless of platform.
+    ///
+    /// [discussion]: https://github.com/jni-rs/jni-rs/pull/414
+    /// [`WideCharToMultiByte`]: https://learn.microsoft.com/en-us/windows/win32/api/stringapiset/nf-stringapiset-widechartomultibyte
+    #[error("option is too long: {opt_string}")]
+    #[non_exhaustive]
+    OptStringTooLong {
+        /// The option string.
+        opt_string: String,
+    },
+
+    /// [`InitArgsBuilder::option`] or [`InitArgsBuilder::try_option`] was used, but the option
+    /// string is not representable in the platform default character encoding.
+    ///
+    /// [`InitArgsBuilder::option_encoded`] never raises this error.
+    #[error(
+        "option {opt_string:?} is not representable in the platform default character encoding"
+    )]
+    #[non_exhaustive]
+    OptStringNotRepresentable {
+        /// The option string.
+        opt_string: String,
+    },
+
+    /// [`InitArgsBuilder::option`] or [`InitArgsBuilder::try_option`] was used, but the platform
+    /// reported an error converting it to its default character encoding.
+    ///
+    /// [`InitArgsBuilder::option_encoded`] never raises this error.
+    #[error("couldn't convert option {opt_string:?} to the platform default character encoding: {error}")]
+    #[non_exhaustive]
+    OptStringTranscodeFailure {
+        /// The option string.
+        opt_string: String,
+
+        /// The error reported by the platform's character encoding conversion routine.
+        #[source]
+        error: io::Error,
+    },
 }
+
+impl JvmError {
+    /// Returns the JVM option that caused the error, if it was caused by one.
+    pub fn opt_string(&self) -> Option<&str> {
+        match self {
+            Self::NullOptString(opt_string) => Some(opt_string),
+            Self::OptStringTooLong { opt_string, .. } => Some(opt_string),
+            Self::OptStringNotRepresentable { opt_string, .. } => Some(opt_string),
+            Self::OptStringTranscodeFailure { opt_string, .. } => Some(opt_string),
+        }
+        .map(String::as_str)
+    }
+
+    #[cfg(all(test, windows))]
+    fn opt_string_mut(&mut self) -> Option<&mut String> {
+        match self {
+            Self::NullOptString(opt_string) => Some(opt_string),
+            Self::OptStringTooLong { opt_string, .. } => Some(opt_string),
+            Self::OptStringNotRepresentable { opt_string, .. } => Some(opt_string),
+            Self::OptStringTranscodeFailure { opt_string, .. } => Some(opt_string),
+        }
+    }
+}
+
+const SPECIAL_OPTIONS: &[&str] = &["vfprintf", "abort", "exit"];
+
+const SPECIAL_OPTIONS_C: &[&CStr] = unsafe {
+    &[
+        CStr::from_bytes_with_nul_unchecked(b"vfprintf\0"),
+        CStr::from_bytes_with_nul_unchecked(b"abort\0"),
+        CStr::from_bytes_with_nul_unchecked(b"exit\0"),
+    ]
+};
 
 /// Builder for JavaVM InitArgs.
 ///
 /// *This API requires "invocation" feature to be enabled,
 /// see ["Launching JVM from Rust"](struct.JavaVM.html#launching-jvm-from-rust).*
 #[derive(Debug)]
-pub struct InitArgsBuilder {
-    opts: Vec<String>,
+pub struct InitArgsBuilder<'a> {
+    opts: Result<Vec<Cow<'a, CStr>>, JvmError>,
     ignore_unrecognized: bool,
     version: JNIVersion,
 }
 
-impl Default for InitArgsBuilder {
+impl<'a> Default for InitArgsBuilder<'a> {
     fn default() -> Self {
         InitArgsBuilder {
-            opts: vec![],
+            opts: Ok(vec![]),
             ignore_unrecognized: false,
             version: JNIVersion::V8,
         }
     }
 }
 
-impl InitArgsBuilder {
+impl<'a> InitArgsBuilder<'a> {
     /// Create a new default InitArgsBuilder
     pub fn new() -> Self {
         Default::default()
     }
 
-    /// Add an option to the init args
+    /// Adds a JVM option, such as `-Djavax.net.debug=all`.
     ///
-    /// The `vfprintf`, `abort`, and `exit` options are unsupported at this time.
-    pub fn option(self, opt_string: &str) -> Self {
-        let mut s = self;
-
-        match opt_string {
-            "vfprintf" | "abort" | "exit" => return s,
-            _ => {}
+    /// See [the JNI specification][jni-options] for details on which options are accepted.
+    ///
+    /// The `vfprintf`, `abort`, and `exit` options are unsupported at this time. Setting one of
+    /// these options has no effect.
+    ///
+    /// The option must not contain any U+0000 code points except one at the end. A U+0000 code
+    /// point at the end is not required, but on platforms where UTF-8 is the default character
+    /// encoding, including one U+0000 code point at the end will make this method run slightly
+    /// faster.
+    ///
+    /// # Errors
+    ///
+    /// This method can fail if:
+    ///
+    /// * `opt_string` contains a U+0000 code point before the end.
+    /// * `opt_string` cannot be represented in the platform default character encoding.
+    /// * the platform's character encoding conversion API reports some other error.
+    /// * `opt_string` is too long. (In the current implementation, the maximum allowed length is
+    ///   1048576 bytes on Windows. There is currently no limit on other platforms.)
+    ///
+    /// Errors raised by this method are deferred. If an error occurs, it is returned from
+    /// [`InitArgsBuilder::build`] instead.
+    ///
+    /// [jni-options]: https://docs.oracle.com/en/java/javase/11/docs/specs/jni/invocation.html#jni_createjavavm
+    pub fn option(mut self, opt_string: impl AsRef<str> + Into<Cow<'a, str>>) -> Self {
+        if let Err(error) = self.try_option(opt_string) {
+            self.opts = Err(error);
         }
 
-        s.opts.push(opt_string.into());
+        self
+    }
 
-        s
+    /// Adds a JVM option, such as `-Djavax.net.debug=all`. Returns an error immediately upon
+    /// failure.
+    ///
+    /// This is an alternative to [`InitArgsBuilder::option`] that does not defer errors. See
+    /// below for details.
+    ///
+    /// See [the JNI specification][jni-options] for details on which options are accepted.
+    ///
+    /// The `vfprintf`, `abort`, and `exit` options are unsupported at this time. Setting one of
+    /// these options has no effect.
+    ///
+    /// The option must not contain any U+0000 code points except one at the end. A U+0000 code
+    /// point at the end is not required, but on platforms where UTF-8 is the default character
+    /// encoding, including one U+0000 code point at the end will make this method run slightly
+    /// faster.
+    ///
+    /// # Errors
+    ///
+    /// This method can fail if:
+    ///
+    /// * `opt_string` contains a U+0000 code point before the end.
+    /// * `opt_string` cannot be represented in the platform default character encoding.
+    /// * the platform's character encoding conversion API reports some other error.
+    /// * `opt_string` is too long. (In the current implementation, the maximum allowed length is
+    ///   1048576 bytes on Windows. There is currently no limit on other platforms.)
+    ///
+    /// Unlike the `option` method, this one does not defer errors. If the `opt_string` cannot be
+    /// used, then this method returns `Err` and `self` is not changed. If there is already a
+    /// deferred error, however, then this method does nothing.
+    ///
+    /// [jni-options]: https://docs.oracle.com/en/java/javase/11/docs/specs/jni/invocation.html#jni_createjavavm
+    pub fn try_option(&mut self, opt_string: impl Into<Cow<'a, str>>) -> Result<(), JvmError> {
+        let opt_string = opt_string.into();
+
+        // If there is already a deferred error, do nothing.
+        let opts = match &mut self.opts {
+            Ok(ok) => ok,
+            Err(_) => return Ok(()),
+        };
+
+        // If the option is the empty string, then skip everything else and pass a constant empty
+        // C string. This isn't just an optimization; Win32 `WideCharToMultiByte` will **fail** if
+        // passed an empty string, so we have to do this check first.
+        if matches!(opt_string.as_ref(), "" | "\0") {
+            opts.push(Cow::Borrowed(unsafe {
+                // Safety: This string not only is null-terminated without any interior null bytes,
+                // it's nothing but a null terminator.
+                CStr::from_bytes_with_nul_unchecked(b"\0")
+            }));
+            return Ok(());
+        }
+        // If this is one of the special options, do nothing.
+        else if SPECIAL_OPTIONS.contains(&&*opt_string) {
+            return Ok(());
+        }
+
+        let encoded: Cow<'a, CStr> = {
+            cfg_if! {
+                if #[cfg(windows)] {
+                    char_encoding_windows::str_to_cstr_win32_default_codepage(opt_string)?
+                }
+                else {
+                    // Assume UTF-8 on all other platforms.
+                    char_encoding_generic::utf8_to_cstr(opt_string)?
+                }
+            }
+        };
+
+        opts.push(encoded);
+        Ok(())
+    }
+
+    /// Adds a JVM option, such as `-Djavax.net.debug=all`. The option must be a `CStr` encoded in
+    /// the platform default character encoding.
+    ///
+    /// This is an alternative to [`InitArgsBuilder::option`] that does not do any encoding. This
+    /// method is not `unsafe` as it cannot cause undefined behavior, but the option will be
+    /// garbled (that is, become [mojibake](https://en.wikipedia.org/wiki/Mojibake)) if not
+    /// encoded correctly.
+    ///
+    /// See [the JNI specification][jni-options] for details on which options are accepted.
+    ///
+    /// The `vfprintf`, `abort`, and `exit` options are unsupported at this time. Setting one of
+    /// these options has no effect.
+    ///
+    /// This method does not fail, and will neither return nor defer an error.
+    ///
+    /// [jni-options]: https://docs.oracle.com/en/java/javase/11/docs/specs/jni/invocation.html#jni_createjavavm
+    pub fn option_encoded(mut self, opt_string: impl Into<Cow<'a, CStr>>) -> Self {
+        let opt_string = opt_string.into();
+
+        // If there is already a deferred error, do nothing.
+        let opts = match &mut self.opts {
+            Ok(ok) => ok,
+            Err(_) => return self,
+        };
+
+        // If this is one of the special options, do nothing.
+        if SPECIAL_OPTIONS_C.contains(&&*opt_string) {
+            return self;
+        }
+
+        // Add the option.
+        opts.push(opt_string);
+
+        self
     }
 
     /// Set JNI version for the init args
@@ -83,19 +301,20 @@ impl InitArgsBuilder {
 
     /// Build the `InitArgs`
     ///
-    /// This will check for internal nulls in the option strings and will return
-    /// an error if one is found.
-    pub fn build(self) -> Result<InitArgs, JvmError> {
-        let mut opts = Vec::with_capacity(self.opts.len());
-        for opt in self.opts {
-            let option_string =
-                CString::new(opt.as_str()).map_err(|_| JvmError::NullOptString(opt))?;
-            let jvm_opt = JavaVMOption {
-                optionString: option_string.into_raw(),
-                extraInfo: ::std::ptr::null_mut(),
-            };
-            opts.push(jvm_opt);
-        }
+    /// # Errors
+    ///
+    /// If a call to [`InitArgsBuilder::option`] caused a deferred error, it is returned from this
+    /// method.
+    pub fn build(self) -> Result<InitArgs<'a>, JvmError> {
+        let opt_strings = self.opts?;
+
+        let opts: Vec<JavaVMOption> = opt_strings
+            .iter()
+            .map(|opt_string| JavaVMOption {
+                optionString: opt_string.as_ptr() as *mut i8,
+                extraInfo: ptr::null_mut(),
+            })
+            .collect();
 
         Ok(InitArgs {
             inner: JavaVMInitArgs {
@@ -104,13 +323,17 @@ impl InitArgsBuilder {
                 options: opts.as_ptr() as _,
                 nOptions: opts.len() as _,
             },
-            opts,
+            _opts: opts,
+            _opt_strings: opt_strings,
         })
     }
 
-    /// Returns collected options
-    pub fn options(&self) -> Vec<String> {
-        self.opts.clone()
+    /// Returns collected options.
+    ///
+    /// If a call to [`InitArgsBuilder::option`] caused a deferred error, then this method returns
+    /// a reference to that error.
+    pub fn options(&self) -> Result<&[Cow<'a, CStr>], &JvmError> {
+        self.opts.as_ref().map(Vec::as_slice)
     }
 }
 
@@ -118,21 +341,20 @@ impl InitArgsBuilder {
 ///
 /// *This API requires "invocation" feature to be enabled,
 /// see ["Launching JVM from Rust"](struct.JavaVM.html#launching-jvm-from-rust).*
-pub struct InitArgs {
+pub struct InitArgs<'a> {
     inner: JavaVMInitArgs,
-    opts: Vec<JavaVMOption>,
+
+    // `JavaVMOption` structures are stored here. The JVM accesses this `Vec`'s contents through a
+    // raw pointer.
+    _opts: Vec<JavaVMOption>,
+
+    // Option strings are stored here. This ensures that any that are owned aren't dropped before
+    // the JVM is finished with them.
+    _opt_strings: Vec<Cow<'a, CStr>>,
 }
 
-impl InitArgs {
+impl<'a> InitArgs<'a> {
     pub(crate) fn inner_ptr(&self) -> *mut c_void {
         &self.inner as *const _ as _
-    }
-}
-
-impl Drop for InitArgs {
-    fn drop(&mut self) {
-        for opt in self.opts.iter() {
-            unsafe { CString::from_raw(opt.optionString) };
-        }
     }
 }

--- a/src/wrapper/java_vm/init_args/char_encoding_generic.rs
+++ b/src/wrapper/java_vm/init_args/char_encoding_generic.rs
@@ -1,0 +1,117 @@
+use super::JvmError;
+use std::{
+    borrow::Cow,
+    ffi::{CStr, CString},
+};
+
+/// Converts `s: Cow<[u8]>` into a `Cow<CStr>`, adding a null byte if necessary.
+///
+/// `original`, if present, is the original string, which will be moved into a [`JvmError]`
+/// in the event of failure. If `original` is absent, then `s` *is* the original
+/// string (i.e. is encoded in UTF-8), and is to be moved into the `JvmError` upon failure.
+///
+/// # Errors
+///
+/// This will fail if `s` contains any null bytes other than a single null byte at the end.
+///
+/// # Safety
+///
+/// If `original` is `None`, then `s` must contain valid UTF-8.
+pub(super) unsafe fn bytes_to_cstr<'a>(
+    mut s: Cow<'a, [u8]>,
+    original: Option<Cow<'_, str>>,
+) -> Result<Cow<'a, CStr>, JvmError> {
+    // Check if it has a null byte at the end already. If not, add one.
+    let mut null_byte_added = false;
+
+    if s.last() != Some(&0) {
+        s.to_mut().push(0);
+        null_byte_added = true;
+    }
+
+    // This function is called if conversion fails because the string has a null byte
+    // in the middle.
+    let convert_error = move |s: Cow<'a, [u8]>| -> JvmError {
+        // We need to get back to a `String` in order to insert it into the error. How
+        // to do that depends on whether we were given a separate original or not.
+        let s: String = {
+            if let Some(original) = original {
+                // Yes, there is a separate original. Use that.
+                original.into_owned()
+            } else {
+                // No, `s` *is* the original. Strip off the null byte if we
+                // added one, then assume the rest is valid UTF-8.
+                let mut s: Vec<u8> = s.into_owned();
+
+                if null_byte_added {
+                    let _removed_null_byte: Option<u8> = s.pop();
+                    debug_assert_eq!(_removed_null_byte, Some(0));
+                }
+
+                // Safety: The caller of this function asserts that this is valid UTF-8. We
+                // have not changed it other than adding a null byte at the end.
+                unsafe { String::from_utf8_unchecked(s) }
+            }
+        };
+
+        JvmError::NullOptString(s)
+    };
+
+    // Now, try to convert. Exactly how to do this, and exactly how to handle errors, depends
+    // on whether it's borrowed or owned.
+    let s: Cow<'a, CStr> = match s {
+        Cow::Owned(s) => Cow::Owned({
+            CString::from_vec_with_nul(s)
+                .map_err(|error| convert_error(Cow::Owned(error.into_bytes())))?
+        }),
+
+        Cow::Borrowed(s) => Cow::Borrowed({
+            CStr::from_bytes_with_nul(s).map_err(|_error| convert_error(Cow::Borrowed(s)))?
+        }),
+    };
+
+    // Done.
+    Ok(s)
+}
+
+/// Converts `s: Cow<str>` into a `Cow<CStr>`, still in UTF-8 encoding, adding a null byte if
+/// necessary.
+pub(super) fn utf8_to_cstr<'a>(s: Cow<'a, str>) -> Result<Cow<'a, CStr>, JvmError> {
+    let s: Cow<'a, [u8]> = match s {
+        Cow::Owned(s) => Cow::Owned(s.into_bytes()),
+        Cow::Borrowed(s) => Cow::Borrowed(s.as_bytes()),
+    };
+
+    // Safety: `s` was just converted from type `str`, so it's already known to contain valid
+    // UTF-8.
+    unsafe { bytes_to_cstr(s, None) }
+}
+
+#[test]
+fn test() {
+    use assert_matches::assert_matches;
+
+    {
+        let result = utf8_to_cstr("Hello, world 😎".into()).unwrap();
+        assert_eq!(
+            result.to_bytes_with_nul(),
+            b"Hello, world \xf0\x9f\x98\x8e\0"
+        );
+        assert_matches!(result, Cow::Owned(_));
+    }
+
+    {
+        let result = utf8_to_cstr("Hello, world 😎\0".into()).unwrap();
+        assert_eq!(
+            result.to_bytes_with_nul(),
+            b"Hello, world \xf0\x9f\x98\x8e\0"
+        );
+        assert_matches!(result, Cow::Borrowed(_));
+    }
+
+    {
+        let result = utf8_to_cstr("Hello,\0world".into()).unwrap_err();
+        let error_string = assert_matches!(result, JvmError::NullOptString(string) => string);
+        assert_eq!(error_string, "Hello,\0world");
+    }
+}

--- a/src/wrapper/java_vm/init_args/char_encoding_windows.rs
+++ b/src/wrapper/java_vm/init_args/char_encoding_windows.rs
@@ -1,0 +1,443 @@
+use super::{char_encoding_generic::*, JvmError};
+use std::{
+    borrow::Cow,
+    convert::TryInto,
+    ffi::{c_int, c_uint, CStr},
+    io,
+    mem::MaybeUninit,
+    ptr,
+};
+use windows_sys::Win32::Globalization as winnls;
+
+// The integer type used by `WideCharToMultiByte` for string lengths.
+type WSize = c_int;
+
+// The type of Windows codepage numbers.
+type WCodepage = c_uint;
+
+// The maximum length, in UTF-8 bytes, of strings that will be accepted for transcoding.
+//
+// The purpose of this limit is to prevent overflow. `WideCharToMultiByte` behaves rather badly
+// (see https://github.com/jni-rs/jni-rs/pull/414 for discussion) if the string is long enough to
+// overflow its counters.
+//
+// Although it is possible to transcode a string of any length by splitting it into smaller
+// substrings, the code complexity needed to do so isn't worthwhile just for transcoding JVM
+// options. Also, `test_overflow` would take a very long time to run, which was deemed unacceptable
+// (see https://github.com/jni-rs/jni-rs/pull/414#issuecomment-1419130483). We set this arbitrary
+// limit instead.
+const MAX_INPUT_LEN: usize = 1048576;
+
+/// Converts `s` into a `Cow<CStr>` encoded in the specified Windows code page.
+pub(super) fn str_to_cstr_win32<'a>(
+    s: Cow<'a, str>,
+    needed_codepage: WCodepage,
+) -> Result<Cow<'static, CStr>, JvmError> {
+    // First, check if the input string (UTF-8) is too long to transcode. Bail early if so.
+    if s.len() > MAX_INPUT_LEN {
+        return Err(JvmError::OptStringTooLong {
+            opt_string: s.into_owned(),
+        });
+    }
+
+    // This function will generate an error if `WideCharToMultiByte` fails.
+    fn convert_error(s: Cow<str>) -> JvmError {
+        JvmError::OptStringTranscodeFailure {
+            opt_string: s.into_owned(),
+            error: io::Error::last_os_error(),
+        }
+    }
+
+    // Convert the string to UTF-16 first.
+    let s_utf16: Vec<u16> = s.encode_utf16().collect();
+
+    // Determine how long the string is, in UTF-16 units, in the integer type that Win32 expects.
+    // Overflow should be impossible; panic if it happens.
+    let s_utf16_len: WSize = s_utf16
+        .len()
+        .try_into()
+        .expect("UTF-16 form of input string is too long");
+
+    // Decide which flags we're going to use.
+    let conversion_flags = match needed_codepage {
+        // No flags may be given for the following code pages.
+        // https://learn.microsoft.com/en-us/windows/win32/api/stringapiset/nf-stringapiset-widechartomultibyte
+        42
+        | 50220
+        | 50221
+        | 50222
+        | 50225
+        | 50227
+        | 50229
+        | 54936
+        | 57002..=57011
+        | 65000
+        | 65001 => 0,
+
+        _ => winnls::WC_COMPOSITECHECK | winnls::WC_NO_BEST_FIT_CHARS,
+    };
+
+    // Find out how much buffer space will be needed for the output and whether the string is
+    // fully representable.
+    let mut is_non_representable: Option<MaybeUninit<_>> = match needed_codepage {
+        // All characters are representable in UTF-7 and UTF-8, and moreover
+        // `WideCharToMultiByte` will fail if the target encoding is UTF-7 or UTF-8 and this is not
+        // `None`.
+        winnls::CP_UTF7 | winnls::CP_UTF8 => None,
+        _ => Some(MaybeUninit::uninit()),
+    };
+
+    // Safety: `s_utf16.as_ptr()` is a valid pointer to a UTF-16 string, and `s_utf16_len` is its
+    // length. `lpDefaultChar` is null. `lpUsedDefaultChar` is either null or valid. `cbMultiByte`
+    // is zero.
+    let required_buffer_space = unsafe {
+        winnls::WideCharToMultiByte(
+            needed_codepage,
+            conversion_flags,
+            s_utf16.as_ptr(),
+            s_utf16_len,
+            ptr::null_mut(),
+            0,
+            ptr::null(),
+            match &mut is_non_representable {
+                Some(x) => x.as_mut_ptr(),
+                None => ptr::null_mut(),
+            },
+        )
+    };
+
+    // Bail on error.
+    if required_buffer_space == 0 {
+        drop(s_utf16);
+
+        return Err(convert_error(s));
+    }
+
+    // Check if the string is not fully representable.
+    if let Some(is_non_representable) = is_non_representable {
+        // Safety: `is_non_representable` has been initialized by `WideCharToMultiByte`.
+        let is_non_representable = unsafe { is_non_representable.assume_init() };
+
+        if is_non_representable != 0 {
+            drop(s_utf16);
+
+            return Err(JvmError::OptStringNotRepresentable {
+                opt_string: s.into_owned(),
+            });
+        }
+    }
+
+    // Convert the required buffer space to `usize`, and increment it by one for the null
+    // terminator.
+    //
+    // This shouldn't overflow (see the comment on `MAX_INPUT_LEN` above), so we won't check for
+    // overflow here.
+    let required_buffer_space_usize: usize = required_buffer_space as _;
+    let required_buffer_space_usize_with_nul: usize = required_buffer_space_usize + 1;
+
+    // Allocate enough buffer space, including one byte for the null terminator.
+    let mut output = Vec::<u8>::with_capacity(required_buffer_space_usize_with_nul);
+
+    // Perform the actual conversion.
+    //
+    // Safety: `chunk.as_ptr()` is a valid pointer, and `chunk_len_i32` is its length.
+    // `chunk_output_ptr` is a valid pointer, and `required_buffer_space` is its length.
+    // All other raw pointers are null.
+    let used_buffer_space = unsafe {
+        winnls::WideCharToMultiByte(
+            needed_codepage,
+            conversion_flags,
+            s_utf16.as_ptr(),
+            s_utf16_len,
+            output.as_mut_ptr(),
+            required_buffer_space,
+            ptr::null(),
+            ptr::null_mut(),
+        )
+    };
+
+    drop(s_utf16);
+
+    // Bail on error.
+    if used_buffer_space == 0 {
+        drop(output);
+
+        return Err(convert_error(s));
+    }
+
+    let used_buffer_space_usize: usize = used_buffer_space as usize;
+
+    // Set the new length of the output buffer. Don't use `required_buffer_space`, just in case
+    // `WideCharToMultiByte` changes its mind about how much buffer space it's actually going to
+    // use.
+    //
+    // Safety: `used_buffer_space_usize` is the number of bytes that `WideCharToMultiByte` has
+    // just initialized.
+    unsafe {
+        output.set_len(used_buffer_space_usize);
+    }
+
+    // That's it, it's converted. Now turn it into a `CString`. This will add a null terminator if
+    // there isn't one already and check for null bytes in the middle.
+    unsafe { bytes_to_cstr(Cow::Owned(output), Some(s.into())) }
+}
+
+/// Converts `s` into the Windows default character encoding.
+pub(super) fn str_to_cstr_win32_default_codepage<'a>(
+    s: Cow<'a, str>,
+) -> Result<Cow<'a, CStr>, JvmError> {
+    // Get the code page. There is a remote possibility that it is UTF-8. If so, pass the
+    // string through unchanged (other than adding a null terminator). If not, we need to have
+    // Windows convert the string to the expected code page first.
+
+    // Safety: This function isn't actually unsafe.
+    let needed_codepage = unsafe { winnls::GetACP() };
+
+    if needed_codepage == winnls::CP_UTF8 {
+        // The code page is UTF-8! Lucky us.
+        return utf8_to_cstr(s);
+    }
+
+    // The code page is not UTF-8, so do the transcoding.
+    str_to_cstr_win32(s, needed_codepage)
+}
+
+/// Transcodes text in an arbitrary Windows codepage into a Rust `String`. Used to test
+/// round-tripping.
+#[cfg(test)]
+fn codepage_to_string_win32(
+    codepage_string: impl AsRef<[u8]>,
+    codepage: WCodepage,
+    max_expected_utf16_len: WSize,
+) -> io::Result<String> {
+    let codepage_string_slice = codepage_string.as_ref();
+
+    let codepage_string_slice_len: WSize = codepage_string_slice
+        .len()
+        .try_into()
+        .expect("`codepage_string`'s length is too large to transcode with Win32");
+
+    let mut buf = Vec::<u16>::with_capacity(
+        max_expected_utf16_len
+            .try_into()
+            .expect("expected_utf16_len is negative or exceeds address space"),
+    );
+
+    // Safety: All of these pointers and lengths are valid and checked for overflow.
+    let utf16_units_transcoded = unsafe {
+        winnls::MultiByteToWideChar(
+            codepage,
+            0,
+            codepage_string_slice.as_ptr() as *const _,
+            codepage_string_slice_len,
+            buf.as_mut_ptr(),
+            max_expected_utf16_len,
+        )
+    };
+
+    if utf16_units_transcoded == 0 {
+        return Err(io::Error::last_os_error());
+    }
+
+    // Safety: `MultiByteToWideChar` claims to have initialized this many UTF-16 units.
+    unsafe {
+        buf.set_len(utf16_units_transcoded as _);
+    }
+
+    drop(codepage_string);
+
+    let string =
+        String::from_utf16(buf.as_slice()).expect("`MultiByteToWideChar` generated invalid UTF-16");
+
+    Ok(string)
+}
+
+#[test]
+fn test() {
+    use assert_matches::assert_matches;
+
+    {
+        let result = str_to_cstr_win32("Hello, world 😎".into(), winnls::CP_UTF8).unwrap();
+        assert_eq!(
+            result.to_bytes_with_nul(),
+            b"Hello, world \xf0\x9f\x98\x8e\0"
+        );
+        assert_matches!(result, Cow::Owned(_));
+    }
+
+    {
+        let result = str_to_cstr_win32("Hello, world 😎\0".into(), winnls::CP_UTF8).unwrap();
+        assert_eq!(
+            result.to_bytes_with_nul(),
+            b"Hello, world \xf0\x9f\x98\x8e\0"
+        );
+    }
+
+    {
+        let result = str_to_cstr_win32("Hello, world 😎".into(), 1252).unwrap_err();
+        let error_string = assert_matches!(result, JvmError::OptStringNotRepresentable { opt_string } => opt_string);
+        assert_eq!(error_string, "Hello, world 😎");
+    }
+
+    {
+        let result = str_to_cstr_win32("Hello, world™".into(), 1252).unwrap();
+        assert_eq!(result.to_bytes_with_nul(), b"Hello, world\x99\0");
+        assert_matches!(result, Cow::Owned(_));
+    }
+}
+
+#[test]
+fn test_overflow() {
+    use assert_matches::assert_matches;
+
+    // Note: We avoid naïvely using `assert` here, because assertion failure will dump millions of
+    // characters to the console. Instead, here are some functions for handling errors without
+    // doing that.
+
+    #[track_caller]
+    fn check_and_clear_error_opt_string(expected_opt_string: &str, error: &mut JvmError) {
+        if let Some(actual_opt_string) = error.opt_string_mut() {
+            if actual_opt_string != expected_opt_string {
+                panic!("opt_string was mangled in moving it to an error");
+            }
+
+            *actual_opt_string = String::new();
+        }
+    }
+
+    #[track_caller]
+    fn expect_success(
+        expected_opt_string: &str,
+        result: Result<Cow<'static, CStr>, JvmError>,
+    ) -> Cow<'static, CStr> {
+        match result {
+            Ok(ok) => ok,
+            Err(mut error) => {
+                check_and_clear_error_opt_string(expected_opt_string, &mut error);
+                panic!("unexpected transcoding failure: {}", error)
+            }
+        }
+    }
+
+    #[track_caller]
+    fn expect_successful_roundtrip(
+        expected_opt_string: &str,
+        result: Result<Cow<'static, CStr>, JvmError>,
+    ) -> Cow<'static, CStr> {
+        let string = expect_success(expected_opt_string, result);
+        assert!(
+            expected_opt_string.as_bytes() == string.to_bytes(),
+            "opt_string was transcoded successfully but mangled"
+        );
+        string
+    }
+
+    #[track_caller]
+    fn expect_opt_string_too_long(
+        expected_opt_string: &str,
+        result: Result<Cow<'static, CStr>, JvmError>,
+    ) {
+        let mut error = match result {
+            Err(err) => err,
+            Ok(ok) => {
+                assert!(
+                    expected_opt_string.as_bytes() == ok.to_bytes(),
+                    "transcoding unexpectedly succeeded and resulted in mangled output"
+                );
+                panic!("transcoding unexpectedly succeeded")
+            }
+        };
+
+        check_and_clear_error_opt_string(expected_opt_string, &mut error);
+
+        assert_matches!(error, JvmError::OptStringTooLong { .. });
+    }
+
+    {
+        // Try transcoding a plain ASCII string.
+
+        // First, allocate enough space to completely fill the maximum allowed length, plus one
+        // more.
+        //eprintln!("Allocating & filling ASCII");
+        let string = vec![b'H'; MAX_INPUT_LEN.checked_add(1).unwrap()];
+
+        //eprintln!("Checking UTF-8 correctness");
+        let mut string = String::from_utf8(string).unwrap();
+
+        // This string is currently one character too long to transcode, so there should be an
+        // overflow error.
+        //eprintln!("Transcoding ASCII string that's too long");
+        expect_opt_string_too_long(
+            &string,
+            str_to_cstr_win32(string.as_str().into(), winnls::CP_UTF8),
+        );
+
+        // But if we remove one character…
+        assert_eq!(string.pop(), Some('H'));
+
+        // …then it should transcode fine.
+        //eprintln!("Transcoding ASCII string that's not too long");
+        expect_successful_roundtrip(
+            &string,
+            str_to_cstr_win32(string.as_str().into(), winnls::CP_UTF8),
+        );
+    }
+
+    {
+        // Try transcoding a non-ASCII string.
+
+        // U+07FF is the highest code point that can be represnted in UTF-8 with only two bytes, so
+        // we'll use that. The UTF-8 encoding is `df bf`. We fill it this way because it's much
+        // faster than the naïve character-by-character approach (at least unless some future Rust
+        // compiler performs this optimization on its own, but 1.66 doesn't).
+        //eprintln!("Allocating & filling non-ASCII for UTF-8 and UTF-7");
+        let string_byte_pairs = vec![u16::from_be(0xdfbf); MAX_INPUT_LEN / 2];
+
+        //eprintln!("Checking UTF-8 correctness");
+        let string: &str =
+            std::str::from_utf8(bytemuck::cast_slice(string_byte_pairs.as_slice())).unwrap();
+
+        // Again, the string should transcode without overflow.
+        //eprintln!("Transcoding non-ASCII to UTF-8");
+        expect_successful_roundtrip(string, str_to_cstr_win32(string.into(), winnls::CP_UTF8));
+
+        // This should work even with UTF-7. This is the real reason we're using U+07FF: we need
+        // to check that the highest code point that fits under the limit will not overflow even
+        // with the worst-case code page.
+        {
+            //eprintln!("Transcoding non-ASCII to UTF-7");
+            let result = expect_success(string, str_to_cstr_win32(string.into(), winnls::CP_UTF7));
+
+            // *And* it should roundtrip back to UTF-8.
+            //eprintln!("Transcoding UTF-7 back to UTF-8");
+            let result: String = codepage_to_string_win32(
+                result.to_bytes(),
+                winnls::CP_UTF7,
+                (string.len() / 2).try_into().unwrap(),
+            )
+            .unwrap();
+
+            assert!(result == string, "didn't roundtrip via UTF-7");
+        }
+    }
+
+    {
+        // Try transcoding to Windows-1252. This is the slowest part of the test
+        // (`WideCharToMultiByte` is very slow at this, for some reason), so it's done last.
+        //eprintln!("Allocating & filling non-ASCII for Windows-1252");
+        let string_byte_pairs = vec![u16::from_be(0xc2ae); MAX_INPUT_LEN / 2];
+
+        //eprintln!("Checking UTF-8 correctness");
+        let string: &str =
+            std::str::from_utf8(bytemuck::cast_slice(string_byte_pairs.as_slice())).unwrap();
+
+        //eprintln!("Transcoding non-ASCII to Windows-1252");
+        let result = expect_success(string, str_to_cstr_win32(string.into(), 1252));
+
+        //eprintln!("Checking Windows-1252 for correctness");
+        assert!(
+            result.to_bytes().iter().all(|byte| *byte == 0xae),
+            "string didn't transcode to Windows-1252 properly"
+        );
+    }
+}

--- a/tests/invocation_character_encoding.rs
+++ b/tests/invocation_character_encoding.rs
@@ -1,0 +1,43 @@
+// This is a separate test program because it has to start a JVM with a specific option.
+
+#![cfg(feature = "invocation")]
+
+use jni::{objects::JString, InitArgsBuilder, JavaVM};
+
+#[test]
+fn invocation_character_encoding() {
+    let jvm_args = InitArgsBuilder::new()
+        .version(jni::JNIVersion::V8)
+        .option("-Xcheck:jni")
+        // U+00A0 NO-BREAK SPACE is the only non-ASCII character that's present in all parts of
+        // ISO 8859. This minimizes the chance of this test failing as a result of the character
+        // not being present in the platform default character encoding. This test will still fail
+        // on platforms where the default character encoding cannot represent a no-break space,
+        // such as GBK.
+        .option("-Dnbsp=\u{00a0}")
+        .build()
+        .unwrap_or_else(|e| panic!("{:#?}", e));
+
+    let jvm = JavaVM::new(jvm_args).unwrap_or_else(|e| panic!("{:#?}", e));
+
+    let mut env = jvm.attach_current_thread().unwrap();
+
+    let prop_name = env.new_string("nbsp").unwrap();
+
+    let prop_value: JString = env
+        .call_static_method(
+            "java/lang/System",
+            "getProperty",
+            "(Ljava/lang/String;)Ljava/lang/String;",
+            &[(&prop_name).into()],
+        )
+        .unwrap()
+        .l()
+        .unwrap()
+        .into();
+
+    let prop_value_str = env.get_string(&prop_value).unwrap();
+    let prop_value_str: &str = prop_value_str.to_str().unwrap();
+
+    assert_eq!("\u{00a0}", prop_value_str);
+}


### PR DESCRIPTION
## Overview

This draft PR fixes #410. It adds code to transcode JVM option strings, as passed to `InitArgsBuilder::option`, into the character encoding that HotSpot expects. It also adds `InitArgsBuilder::option_encoded` to skip transcoding and pass a raw `CStr` to the JVM.

This is a draft because it's a work in progress. Only Windows is handled so far. Next I will see about doing the same for POSIX platforms.

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Change is covered by [automated tests](https://github.com/jni-rs/jni-rs/blob/master/CONTRIBUTING.md#tests)
- [x] The [coding guidelines](https://github.com/jni-rs/jni-rs/blob/master/CONTRIBUTING.md#the-code-style) are followed
- [x] Public API has documentation
- [x] User-visible changes are mentioned in the Changelog
- [x] The continuous integration build passes
