### PR TITLE
Wrapped `CallNonvirtual*Method`

### DIFF
--- a/src/wrapper/jnienv.rs
+++ b/src/wrapper/jnienv.rs
@@ -1341,6 +1341,87 @@ impl<'local> JNIEnv<'local> {
         }) // match parsed.ret
     }
 
+    /// Call an non-virtual object method in an unsafe manner. This does nothing to check
+    /// whether the method is valid to call on the object, whether the return
+    /// type is correct, or whether the number of args is valid for the method.
+    ///
+    /// Under the hood, this simply calls the `CallNonvirtual<Type>MethodA` method with
+    /// the provided arguments.
+    ///
+    /// # Safety
+    ///
+    /// The provided JMethodID must be valid, and match the types and number of arguments, and return type.
+    /// If these are incorrect, the JVM may crash. The JMethodID must also match the passed type.
+    pub unsafe fn call_nonvirtual_method_unchecked<'other_local, O, T, U>(
+        &mut self,
+        obj: O,
+        class: T,
+        method_id: U,
+        ret: ReturnType,
+        args: &[jvalue],
+    ) -> Result<JValueOwned<'local>>
+        where
+            O: AsRef<JObject<'other_local>>,
+            T: Desc<'local, JClass<'other_local>>,
+            U: Desc<'local, JMethodID>,
+    {
+        let method_id = method_id.lookup(self)?.as_ref().into_raw();
+        let class = class.lookup(self)?;
+
+        let obj = obj.as_ref().as_raw();
+        let class_raw = class.as_ref().as_raw();
+
+        let jni_args = args.as_ptr();
+
+        // TODO clean this up
+        Ok(match ret {
+            ReturnType::Object | ReturnType::Array => {
+                let obj =
+                    jni_non_void_call!(self.internal, CallNonvirtualObjectMethodA, obj, class_raw, method_id, jni_args);
+                let obj = unsafe { JObject::from_raw(obj) };
+                obj.into()
+            }
+            ReturnType::Primitive(p) => match p {
+                Primitive::Boolean => {
+                    jni_non_void_call!(self.internal, CallNonvirtualBooleanMethodA, obj, class_raw, method_id, jni_args)
+                        .into()
+                }
+                Primitive::Char => {
+                    jni_non_void_call!(self.internal, CallNonvirtualCharMethodA, obj, class_raw, method_id, jni_args)
+                        .into()
+                }
+                Primitive::Short => {
+                    jni_non_void_call!(self.internal, CallNonvirtualShortMethodA, obj, class_raw, method_id, jni_args)
+                        .into()
+                }
+                Primitive::Int => {
+                    jni_non_void_call!(self.internal, CallNonvirtualIntMethodA, obj, class_raw, method_id, jni_args)
+                        .into()
+                }
+                Primitive::Long => {
+                    jni_non_void_call!(self.internal, CallNonvirtualLongMethodA, obj, class_raw, method_id, jni_args)
+                        .into()
+                }
+                Primitive::Float => {
+                    jni_non_void_call!(self.internal, CallNonvirtualFloatMethodA, obj, class_raw, method_id, jni_args)
+                        .into()
+                }
+                Primitive::Double => {
+                    jni_non_void_call!(self.internal, CallNonvirtualDoubleMethodA, obj, class_raw, method_id, jni_args)
+                        .into()
+                }
+                Primitive::Byte => {
+                    jni_non_void_call!(self.internal, CallNonvirtualByteMethodA, obj, class_raw, method_id, jni_args)
+                        .into()
+                }
+                Primitive::Void => {
+                    jni_void_call!(self.internal, CallNonvirtualVoidMethodA, obj, class_raw, method_id, jni_args);
+                    return Ok(JValueOwned::Void);
+                }
+            }, // JavaType::Primitive
+        }) // match parsed.ret
+    }
+
     /// Calls an object method safely. This comes with a number of
     /// lookups/checks. It
     ///
