### PR TITLE
Make most from_raw(), get_raw() and into_raw() methods `const fn`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Changed
 - `JValueGen` has been removed. `JValue` and `JValueOwned` are now separate, unrelated, non-generic types. ([#429](https://github.com/jni-rs/jni-rs/pull/429))
+- Make most `from_raw()`, `get_raw()` and `into_raw()` methods `const fn`. ([#453](https://github.com/jni-rs/jni-rs/pull/453))
 
 ## [0.21.1] — 2023-03-08
 

--- a/src/wrapper/objects/auto_elements_critical.rs
+++ b/src/wrapper/objects/auto_elements_critical.rs
@@ -69,7 +69,7 @@ impl<'local, 'other_local, 'array, 'env, T: TypeArray>
     }
 
     /// Get a reference to the wrapped pointer
-    pub fn as_ptr(&self) -> *mut T {
+    pub const fn as_ptr(&self) -> *mut T {
         self.ptr.as_ptr()
     }
 

--- a/src/wrapper/objects/global_ref.rs
+++ b/src/wrapper/objects/global_ref.rs
@@ -80,7 +80,7 @@ impl GlobalRef {
 impl GlobalRefGuard {
     /// Creates a new global reference guard. This assumes that `NewGlobalRef`
     /// has already been called.
-    unsafe fn from_raw(vm: JavaVM, obj: sys::jobject) -> Self {
+    const unsafe fn from_raw(vm: JavaVM, obj: sys::jobject) -> Self {
         GlobalRefGuard {
             obj: JObject::from_raw(obj),
             vm,

--- a/src/wrapper/objects/jbytebuffer.rs
+++ b/src/wrapper/objects/jbytebuffer.rs
@@ -57,12 +57,12 @@ impl<'local> JByteBuffer<'local> {
     /// # Safety
     /// No runtime check is made to verify that the given [`jobject`] is an instance of
     /// a `ByteBuffer`.
-    pub unsafe fn from_raw(raw: jobject) -> Self {
+    pub const unsafe fn from_raw(raw: jobject) -> Self {
         Self(JObject::from_raw(raw as jobject))
     }
 
     /// Unwrap to the raw jni type.
-    pub fn into_raw(self) -> jobject {
+    pub const fn into_raw(self) -> jobject {
         self.0.into_raw() as jobject
     }
 }

--- a/src/wrapper/objects/jclass.rs
+++ b/src/wrapper/objects/jclass.rs
@@ -67,17 +67,17 @@ impl<'local> JClass<'local> {
     /// * There must not be any other `JObject` representing the same local reference.
     /// * The lifetime `'local` must not outlive the local reference frame that the local reference
     ///   was created in.
-    pub unsafe fn from_raw(raw: jclass) -> Self {
+    pub const unsafe fn from_raw(raw: jclass) -> Self {
         Self(JObject::from_raw(raw as jobject))
     }
 
     /// Returns the raw JNI pointer.
-    pub fn as_raw(&self) -> jclass {
+    pub const fn as_raw(&self) -> jclass {
         self.0.as_raw() as jclass
     }
 
     /// Unwrap to the raw jni type.
-    pub fn into_raw(self) -> jclass {
+    pub const fn into_raw(self) -> jclass {
         self.0.into_raw() as jclass
     }
 }

--- a/src/wrapper/objects/jfieldid.rs
+++ b/src/wrapper/objects/jfieldid.rs
@@ -36,13 +36,12 @@ impl JFieldID {
     /// # Safety
     ///
     /// Expects a valid, non-`null` ID
-    pub unsafe fn from_raw(raw: jfieldID) -> Self {
-        debug_assert!(!raw.is_null(), "from_raw fieldID argument");
+    pub const unsafe fn from_raw(raw: jfieldID) -> Self {
         Self { internal: raw }
     }
 
     /// Unwrap to the internal jni type.
-    pub fn into_raw(self) -> jfieldID {
+    pub const fn into_raw(self) -> jfieldID {
         self.internal
     }
 }

--- a/src/wrapper/objects/jmethodid.rs
+++ b/src/wrapper/objects/jmethodid.rs
@@ -36,13 +36,12 @@ impl JMethodID {
     /// # Safety
     ///
     /// Expects a valid, non-`null` ID
-    pub unsafe fn from_raw(raw: jmethodID) -> Self {
-        debug_assert!(!raw.is_null(), "from_raw methodID argument");
+    pub const unsafe fn from_raw(raw: jmethodID) -> Self {
         Self { internal: raw }
     }
 
     /// Unwrap to the internal jni type.
-    pub fn into_raw(self) -> jmethodID {
+    pub const fn into_raw(self) -> jmethodID {
         self.internal
     }
 }

--- a/src/wrapper/objects/jobject.rs
+++ b/src/wrapper/objects/jobject.rs
@@ -70,7 +70,7 @@ impl<'local> JObject<'local> {
     /// * There must not be any other `JObject` representing the same local reference.
     /// * The lifetime `'local` must not outlive the local reference frame that the local reference
     ///   was created in.
-    pub unsafe fn from_raw(raw: jobject) -> Self {
+    pub const unsafe fn from_raw(raw: jobject) -> Self {
         Self {
             internal: raw,
             lifetime: PhantomData,
@@ -78,12 +78,12 @@ impl<'local> JObject<'local> {
     }
 
     /// Returns the raw JNI pointer.
-    pub fn as_raw(&self) -> jobject {
+    pub const fn as_raw(&self) -> jobject {
         self.internal
     }
 
     /// Unwrap to the internal jni type.
-    pub fn into_raw(self) -> jobject {
+    pub const fn into_raw(self) -> jobject {
         self.internal
     }
 
@@ -91,7 +91,7 @@ impl<'local> JObject<'local> {
     ///
     /// Null references are always valid and do not belong to a local reference frame. Therefore,
     /// the returned `JObject` always has the `'static` lifetime.
-    pub fn null() -> JObject<'static> {
+    pub const fn null() -> JObject<'static> {
         unsafe { JObject::from_raw(std::ptr::null_mut() as jobject) }
     }
 }

--- a/src/wrapper/objects/jobject_array.rs
+++ b/src/wrapper/objects/jobject_array.rs
@@ -70,12 +70,12 @@ impl<'local> JObjectArray<'local> {
     /// * There must not be any other `JObject` representing the same local reference.
     /// * The lifetime `'local` must not outlive the local reference frame that the local reference
     ///   was created in.
-    pub unsafe fn from_raw(raw: jobjectArray) -> Self {
+    pub const unsafe fn from_raw(raw: jobjectArray) -> Self {
         Self(JObject::from_raw(raw as jobject))
     }
 
     /// Unwrap to the raw jni type.
-    pub fn into_raw(self) -> jobjectArray {
+    pub const fn into_raw(self) -> jobjectArray {
         self.0.into_raw() as jobjectArray
     }
 }

--- a/src/wrapper/objects/jprimitive_array.rs
+++ b/src/wrapper/objects/jprimitive_array.rs
@@ -90,7 +90,7 @@ impl<'local, T: TypeArray> JPrimitiveArray<'local, T> {
     /// * There must not be any other `JObject` representing the same local reference.
     /// * The lifetime `'local` must not outlive the local reference frame that the local reference
     ///   was created in.
-    pub unsafe fn from_raw(raw: jarray) -> Self {
+    pub const unsafe fn from_raw(raw: jarray) -> Self {
         Self {
             obj: JObject::from_raw(raw as jobject),
             lifetime: PhantomData,
@@ -98,7 +98,7 @@ impl<'local, T: TypeArray> JPrimitiveArray<'local, T> {
     }
 
     /// Unwrap to the raw jni type.
-    pub fn into_raw(self) -> jarray {
+    pub const fn into_raw(self) -> jarray {
         self.obj.into_raw() as jarray
     }
 }

--- a/src/wrapper/objects/jstaticfieldid.rs
+++ b/src/wrapper/objects/jstaticfieldid.rs
@@ -36,13 +36,12 @@ impl JStaticFieldID {
     /// # Safety
     ///
     /// Expects a valid, non-`null` ID
-    pub unsafe fn from_raw(raw: jfieldID) -> Self {
-        debug_assert!(!raw.is_null(), "from_raw fieldID argument");
+    pub const unsafe fn from_raw(raw: jfieldID) -> Self {
         Self { internal: raw }
     }
 
     /// Unwrap to the internal jni type.
-    pub fn into_raw(self) -> jfieldID {
+    pub const fn into_raw(self) -> jfieldID {
         self.internal
     }
 }

--- a/src/wrapper/objects/jstaticmethodid.rs
+++ b/src/wrapper/objects/jstaticmethodid.rs
@@ -36,13 +36,12 @@ impl JStaticMethodID {
     /// # Safety
     ///
     /// Expects a valid, non-`null` ID
-    pub unsafe fn from_raw(raw: jmethodID) -> Self {
-        debug_assert!(!raw.is_null(), "from_raw methodID argument");
+    pub const unsafe fn from_raw(raw: jmethodID) -> Self {
         Self { internal: raw }
     }
 
     /// Unwrap to the internal jni type.
-    pub fn into_raw(self) -> jmethodID {
+    pub const fn into_raw(self) -> jmethodID {
         self.internal
     }
 }

--- a/src/wrapper/objects/jstring.rs
+++ b/src/wrapper/objects/jstring.rs
@@ -64,12 +64,12 @@ impl<'local> JString<'local> {
     /// * There must not be any other `JObject` representing the same local reference.
     /// * The lifetime `'local` must not outlive the local reference frame that the local reference
     ///   was created in.
-    pub unsafe fn from_raw(raw: jstring) -> Self {
+    pub const unsafe fn from_raw(raw: jstring) -> Self {
         Self(JObject::from_raw(raw as jobject))
     }
 
     /// Unwrap to the raw jni type.
-    pub fn into_raw(self) -> jstring {
+    pub const fn into_raw(self) -> jstring {
         self.0.into_raw() as jstring
     }
 }

--- a/src/wrapper/objects/jthrowable.rs
+++ b/src/wrapper/objects/jthrowable.rs
@@ -64,12 +64,12 @@ impl<'local> JThrowable<'local> {
     /// * There must not be any other `JObject` representing the same local reference.
     /// * The lifetime `'local` must not outlive the local reference frame that the local reference
     ///   was created in.
-    pub unsafe fn from_raw(raw: jthrowable) -> Self {
+    pub const unsafe fn from_raw(raw: jthrowable) -> Self {
         Self(JObject::from_raw(raw as jobject))
     }
 
     /// Unwrap to the raw jni type.
-    pub fn into_raw(self) -> jthrowable {
+    pub const fn into_raw(self) -> jthrowable {
         self.0.into_raw() as jthrowable
     }
 }

--- a/src/wrapper/strings/java_str.rs
+++ b/src/wrapper/strings/java_str.rs
@@ -92,7 +92,7 @@ impl<'local, 'other_local: 'obj_ref, 'obj_ref> JavaStr<'local, 'other_local, 'ob
     /// The string will be `NULL` terminated and encoded as
     /// [Modified UTF-8](https://en.wikipedia.org/wiki/UTF-8#Modified_UTF-8) /
     /// [CESU-8](https://en.wikipedia.org/wiki/CESU-8).
-    pub fn get_raw(&self) -> *const c_char {
+    pub const fn get_raw(&self) -> *const c_char {
         self.internal
     }
 


### PR DESCRIPTION
Make most `from_raw()`, `get_raw()` and `into_raw()` methods `const fn`.

This change is a gain in usability in `const` contexts, but it introduces a risk, because it promises that the implementation of the methods that are now `const` will continue being [pure](https://en.wikipedia.org/wiki/Pure_function), unless a breaking change occurs.

- [x] There are no TODOs left in the code
- [ ] Change is covered by [automated tests](https://github.com/jni-rs/jni-rs/blob/master/CONTRIBUTING.md#tests)
- [x] The [coding guidelines](https://github.com/jni-rs/jni-rs/blob/master/CONTRIBUTING.md#the-code-style) are followed
- [x] Public API has documentation
- [x] User-visible changes are mentioned in the Changelog
- [x] The continuous integration build passes

Closes #451
