### PR TITLE
Release 0.21.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 
 
+## [0.21.1] — 2023-03-08
+
+### Fixes
+- Compilation is fixed for architectures with a C ABI that has unsigned `char` types. ([#419](https://github.com/jni-rs/jni-rs/pull/419))
+
 ## [0.21.0] — 2023-02-13
 
 This release makes extensive breaking changes in order to improve safety. Most projects that use this library will need to be changed. Please see [the migration guide](docs/0.21-MIGRATION.md).
@@ -307,7 +312,8 @@ to call if there is a pending exception (#124):
 ## [0.10.1]
 - No changes has been made to the Changelog until this release.
 
-[Unreleased]: https://github.com/jni-rs/jni-rs/compare/v0.21.0...HEAD
+[Unreleased]: https://github.com/jni-rs/jni-rs/compare/v0.21.1...HEAD
+[0.21.1]: https://github.com/jni-rs/jni-rs/compare/v0.21.0...v0.21.1
 [0.21.0]: https://github.com/jni-rs/jni-rs/compare/v0.20.0...v0.21.0
 [0.20.0]: https://github.com/jni-rs/jni-rs/compare/v0.19.0...v0.20.0
 [0.19.0]: https://github.com/jni-rs/jni-rs/compare/v0.18.0...v0.19.0

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -111,7 +111,7 @@ They might help you to see the performance differences between
 two [API flavours][checked-unchecked]: checked and unchecked, and
 pick the right one for your application.
 
-[checked-unchecked]: https://docs.rs/jni/0.21.0/jni/struct.JNIEnv.html#checked-and-unchecked-methods
+[checked-unchecked]: https://docs.rs/jni/0.21.1/jni/struct.JNIEnv.html#checked-and-unchecked-methods
 
 ## The Code Style
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ license = "MIT/Apache-2.0"
 name = "jni"
 repository = "https://github.com/jni-rs/jni-rs"
 # ¡When bumping version please also update it in examples and documentation!
-version = "0.21.0"
+version = "0.21.1"
 edition = "2018"
 
 [dependencies]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -85,7 +85,7 @@
 //! `mylib` that has everything needed to build an basic crate with `cargo`. We
 //! need to make a couple of changes to `Cargo.toml` before we do anything else.
 //!
-//! * Under `[dependencies]`, add `jni = "0.21.0"`
+//! * Under `[dependencies]`, add `jni = "0.21.1"`
 //! * Add a new `[lib]` section and under it, `crate_type = ["cdylib"]`.
 //!
 //! Now, if you run `cargo build` from inside the crate directory, you should

--- a/src/wrapper/java_vm/vm.rs
+++ b/src/wrapper/java_vm/vm.rs
@@ -62,7 +62,7 @@ use {
 /// feature in the Cargo.toml:
 ///
 /// ```toml
-/// jni = { version = "0.21.0", features = ["invocation"] }
+/// jni = { version = "0.21.1", features = ["invocation"] }
 /// ```
 ///
 /// The application will be able to use [`JavaVM::new`] which will dynamically


### PR DESCRIPTION
This patch release fixes builds on architectures with unsigned `char` C ABI types. ([#419](https://github.com/jni-rs/jni-rs/pull/419))

This is a follow up to @bazald's request for a patch release here: https://github.com/jni-rs/jni-rs/discussions/430

