### PR TITLE
Use the  "system-unwind" ABI in examples

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -113,7 +113,7 @@
 //! // This keeps Rust from "mangling" the name and making it unique for this
 //! // crate.
 //! #[no_mangle]
-//! pub extern "system" fn Java_HelloWorld_hello<'local>(mut env: JNIEnv<'local>,
+//! pub extern "system-unwind" fn Java_HelloWorld_hello<'local>(mut env: JNIEnv<'local>,
 //! // This is the class that owns our static method. It's not going to be used,
 //! // but still must be present to match the expected signature of a static
 //! // native method.


### PR DESCRIPTION
Given that the ABI "system-unwind" is [now in stable Rust](https://github.com/rust-lang/rust/issues/74990#issuecomment-1363473645), it should be the new recommended way to define JNI functions in Rust, in order to avoid undefined behavior when an unwind happens, due to a C++ exception, or a Rust panic, etc.

### Definition of Done

- [x] There are no TODOs left in the code
- [ ] Change is covered by [automated tests](https://github.com/jni-rs/jni-rs/blob/master/CONTRIBUTING.md#tests)
- [x] The [coding guidelines](https://github.com/jni-rs/jni-rs/blob/master/CONTRIBUTING.md#the-code-style) are followed
- [x] Public API has documentation
- [ ] User-visible changes are mentioned in the Changelog
- [ ] The continuous integration build passes
