### PR TITLE
Fix a build failure in the benchmark

### DIFF
--- a/benches/api_calls.rs
+++ b/benches/api_calls.rs
@@ -227,8 +227,9 @@ mod tests {
         let mut env = VM.attach_current_thread().unwrap();
         let s = env.new_string("").unwrap();
         let obj = black_box(JObject::from(s));
+        let obj_class = env.get_object_class(&obj).unwrap();
         let method_id = env
-            .get_method_id(&obj, METHOD_OBJECT_HASH_CODE, SIG_OBJECT_HASH_CODE)
+            .get_method_id(&obj_class, METHOD_OBJECT_HASH_CODE, SIG_OBJECT_HASH_CODE)
             .unwrap();
 
         b.iter(|| jni_int_call_unchecked(&mut env, &obj, method_id));


### PR DESCRIPTION
## Overview

This trivial PR fixes a compile error in the benchmark, which was caused by the fact that arbitrary objects no longer implement `Desc<JClass>`.

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Change is covered by [automated tests](https://github.com/jni-rs/jni-rs/blob/master/CONTRIBUTING.md#tests)
- [x] The [coding guidelines](https://github.com/jni-rs/jni-rs/blob/master/CONTRIBUTING.md#the-code-style) are followed
- [x] Public API has documentation
- [x] User-visible changes are mentioned in the Changelog
- [x] The continuous integration build passes
