### PR TITLE
Remove `JValueGen`; degenerify `JValue` and `JValueOwned`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+- `JValueGen` has been removed. `JValue` and `JValueOwned` are now separate, unrelated, non-generic types. ([#429](https://github.com/jni-rs/jni-rs/pull/429))
+
 
 ## [0.21.1] — 2023-03-08
 


### PR DESCRIPTION
## Overview

As discussed in https://github.com/jni-rs/jni-rs/issues/426#issuecomment-1458343035, this PR removes `JValueGen`. `JValue` and `JValueOwned` are now separate, unrelated, non-generic types.

Although this introduces some code duplication, it should result in better compiler error messages when you mistakenly use one when the other is expected.

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Change is covered by [automated tests](https://github.com/jni-rs/jni-rs/blob/master/CONTRIBUTING.md#tests)
- [x] The [coding guidelines](https://github.com/jni-rs/jni-rs/blob/master/CONTRIBUTING.md#the-code-style) are followed
- [x] Public API has documentation
- [x] User-visible changes are mentioned in the Changelog
- [x] The continuous integration build passes
