### PR TITLE
Feat: Make JObject fields public to allow destructuring

### DIFF
--- a/src/wrapper/objects/jobject.rs
+++ b/src/wrapper/objects/jobject.rs
@@ -32,8 +32,8 @@ use crate::{objects::GlobalRef, JNIEnv};
 #[repr(transparent)]
 #[derive(Debug)]
 pub struct JObject<'local> {
-    internal: jobject,
-    lifetime: PhantomData<&'local ()>,
+    pub internal: jobject,
+    pub lifetime: PhantomData<&'local ()>,
 }
 
 unsafe impl Send for JObject<'static> {}


### PR DESCRIPTION
## Overview

I need to convert a JObject to a JValueGen in order to use a match statement to convert  JValueGen::Object into other rust types

```rust
pub fn to_rust<'local, 'obj_ref, T>(
    env: &mut JNIEnv<'local>,
    _class: &JClass<'local>,
    input: &JObject,
)  {
    let java_value = JValue::from(input);

    let outcome = match java_value {
        JValueGen::Object(value) => {
            let JObject { internal, lifetime } = *value;
            let destructured_value = JObject { internal, lifetime };

            if let Ok(inner_value) = JString::try_from(destructured_value) {
                let string_outcome = env.get_string(&inner_value)?.into();

                println!("{}", string_outcome);

            } else {
                todo!()
            }
        }
        _ => panic!(),
    };


}
```

To do this I need the values of `internal` and `lifetime` to be public in the JObject {} struct as done in this pull request.

If there is a better way to do this I am open to ideas