### PR TITLE
Make `get_object_class` take a mutable reference

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Changed
 - `JValueGen` has been removed. `JValue` and `JValueOwned` are now separate, unrelated, non-generic types. ([#429](https://github.com/jni-rs/jni-rs/pull/429))
 - Make most `from_raw()`, `get_raw()` and `into_raw()` methods `const fn`. ([#453](https://github.com/jni-rs/jni-rs/pull/453))
+- `get_object_class` borrows the `JNIEnv` mutably because it creates a new local reference. ([#456](https://github.com/jni-rs/jni-rs/pull/456))
 
 ## [0.21.1] — 2023-03-08
 

--- a/src/wrapper/jnienv.rs
+++ b/src/wrapper/jnienv.rs
@@ -1273,7 +1273,7 @@ impl<'local> JNIEnv<'local> {
     }
 
     /// Get the class for an object.
-    pub fn get_object_class<'other_local, O>(&self, obj: O) -> Result<JClass<'local>>
+    pub fn get_object_class<'other_local, O>(&mut self, obj: O) -> Result<JClass<'local>>
     where
         O: AsRef<JObject<'other_local>>,
     {
@@ -1553,7 +1553,8 @@ impl<'local> JNIEnv<'local> {
             return Err(Error::InvalidArgList(parsed));
         }
 
-        let class = self.auto_local(self.get_object_class(obj)?);
+        let class = self.get_object_class(obj)?;
+        let class = self.auto_local(class);
 
         let args: Vec<jvalue> = args.iter().map(|v| v.as_jni()).collect();
 
@@ -1861,7 +1862,8 @@ impl<'local> JNIEnv<'local> {
         obj: &'obj_ref JString<'other_local>,
     ) -> Result<JavaStr<'local, 'other_local, 'obj_ref>> {
         let string_class = self.find_class("java/lang/String")?;
-        if !self.is_assignable_from(string_class, self.get_object_class(obj)?)? {
+        let obj_class = self.get_object_class(obj)?;
+        if !self.is_assignable_from(string_class, obj_class)? {
             return Err(JniCall(JniError::InvalidArguments));
         }
 
@@ -2597,7 +2599,8 @@ impl<'local> JNIEnv<'local> {
         T: Into<JNIString> + AsRef<str>,
     {
         let obj = obj.as_ref();
-        let class = self.auto_local(self.get_object_class(obj)?);
+        let class = self.get_object_class(obj)?;
+        let class = self.auto_local(class);
 
         let parsed = ReturnType::from_str(ty.as_ref())?;
 
@@ -2635,7 +2638,8 @@ impl<'local> JNIEnv<'local> {
                 "cannot set field with method type",
             )),
             _ => {
-                let class = self.auto_local(self.get_object_class(obj)?);
+                let class = self.get_object_class(obj)?;
+                let class = self.auto_local(class);
 
                 self.set_field_unchecked(obj, (&class, name, ty), val)
             }
@@ -2824,7 +2828,8 @@ impl<'local> JNIEnv<'local> {
         T: Send + 'static,
     {
         let obj = obj.as_ref();
-        let class = self.auto_local(self.get_object_class(obj)?);
+        let class = self.get_object_class(obj)?;
+        let class = self.auto_local(class);
         let field_id: JFieldID = Desc::<JFieldID>::lookup((&class, &field, "J"), self)?;
 
         let guard = self.lock_obj(obj)?;
@@ -2895,7 +2900,8 @@ impl<'local> JNIEnv<'local> {
         T: Send + 'static,
     {
         let obj = obj.as_ref();
-        let class = self.auto_local(self.get_object_class(obj)?);
+        let class = self.get_object_class(obj)?;
+        let class = self.auto_local(class);
         let field_id: JFieldID = Desc::<JFieldID>::lookup((&class, &field, "J"), self)?;
 
         let mbox = {

--- a/tests/jni_api.rs
+++ b/tests/jni_api.rs
@@ -767,7 +767,7 @@ pub fn get_array_elements_critical() {
 
 #[test]
 pub fn get_object_class() {
-    let env = attach_current_thread();
+    let mut env = attach_current_thread();
     let string = env.new_string("test").unwrap();
     let result = env.get_object_class(string);
     assert!(result.is_ok());
@@ -776,7 +776,7 @@ pub fn get_object_class() {
 
 #[test]
 pub fn get_object_class_null_arg() {
-    let env = attach_current_thread();
+    let mut env = attach_current_thread();
     let null_obj = JObject::null();
     let result = env
         .get_object_class(null_obj)


### PR DESCRIPTION
## Overview

Since this API creates a new local reference it needs to take a mutable reference to the JNIEnv to be sure it's safe to create a new local reference with the `'local` lifetime associated with that `JNIEnv`.

Without a mutable reference then it's possible that the `JNIEnv` isn't associated with the top JNI stack frame.

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Change is covered by [automated tests](https://github.com/jni-rs/jni-rs/blob/master/CONTRIBUTING.md#tests)
- [x] The [coding guidelines](https://github.com/jni-rs/jni-rs/blob/master/CONTRIBUTING.md#the-code-style) are followed
- [x] Public API has documentation
- [x] User-visible changes are mentioned in the Changelog
- [x] The continuous integration build passes