@@ -1409,7 +1490,7 @@ impl<'local> JNIEnv<'local> {
     /// * Looks up the JMethodID for the class/name/signature combination
     /// * Ensures that the number/types of args matches the signature
     ///   * Cannot check an object's type - but primitive types are matched against each other (including Object)
-    /// * Calls `call_method_unchecked` with the verified safe arguments.
+    /// * Calls `call_static_method_unchecked` with the verified safe arguments.
     ///
     /// Note: this may cause a Java exception if the arguments are the wrong
     /// type, in addition to if the method itself throws.
@@ -1456,6 +1537,68 @@ impl<'local> JNIEnv<'local> {
         // We've also validated the argument counts and types using the same type signature
         // we fetched the original method ID from.
         unsafe { self.call_static_method_unchecked(class, (class, name, sig), parsed.ret, &args) }
+    }
+
+    /// Calls a non-virtual method safely. This comes with a number of
+    /// lookups/checks. It
+    ///
+    /// * Parses the type signature to find the number of arguments and return
+    ///   type
+    /// * Looks up the JMethodID for the class/name/signature combination
+    /// * Ensures that the number/types of args matches the signature
+    ///   * Cannot check an object's type - but primitive types are matched against each other (including Object)
+    /// * Calls `call_nonvirtual_method_unchecked` with the verified safe arguments.
+    ///
+    /// Note: this may cause a Java exception if the arguments are the wrong
+    /// type, in addition to if the method itself throws.
+    pub fn call_nonvirtual_method<'other_local, O, T, U, V>(
+        &mut self,
+        obj: O,
+        class: T,
+        name: U,
+        sig: V,
+        args: &[JValue],
+    ) -> Result<JValueOwned<'local>>
+        where
+            O: AsRef<JObject<'other_local>>,
+            T: Desc<'local, JClass<'other_local>>,
+            U: Into<JNIString>,
+            V: Into<JNIString> + AsRef<str>,
+    {
+        let obj = obj.as_ref();
+        non_null!(obj, "call_method obj argument");
+
+        let parsed = TypeSignature::from_str(&sig)?;
+        if parsed.args.len() != args.len() {
+            return Err(Error::InvalidArgList(parsed));
+        }
+
+        // check arguments types
+        let base_types_match = parsed
+            .args
+            .iter()
+            .zip(args.iter())
+            .all(|(exp, act)| match exp {
+                JavaType::Primitive(p) => act.primitive_type() == Some(*p),
+                JavaType::Object(_) | JavaType::Array(_) => act.primitive_type().is_none(),
+                JavaType::Method(_) => {
+                    unreachable!("JavaType::Method(_) should not come from parsing a method sig")
+                }
+            });
+        if !base_types_match {
+            return Err(Error::InvalidArgList(parsed));
+        }
+
+        // go ahead and look up the class since we'll need that for the next call.
+        let class = class.lookup(self)?;
+        let class = class.as_ref();
+
+        let args: Vec<jvalue> = args.iter().map(|v| v.as_jni()).collect();
+
+        // SAFETY: We've obtained the method_id above, so it is valid for this class.
+        // We've also validated the argument counts and types using the same type signature
+        // we fetched the original method ID from.
+        unsafe { self.call_nonvirtual_method_unchecked(obj, class, (class, name, sig), parsed.ret, &args) }
     }
 
     /// Create a new object using a constructor. This is done safely using


### PR DESCRIPTION
## Overview

Wrapped `CallNonvirtual*Method` in `jni.h`

Tested it locally.

```java
public class Parent {
    public void print() {
        System.out.println("[*] Parent class!");
    }
}

public class Child extends Parent {
    @Override
    public void print() {
        System.out.println("[*] Child class!");
    }
}
```
and this is the rust part
```rust
#[no_mangle]
pub extern "system" fn Java_org_example_nativetest_Native_testCallNonvirtualMethod<'local>(
    mut env: JNIEnv<'local>,
    _class: JClass<'local>,
    obj: JObject<'local>,
) {
    println!("Let's call the virtual one");
    env.call_method(&obj, "print", "()V", &[]).unwrap();
    println!("Let's call the non-virtual one");
    let clazz = env.find_class("org/example/nativetest/nonvirtualtest/Parent").unwrap();
    env.call_nonvirtual_method(&obj, clazz, "print", "()V", &[]).unwrap();
}
```

### Definition of Done

- [x] There are no TODOs left in the code
- [ ] Change is covered by [automated tests](https://github.com/jni-rs/jni-rs/blob/master/CONTRIBUTING.md#tests)
- [x] The [coding guidelines](https://github.com/jni-rs/jni-rs/blob/master/CONTRIBUTING.md#the-code-style) are followed
- [x] Public API has documentation
- [x] User-visible changes are mentioned in the Changelog
- [x] The continuous integration build passes
