### PR TITLE
Don't assume JavaVMOption::optionString is signed/unsigned

### DIFF
--- a/src/wrapper/java_vm/init_args.rs
+++ b/src/wrapper/java_vm/init_args.rs
@@ -311,7 +311,7 @@ impl<'a> InitArgsBuilder<'a> {
         let opts: Vec<JavaVMOption> = opt_strings
             .iter()
             .map(|opt_string| JavaVMOption {
-                optionString: opt_string.as_ptr() as *mut i8,
+                optionString: opt_string.as_ptr() as _,
                 extraInfo: ptr::null_mut(),
             })
             .collect();


### PR DESCRIPTION
Depending on the compiler target the `JavaVMOption::optionString` may be `*mut u8` or `*mut i8`.

For example, when compiling with `aarch64-linux-android` it is `u8` and when compiling with `x86_64-pc-windows-msvc` it is `i8`

TODO: ideally we should incorporate an Android build into the CI, since that's a very likely use case for the `jni` crate. (luckily this isn't a big issue for Android because the `invocation` feature isn't really applicable to Android)


