### PR TITLE
Don't require mutable borrow for get/set/take_rust_field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Make most `from_raw()`, `get_raw()` and `into_raw()` methods `const fn`. ([#453](https://github.com/jni-rs/jni-rs/pull/453))
 - `get_object_class` borrows the `JNIEnv` mutably because it creates a new local reference. ([#456](https://github.com/jni-rs/jni-rs/pull/456))
 - `get/set_field_unchecked` have been marked as unsafe since they can lead to undefined behaviour if the given types don't match the field type ([#457](https://github.com/jni-rs/jni-rs/pull/457))
+- `get/set/take_rust_field` no longer require a mutable `JNIEnv` reference since they don't return any new local references to the caller ([#455](https://github.com/jni-rs/jni-rs/issues/455))
 
 ## [0.21.1] — 2023-03-08
 


### PR DESCRIPTION
These APIs don't need to return any new local references to the caller and so they don't need a mutable JNIEnv reference.

Since they may need to create temporary local references to look up the class for the given object then we need to take some extra care to make sure any transient reference is deleted before returning.

This adds clearer documentation of the safety concerns with these APIs

This makes the implementations of `get_rust_field`, `set_rust_field` and `take_rust_field` more consistent, including sharing a common utility for taking the monitor lock and getting the field ID.

Fixes #455

### Definition of Done

- [x] There are no TODOs left in the code
- [ ] Change is covered by [automated tests](https://github.com/jni-rs/jni-rs/blob/master/CONTRIBUTING.md#tests)
- [x] The [coding guidelines](https://github.com/jni-rs/jni-rs/blob/master/CONTRIBUTING.md#the-code-style) are followed
- [x] Public API has documentation
- [x] User-visible changes are mentioned in the Changelog
- [x] The continuous integration build passes
