### PR TITLE
Ports jni to the proposed jni-sys 0.4 API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+<!-- markdownlint-disable MD022 MD024 MD032  -->
+
 # Changelog
 
 All notable changes to this project will be documented in this file.
@@ -14,6 +16,20 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   - Security in case of vulnerabilities. -->
 
 ## [Unreleased]
+### Changed
+- `jni-sys` dependency dumped to `0.4` ([#478](https://github.com/jni-rs/jni-rs/issues/478)
+- `JNIEnv::get_version` has been renamed to `JNIEnv::version` ([#478](https://github.com/jni-rs/jni-rs/issues/478)
+- `JNIEnv::from_raw` now explicitly checks that the JNI version is `>= 1.4` since the crate needs to be able to assume `>= 1.2` so it can check for exceptions and assume `>= 1.4` to avoid runtime checks for direct byte buffers ([#478](https://github.com/jni-rs/jni-rs/issues/478)
+- The following functions are now infallible ([#478](https://github.com/jni-rs/jni-rs/issues/478):
+  - `JNIEnv::version`
+  - `JNIEnv::exception_check`
+  - `JNIEnv::exception_clear`
+  - `JNIEnv::exception_describe`
+  - `JNIEnv::is_same_object`
+  - `JNIEnv::delete_local_ref`
+  - `WeakRef::is_same_object`
+  - `WeakRef::is_weak_ref_to_same_object`
+  - `WeakRef::is_garbage_collected`
 
 ### Added
 - New functions for converting Rust `char` to and from Java `char` and `int` ([#427](https://github.com/jni-rs/jni-rs/issues/427) / [#434](https://github.com/jni-rs/jni-rs/pull/434))

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,9 +29,10 @@ cfg-if = "1.0.0"
 cesu8 = "1.1.0"
 combine = "4.1.0"
 java-locator = { version = "0.1", optional = true }
-jni-sys = "0.3.0"
+jni-sys = "0.4"
 libloading = { version = "0.8", optional = true }
 log = "0.4.4"
+static_assertions = "1"
 thiserror = "1.0.20"
 
 [build-dependencies]

--- a/benches/api_calls.rs
+++ b/benches/api_calls.rs
@@ -134,7 +134,7 @@ mod tests {
     lazy_static! {
         static ref VM: JavaVM = {
             let args = InitArgsBuilder::new()
-                .version(JNIVersion::V8)
+                .version(JNIVersion::V1_8)
                 .build()
                 .unwrap();
             JavaVM::new(args).unwrap()
@@ -182,7 +182,7 @@ mod tests {
         let mut env = VM.attach_current_thread().unwrap();
         b.iter(|| {
             let obj = jni_local_date_time_of_safe(&mut env, 1, 1, 1, 1, 1, 1, 1);
-            env.delete_local_ref(obj).unwrap();
+            env.delete_local_ref(obj);
         });
     }
 
@@ -209,7 +209,7 @@ mod tests {
                     JValue::Int(1).as_jni(),
                 ],
             );
-            env.delete_local_ref(obj).unwrap();
+            env.delete_local_ref(obj);
         });
     }
 
@@ -242,7 +242,7 @@ mod tests {
 
         b.iter(|| {
             let obj = env.new_object(class, SIG_OBJECT_CTOR, &[]).unwrap();
-            env.delete_local_ref(obj).unwrap();
+            env.delete_local_ref(obj);
         });
     }
 
@@ -256,7 +256,7 @@ mod tests {
 
         b.iter(|| {
             let obj = unsafe { env.new_object_unchecked(class, ctor_id, &[]) }.unwrap();
-            env.delete_local_ref(obj).unwrap();
+            env.delete_local_ref(obj);
         });
     }
 
@@ -267,7 +267,7 @@ mod tests {
 
         b.iter(|| {
             let obj = env.new_object(&class, SIG_OBJECT_CTOR, &[]).unwrap();
-            env.delete_local_ref(obj).unwrap();
+            env.delete_local_ref(obj);
         });
     }
 
@@ -281,7 +281,7 @@ mod tests {
 
         b.iter(|| {
             let obj = unsafe { env.new_object_unchecked(&class, ctor_id, &[]) }.unwrap();
-            env.delete_local_ref(obj).unwrap();
+            env.delete_local_ref(obj);
         });
     }
 
@@ -291,7 +291,7 @@ mod tests {
         let class = CLASS_OBJECT;
         let obj = env.new_object(class, SIG_OBJECT_CTOR, &[]).unwrap();
         let global_ref = env.new_global_ref(&obj).unwrap();
-        env.delete_local_ref(obj).unwrap();
+        env.delete_local_ref(obj);
 
         b.iter(|| env.new_global_ref(&global_ref).unwrap());
     }
@@ -306,7 +306,7 @@ mod tests {
     fn jni_check_exception(b: &mut Bencher) {
         let env = VM.attach_current_thread().unwrap();
 
-        b.iter(|| env.exception_check().unwrap());
+        b.iter(|| env.exception_check());
     }
 
     #[bench]
@@ -415,7 +415,7 @@ mod tests {
         let class = CLASS_OBJECT;
         let obj = env.new_object(class, SIG_OBJECT_CTOR, &[]).unwrap();
         let global_ref = env.new_global_ref(&obj).unwrap();
-        env.delete_local_ref(obj).unwrap();
+        env.delete_local_ref(obj);
         let arc = Arc::new(global_ref);
 
         b.iter(|| {

--- a/src/wrapper/errors.rs
+++ b/src/wrapper/errors.rs
@@ -66,6 +66,9 @@ pub enum Error {
         #[source]
         source: CharTryFromError,
     },
+
+    #[error("This Java virtual machine is too old; at least Java 1.4 is required")]
+    UnsupportedVersion,
 }
 
 #[derive(Debug, Error)]

--- a/src/wrapper/executor.rs
+++ b/src/wrapper/executor.rs
@@ -73,7 +73,7 @@ impl Executor {
     {
         assert!(capacity > 0, "capacity should be a positive integer");
 
-        let mut jni_env = self.vm.attach_current_thread_as_daemon()?;
+        let mut jni_env = self.vm.attach_current_thread_permanently()?;
         jni_env.with_local_frame(capacity, |jni_env| f(jni_env))
     }
 

--- a/src/wrapper/java_vm/init_args.rs
+++ b/src/wrapper/java_vm/init_args.rs
@@ -124,7 +124,7 @@ impl<'a> Default for InitArgsBuilder<'a> {
         InitArgsBuilder {
             opts: Ok(vec![]),
             ignore_unrecognized: false,
-            version: JNIVersion::V8,
+            version: JNIVersion::V1_8,
         }
     }
 }

--- a/src/wrapper/java_vm/init_args/char_encoding_windows.rs
+++ b/src/wrapper/java_vm/init_args/char_encoding_windows.rs
@@ -29,8 +29,8 @@ type WCodepage = c_uint;
 const MAX_INPUT_LEN: usize = 1048576;
 
 /// Converts `s` into a `Cow<CStr>` encoded in the specified Windows code page.
-pub(super) fn str_to_cstr_win32<'a>(
-    s: Cow<'a, str>,
+pub(super) fn str_to_cstr_win32(
+    s: Cow<str>,
     needed_codepage: WCodepage,
 ) -> Result<Cow<'static, CStr>, JvmError> {
     // First, check if the input string (UTF-8) is too long to transcode. Bail early if so.
@@ -179,13 +179,11 @@ pub(super) fn str_to_cstr_win32<'a>(
 
     // That's it, it's converted. Now turn it into a `CString`. This will add a null terminator if
     // there isn't one already and check for null bytes in the middle.
-    unsafe { bytes_to_cstr(Cow::Owned(output), Some(s.into())) }
+    unsafe { bytes_to_cstr(Cow::Owned(output), Some(s)) }
 }
 
 /// Converts `s` into the Windows default character encoding.
-pub(super) fn str_to_cstr_win32_default_codepage<'a>(
-    s: Cow<'a, str>,
-) -> Result<Cow<'a, CStr>, JvmError> {
+pub(super) fn str_to_cstr_win32_default_codepage(s: Cow<str>) -> Result<Cow<CStr>, JvmError> {
     // Get the code page. There is a remote possibility that it is UTF-8. If so, pass the
     // string through unchanged (other than adding a null terminator). If not, we need to have
     // Windows convert the string to the expected code page first.

--- a/src/wrapper/objects/auto_local.rs
+++ b/src/wrapper/objects/auto_local.rs
@@ -4,8 +4,6 @@ use std::{
     ptr,
 };
 
-use log::debug;
-
 use crate::{objects::JObject, JNIEnv};
 
 /// Auto-delete wrapper for local refs.
@@ -108,12 +106,7 @@ where
         // Safety: `self.obj` is not used again after this `take` call.
         let obj = unsafe { ManuallyDrop::take(&mut self.obj) };
 
-        // Delete the extracted local reference.
-        let res = self.env.delete_local_ref(obj);
-        match res {
-            Ok(()) => {}
-            Err(e) => debug!("error dropping global ref: {:#?}", e),
-        }
+        self.env.delete_local_ref(obj);
     }
 }
 

--- a/src/wrapper/objects/global_ref.rs
+++ b/src/wrapper/objects/global_ref.rs
@@ -93,9 +93,10 @@ impl Drop for GlobalRefGuard {
         let raw: sys::jobject = mem::take(&mut self.obj).into_raw();
 
         let drop_impl = |env: &JNIEnv| -> Result<()> {
-            let internal = env.get_native_interface();
-            // This method is safe to call in case of pending exceptions (see chapter 2 of the spec)
-            jni_unchecked!(internal, DeleteGlobalRef, raw);
+            // Safety: This method is safe to call in case of pending exceptions (see chapter 2 of the spec)
+            unsafe {
+                jni_call_unchecked!(env, v1_1, DeleteGlobalRef, raw);
+            }
             Ok(())
         };
 

--- a/src/wrapper/objects/jvalue.rs
+++ b/src/wrapper/objects/jvalue.rs
@@ -381,19 +381,6 @@ impl<'local> TryFrom<JValueOwned<'local>> for JObject<'local> {
     }
 }
 
-impl<'local> From<bool> for JValueOwned<'local> {
-    fn from(other: bool) -> Self {
-        Self::Bool(if other { JNI_TRUE } else { JNI_FALSE })
-    }
-}
-
-impl<'obj_ref> From<bool> for JValue<'obj_ref> {
-    fn from(other: bool) -> Self {
-        Self::Bool(if other { JNI_TRUE } else { JNI_FALSE })
-    }
-}
-
-// jbool
 impl<'local> From<jboolean> for JValueOwned<'local> {
     fn from(other: jboolean) -> Self {
         Self::Bool(other)

--- a/src/wrapper/objects/weak_ref.rs
+++ b/src/wrapper/objects/weak_ref.rs
@@ -5,7 +5,7 @@ use log::{debug, warn};
 use crate::{
     errors::Result,
     objects::{GlobalRef, JObject},
-    sys, JNIEnv, JavaVM,
+    sys, JNIEnv, JNIVersion, JavaVM,
 };
 
 // Note: `WeakRef` must not implement `Into<JObject>`! If it did, then it would be possible to
@@ -169,7 +169,9 @@ impl Drop for WeakRefGuard {
             Ok(())
         }
 
-        let res = match self.vm.get_env() {
+        // Safety: we can assume we couldn't have created the weak reference in the first place without
+        // having already required the JavaVM to support JNI >= 1.4
+        let res = match unsafe { self.vm.get_env(JNIVersion::V1_4) } {
             Ok(env) => drop_impl(&env, self.raw),
             Err(_) => {
                 warn!("Dropping a WeakRef in a detached thread. Fix your code if this message appears frequently (see the WeakRef docs).");

--- a/src/wrapper/objects/weak_ref.rs
+++ b/src/wrapper/objects/weak_ref.rs
@@ -68,9 +68,17 @@ impl WeakRef {
     /// If this method returns `Ok(Some(r))`, it is guaranteed that the object will not be garbage
     /// collected at least until `r` is deleted or becomes invalid.
     pub fn upgrade_local<'local>(&self, env: &JNIEnv<'local>) -> Result<Option<JObject<'local>>> {
-        let r = env.new_local_ref(unsafe { JObject::from_raw(self.as_raw()) })?;
+        // XXX: Don't use env.new_local_ref here because that will treat `null`
+        // return values (for non-null objects) as out-of-memory errors
+        let r = unsafe {
+            JObject::from_raw(jni_call_unchecked!(env, v1_2, NewLocalRef, self.as_raw()))
+        };
 
         // Per JNI spec, `NewLocalRef` will return a null pointer if the object was GC'd.
+        //
+        // XXX: technically the `null` could also mean that the system is out of memory
+        // but we have no way of differentiating that here.
+        //
         if r.is_null() {
             Ok(None)
         } else {
@@ -91,7 +99,7 @@ impl WeakRef {
 
         // Unlike `NewLocalRef`, the JNI spec does *not* guarantee that `NewGlobalRef` will return a
         // null pointer if the object was GC'd, so we'll have to check.
-        if env.is_same_object(&r, JObject::null())? {
+        if env.is_same_object(&r, JObject::null()) {
             Ok(None)
         } else {
             Ok(Some(r))
@@ -106,7 +114,7 @@ impl WeakRef {
     ///
     /// This is equivalent to
     /// <code>self.[is_same_object][WeakRef::is_same_object](env, [JObject::null]\())</code>.
-    pub fn is_garbage_collected(&self, env: &JNIEnv) -> Result<bool> {
+    pub fn is_garbage_collected(&self, env: &JNIEnv) -> bool {
         self.is_same_object(env, JObject::null())
     }
 
@@ -121,7 +129,7 @@ impl WeakRef {
     /// [`WeakRef::is_garbage_collected`]: it returns true if the object referred to by this
     /// `WeakRef` has been garbage collected, or false if the object has not yet been garbage
     /// collected.
-    pub fn is_same_object<'local, O>(&self, env: &JNIEnv<'local>, object: O) -> Result<bool>
+    pub fn is_same_object<'local, O>(&self, env: &JNIEnv<'local>, object: O) -> bool
     where
         O: AsRef<JObject<'local>>,
     {
@@ -133,7 +141,7 @@ impl WeakRef {
     ///
     /// This method will also return true if both weak references refer to an object that has been
     /// garbage collected.
-    pub fn is_weak_ref_to_same_object(&self, env: &JNIEnv, other: &WeakRef) -> Result<bool> {
+    pub fn is_weak_ref_to_same_object(&self, env: &JNIEnv, other: &WeakRef) -> bool {
         self.is_same_object(env, unsafe { JObject::from_raw(other.as_raw()) })
     }
 
@@ -153,9 +161,11 @@ impl WeakRef {
 impl Drop for WeakRefGuard {
     fn drop(&mut self) {
         fn drop_impl(env: &JNIEnv, raw: sys::jweak) -> Result<()> {
-            let internal = env.get_native_interface();
-            // This method is safe to call in case of pending exceptions (see chapter 2 of the spec)
-            jni_unchecked!(internal, DeleteWeakGlobalRef, raw);
+            // Safety: This method is safe to call in case of pending exceptions (see chapter 2 of the spec)
+            // jni-rs requires JNI_VERSION > 1.2
+            unsafe {
+                jni_call_unchecked!(env, v1_2, DeleteWeakGlobalRef, raw);
+            }
             Ok(())
         }
 

--- a/src/wrapper/strings/java_str.rs
+++ b/src/wrapper/strings/java_str.rs
@@ -43,14 +43,15 @@ impl<'local, 'other_local: 'obj_ref, 'obj_ref> JavaStr<'local, 'other_local, 'ob
         env: &JNIEnv<'_>,
         obj: &JString<'_>,
     ) -> Result<(*const c_char, bool)> {
-        non_null!(obj, "get_string_utf_chars obj argument");
-        let mut is_copy: jboolean = 0;
-        let ptr: *const c_char = jni_non_null_call!(
-            env.get_raw(),
+        let obj = null_check!(obj, "get_string_utf_chars obj argument")?;
+        let mut is_copy: jboolean = false;
+        let ptr: *const c_char = jni_call_only_check_null_ret!(
+            env,
+            v1_1,
             GetStringUTFChars,
             obj.as_raw(),
             &mut is_copy as *mut _
-        );
+        )?;
 
         let is_copy = is_copy == JNI_TRUE;
         Ok((ptr, is_copy))
@@ -65,12 +66,13 @@ impl<'local, 'other_local: 'obj_ref, 'obj_ref> JavaStr<'local, 'other_local, 'ob
     ///
     /// The caller must guarantee that [Self::internal] was constructed from a valid pointer obtained from [Self::get_string_utf_chars]
     unsafe fn release_string_utf_chars(&mut self) -> Result<()> {
-        non_null!(self.obj, "release_string_utf_chars obj argument");
+        let obj = null_check!(self.obj, "release_string_utf_chars obj argument")?;
         // This method is safe to call in case of pending exceptions (see the chapter 2 of the spec)
-        jni_unchecked!(
-            self.env.get_raw(),
+        jni_call_unchecked!(
+            self.env,
+            v1_1,
             ReleaseStringUTFChars,
-            self.obj.as_raw(),
+            obj.as_raw(),
             self.internal
         );
 

--- a/src/wrapper/version.rs
+++ b/src/wrapper/version.rs
@@ -1,43 +1,101 @@
-use crate::sys::{
-    JNI_VERSION_1_1, JNI_VERSION_1_2, JNI_VERSION_1_4, JNI_VERSION_1_6, JNI_VERSION_1_8,
-};
-
 /// JNI Version
-///
-/// This maps to the `jni_sys::JNI_VERSION_1_*` constants.
-#[derive(Debug, Copy, Clone)]
-#[allow(missing_docs)]
-pub enum JNIVersion {
-    V1,
-    V2,
-    V4,
-    V6,
-    V8,
-    Invalid(i32),
+#[derive(Debug, Copy, Clone, PartialEq, PartialOrd, Ord, Eq, Hash)]
+#[repr(transparent)]
+pub struct JNIVersion {
+    ver: u32,
 }
 
-impl From<i32> for JNIVersion {
-    fn from(other: i32) -> Self {
-        match other {
-            JNI_VERSION_1_1 => JNIVersion::V1,
-            JNI_VERSION_1_2 => JNIVersion::V2,
-            JNI_VERSION_1_4 => JNIVersion::V4,
-            JNI_VERSION_1_6 => JNIVersion::V6,
-            JNI_VERSION_1_8 => JNIVersion::V8,
-            v => JNIVersion::Invalid(v),
-        }
+impl JNIVersion {
+    /// JNI Version 1.1
+    pub const V1_1: Self = JNIVersion {
+        ver: jni_sys::JNI_VERSION_1_1 as u32,
+    };
+    /// JNI Version 1.2
+    pub const V1_2: Self = JNIVersion {
+        ver: jni_sys::JNI_VERSION_1_2 as u32,
+    };
+    /// JNI Version 1.4
+    pub const V1_4: Self = JNIVersion {
+        ver: jni_sys::JNI_VERSION_1_4 as u32,
+    };
+    /// JNI Version 1.6
+    pub const V1_6: Self = JNIVersion {
+        ver: jni_sys::JNI_VERSION_1_6 as u32,
+    };
+    /// JNI Version 1.8
+    pub const V1_8: Self = JNIVersion {
+        ver: jni_sys::JNI_VERSION_1_8 as u32,
+    };
+    /// JNI Version 9.0
+    pub const V9: Self = JNIVersion {
+        ver: jni_sys::JNI_VERSION_9 as u32,
+    };
+    /// JNI Version 10.0
+    pub const V10: Self = JNIVersion {
+        ver: jni_sys::JNI_VERSION_10 as u32,
+    };
+    /// JNI Version 19.0
+    pub const V19: Self = JNIVersion {
+        ver: jni_sys::JNI_VERSION_19 as u32,
+    };
+    /// JNI Version 20.0
+    pub const V20: Self = JNIVersion {
+        ver: jni_sys::JNI_VERSION_20 as u32,
+    };
+    /// JNI Version 21.0
+    pub const V21: Self = JNIVersion {
+        ver: jni_sys::JNI_VERSION_21 as u32,
+    };
+
+    /// Return a version from a raw version constant like [`jni_sys::JNI_VERSION_1_2`]
+    pub fn new(ver: jni_sys::jint) -> Self {
+        Self::from(ver)
+    }
+
+    /// Get the major component of the version number
+    pub fn major(&self) -> u16 {
+        ((self.ver & 0x00ff0000) >> 16) as u16
+    }
+
+    /// Get the minor component of the version number
+    pub fn minor(&self) -> u16 {
+        (self.ver & 0xff) as u16
     }
 }
 
-impl From<JNIVersion> for i32 {
-    fn from(other: JNIVersion) -> Self {
-        match other {
-            JNIVersion::V1 => JNI_VERSION_1_1,
-            JNIVersion::V2 => JNI_VERSION_1_2,
-            JNIVersion::V4 => JNI_VERSION_1_4,
-            JNIVersion::V6 => JNI_VERSION_1_6,
-            JNIVersion::V8 => JNI_VERSION_1_8,
-            JNIVersion::Invalid(v) => v,
-        }
+impl From<jni_sys::jint> for JNIVersion {
+    fn from(value: jni_sys::jint) -> Self {
+        Self { ver: value as u32 }
     }
+}
+
+impl From<JNIVersion> for jni_sys::jint {
+    fn from(val: JNIVersion) -> Self {
+        val.ver as i32
+    }
+}
+
+#[test]
+fn jni_version_major_minor() {
+    macro_rules! check_major_minor {
+        ($major:expr, $minor:expr, $jni_ver:tt, $jni_sys_ver:tt) => {
+            let v = JNIVersion::$jni_ver;
+            assert_eq!(v.major(), $major);
+            assert_eq!(v.minor(), $minor);
+            let v = JNIVersion::new(jni_sys::$jni_sys_ver);
+            assert_eq!(v.major(), $major);
+            assert_eq!(v.minor(), $minor);
+        };
+    }
+
+    check_major_minor!(1, 1, V1_1, JNI_VERSION_1_1);
+    check_major_minor!(1, 2, V1_2, JNI_VERSION_1_2);
+    check_major_minor!(1, 4, V1_4, JNI_VERSION_1_4);
+    check_major_minor!(1, 6, V1_6, JNI_VERSION_1_6);
+    check_major_minor!(1, 8, V1_8, JNI_VERSION_1_8);
+    check_major_minor!(9, 0, V9, JNI_VERSION_9);
+    check_major_minor!(10, 0, V10, JNI_VERSION_10);
+    check_major_minor!(19, 0, V19, JNI_VERSION_19);
+    check_major_minor!(20, 0, V20, JNI_VERSION_20);
+    check_major_minor!(21, 0, V21, JNI_VERSION_21);
 }

--- a/tests/executor.rs
+++ b/tests/executor.rs
@@ -132,7 +132,7 @@ fn test_destroy() {
             // JavaVM before it gets destroyed, including dropping the AutoLocal
             // for the `MATH_CLASS`
             {
-                let mut env = jvm.attach_current_thread_as_daemon().unwrap();
+                let mut env = unsafe { jvm.attach_current_thread_as_daemon().unwrap() };
                 println!("daemon thread attach");
                 attach_barrier.wait();
                 println!("daemon thread run");

--- a/tests/executor_nested_attach.rs
+++ b/tests/executor_nested_attach.rs
@@ -4,7 +4,7 @@ use std::{sync::Arc, thread::spawn};
 
 use jni::{
     errors::{Error, JniError},
-    Executor, JavaVM,
+    Executor, JNIVersion, JavaVM,
 };
 
 mod util;
@@ -52,7 +52,8 @@ fn check_detached(vm: &JavaVM) {
 }
 
 fn is_attached(vm: &JavaVM) -> bool {
-    vm.get_env()
+    // Safety: assumes tests are only run against a JavaVM that implements JNI >= 1.4
+    unsafe { vm.get_env(JNIVersion::V1_4) }
         .map(|_| true)
         .or_else(|jni_err| match jni_err {
             Error::JniCall(JniError::ThreadDetached) => Ok(false),

--- a/tests/invocation_character_encoding.rs
+++ b/tests/invocation_character_encoding.rs
@@ -7,7 +7,7 @@ use jni::{objects::JString, InitArgsBuilder, JavaVM};
 #[test]
 fn invocation_character_encoding() {
     let jvm_args = InitArgsBuilder::new()
-        .version(jni::JNIVersion::V8)
+        .version(jni::JNIVersion::V1_8)
         .option("-Xcheck:jni")
         // U+00A0 NO-BREAK SPACE is the only non-ASCII character that's present in all parts of
         // ISO 8859. This minimizes the chance of this test failing as a result of the character

--- a/tests/jni_weak_refs.rs
+++ b/tests/jni_weak_refs.rs
@@ -129,10 +129,7 @@ fn weak_ref_is_actually_weak() {
                 );
 
                 assert!(!obj_local_from_weak.is_null());
-                assert!(unwrap(
-                    env.is_same_object(&obj_local_from_weak, &obj_local),
-                    &env,
-                ));
+                assert!(env.is_same_object(&obj_local_from_weak, &obj_local));
             }
 
             {
@@ -140,24 +137,18 @@ fn weak_ref_is_actually_weak() {
                     .expect("object shouldn't have been GC'd yet");
 
                 assert!(!obj_global_from_weak.is_null());
-                assert!(unwrap(
-                    env.is_same_object(&obj_global_from_weak, &obj_local),
-                    &env,
-                ));
+                assert!(env.is_same_object(&obj_global_from_weak, &obj_local));
             }
 
-            assert!(unwrap(obj_weak.is_same_object(&env, &obj_local), &env));
+            assert!(obj_weak.is_same_object(&env, &obj_local));
 
             assert!(
-                !unwrap(obj_weak.is_garbage_collected(&env), &env),
+                !obj_weak.is_garbage_collected(&env),
                 "`is_garbage_collected` returned incorrect value"
             );
         }
 
-        assert!(unwrap(
-            obj_weak.is_weak_ref_to_same_object(&env, &obj_weak2),
-            &env,
-        ));
+        assert!(obj_weak.is_weak_ref_to_same_object(&env, &obj_weak2));
 
         drop(obj_local);
         run_gc(&mut env);
@@ -182,14 +173,11 @@ fn weak_ref_is_actually_weak() {
             }
 
             assert!(
-                unwrap(obj_weak.is_garbage_collected(&env), &env),
+                obj_weak.is_garbage_collected(&env),
                 "`is_garbage_collected` returned incorrect value"
             );
         }
 
-        assert!(unwrap(
-            obj_weak.is_weak_ref_to_same_object(&env, &obj_weak2),
-            &env,
-        ));
+        assert!(obj_weak.is_weak_ref_to_same_object(&env, &obj_weak2));
     }
 }

--- a/tests/threads_attach_guard.rs
+++ b/tests/threads_attach_guard.rs
@@ -1,6 +1,7 @@
 #![cfg(feature = "invocation")]
 
 mod util;
+use jni::JNIVersion;
 use util::{attach_current_thread, call_java_abs, jvm};
 
 #[test]
@@ -14,5 +15,5 @@ fn thread_attach_guard_detaches_on_drop() {
     }
     assert_eq!(jvm().threads_attached(), 0);
     // Verify that this thread is really detached.
-    assert!(jvm().get_env().is_err());
+    unsafe { assert!(jvm().get_env(JNIVersion::V1_4).is_err()) };
 }

--- a/tests/threads_detach_daemon.rs
+++ b/tests/threads_detach_daemon.rs
@@ -8,7 +8,7 @@ use util::{attach_current_thread_as_daemon, call_java_abs, jvm};
 #[test]
 fn daemon_thread_detaches_when_finished() {
     let thread = spawn(|| {
-        let mut env = attach_current_thread_as_daemon();
+        let mut env = unsafe { attach_current_thread_as_daemon() };
         let val = call_java_abs(&mut env, -3);
         assert_eq!(val, 3);
         assert_eq!(jvm().threads_attached(), 1);

--- a/tests/threads_explicit_detach.rs
+++ b/tests/threads_explicit_detach.rs
@@ -1,6 +1,7 @@
 #![cfg(feature = "invocation")]
 
 mod util;
+use jni::JNIVersion;
 use util::{attach_current_thread, call_java_abs, detach_current_thread, jvm};
 
 #[test]
@@ -17,5 +18,5 @@ pub fn explicit_detach_detaches_thread_attached_locally() {
         detach_current_thread();
     }
     assert_eq!(jvm().threads_attached(), 0);
-    assert!(jvm().get_env().is_err());
+    unsafe { assert!(jvm().get_env(JNIVersion::V1_4).is_err()) };
 }

--- a/tests/threads_explicit_detach_daemon.rs
+++ b/tests/threads_explicit_detach_daemon.rs
@@ -1,12 +1,13 @@
 #![cfg(feature = "invocation")]
 
 mod util;
+use jni::JNIVersion;
 use util::{attach_current_thread_as_daemon, call_java_abs, detach_current_thread, jvm};
 
 #[test]
 pub fn explicit_detach_detaches_thread_attached_as_daemon() {
     assert_eq!(jvm().threads_attached(), 0);
-    let mut guard = attach_current_thread_as_daemon();
+    let mut guard = unsafe { attach_current_thread_as_daemon() };
     let val = call_java_abs(&mut guard, -1);
     assert_eq!(val, 1);
     assert_eq!(jvm().threads_attached(), 1);
@@ -17,5 +18,5 @@ pub fn explicit_detach_detaches_thread_attached_as_daemon() {
         detach_current_thread();
     }
     assert_eq!(jvm().threads_attached(), 0);
-    assert!(jvm().get_env().is_err());
+    unsafe { assert!(jvm().get_env(JNIVersion::V1_4).is_err()) };
 }

--- a/tests/threads_explicit_detach_permanent.rs
+++ b/tests/threads_explicit_detach_permanent.rs
@@ -1,6 +1,7 @@
 #![cfg(feature = "invocation")]
 
 mod util;
+use jni::JNIVersion;
 use util::{attach_current_thread_permanently, call_java_abs, detach_current_thread, jvm};
 
 #[test]
@@ -17,5 +18,5 @@ pub fn explicit_detach_detaches_thread_attached_permanently() {
         detach_current_thread();
     }
     assert_eq!(jvm().threads_attached(), 0);
-    assert!(jvm().get_env().is_err());
+    unsafe { assert!(jvm().get_env(JNIVersion::V1_4).is_err()) };
 }

--- a/tests/threads_nested_attach_daemon.rs
+++ b/tests/threads_nested_attach_daemon.rs
@@ -9,7 +9,7 @@ use util::{
 #[test]
 pub fn nested_attaches_should_not_detach_daemon_thread() {
     assert_eq!(jvm().threads_attached(), 0);
-    let mut env = attach_current_thread_as_daemon();
+    let mut env = unsafe { attach_current_thread_as_daemon() };
     let val = call_java_abs(&mut env, -1);
     assert_eq!(val, 1);
     assert_eq!(jvm().threads_attached(), 1);
@@ -39,7 +39,7 @@ pub fn nested_attaches_should_not_detach_daemon_thread() {
 
     // Nested attach_as_daemon is a no-op.
     {
-        let mut env_nested = attach_current_thread_as_daemon();
+        let mut env_nested = unsafe { attach_current_thread_as_daemon() };
         let val = call_java_abs(&mut env_nested, -5);
         assert_eq!(val, 5);
         assert_eq!(jvm().threads_attached(), 1);

--- a/tests/threads_nested_attach_guard.rs
+++ b/tests/threads_nested_attach_guard.rs
@@ -1,6 +1,7 @@
 #![cfg(feature = "invocation")]
 
 mod util;
+use jni::JNIVersion;
 use util::{
     attach_current_thread, attach_current_thread_as_daemon, attach_current_thread_permanently,
     call_java_abs, jvm,
@@ -39,7 +40,7 @@ pub fn nested_attaches_should_not_detach_guarded_thread() {
 
     // Nested attach_as_daemon is a no-op.
     {
-        let mut env_nested = attach_current_thread_as_daemon();
+        let mut env_nested = unsafe { attach_current_thread_as_daemon() };
         let val = call_java_abs(&mut env_nested, -5);
         assert_eq!(val, 5);
         assert_eq!(jvm().threads_attached(), 1);
@@ -50,5 +51,5 @@ pub fn nested_attaches_should_not_detach_guarded_thread() {
     // despite nested "permanent" attaches.
     drop(env);
     assert_eq!(jvm().threads_attached(), 0);
-    assert!(jvm().get_env().is_err());
+    unsafe { assert!(jvm().get_env(JNIVersion::V1_4).is_err()) };
 }

--- a/tests/threads_nested_attach_permanently.rs
+++ b/tests/threads_nested_attach_permanently.rs
@@ -1,6 +1,7 @@
 #![cfg(feature = "invocation")]
 
 mod util;
+use jni::JNIVersion;
 use util::{
     attach_current_thread, attach_current_thread_as_daemon, attach_current_thread_permanently,
     call_java_abs, jvm,
@@ -39,11 +40,11 @@ pub fn nested_attaches_should_not_detach_permanent_thread() {
 
     // Nested attach_as_daemon is a no-op.
     {
-        let mut env_nested = attach_current_thread_as_daemon();
+        let mut env_nested = unsafe { attach_current_thread_as_daemon() };
         let val = call_java_abs(&mut env_nested, -5);
         assert_eq!(val, 5);
         assert_eq!(jvm().threads_attached(), 1);
     }
     assert_eq!(jvm().threads_attached(), 1);
-    assert!(jvm().get_env().is_ok());
+    unsafe { assert!(jvm().get_env(JNIVersion::V1_4).is_ok()) };
 }

--- a/tests/util/mod.rs
+++ b/tests/util/mod.rs
@@ -14,7 +14,7 @@ pub fn jvm() -> &'static Arc<JavaVM> {
 
     INIT.call_once(|| {
         let jvm_args = InitArgsBuilder::new()
-            .version(JNIVersion::V8)
+            .version(JNIVersion::V1_8)
             .option("-Xcheck:jni")
             .build()
             .unwrap_or_else(|e| panic!("{:#?}", e));
@@ -69,10 +69,9 @@ pub unsafe fn detach_current_thread() {
 }
 
 pub fn print_exception(env: &JNIEnv) {
-    let exception_occurred = env.exception_check().unwrap_or_else(|e| panic!("{:?}", e));
+    let exception_occurred = env.exception_check();
     if exception_occurred {
-        env.exception_describe()
-            .unwrap_or_else(|e| panic!("{:?}", e));
+        env.exception_describe();
     }
 }
 

--- a/tests/util/mod.rs
+++ b/tests/util/mod.rs
@@ -50,7 +50,7 @@ pub fn attach_current_thread() -> AttachGuard<'static> {
 }
 
 #[allow(dead_code)]
-pub fn attach_current_thread_as_daemon() -> JNIEnv<'static> {
+pub unsafe fn attach_current_thread_as_daemon() -> JNIEnv<'static> {
     jvm()
         .attach_current_thread_as_daemon()
         .expect("failed to attach jvm daemon thread")


### PR DESCRIPTION
This ports to the `jni-sys` changes I have currently opened as PRs here: https://github.com/jni-rs/jni-sys/pull/28 + https://github.com/jni-rs/jni-sys/pull/23

I'll leave this as a 'draft' until hopefully landing + releasing those `jni-sys` changes.

The two notable changes in jni-sys 0.4 are that JNINativeInterface is now a union that namespaces the functions by the versions they are valid for like:

```rust
struct JNINativeInterface__1_1 {
    GetVersion:
}
struct JNINativeInterface__1_2 {}
struct JNINativeInterface__1_3 {}
struct JNINativeInterface__reserved {}
union JNINativeInterface {
    v1_1: JNINativeInterface__1_1,
    v1_2: JNINativeInterface__1_2,
    v1_3: JNINativeInterface__1_3,
    reserved: JNINativeInterface__reserved,
}
```

and `jboolean` is now an alias for `bool` instead of `u8`

This was used as an opportunity to quite significantly rework the low-level macros used to make jni-sys function calls to make them much simpler and also safer to use.

Key changes:
- The JNI API version needs to be specified along with every function call and will fail to compile if the function doesn't exist for the given version.
- No hidden use of `return` in the macros that can lead to very surprising / non-obvious control flow. Macros evaluate to a single value that may be a Result such that we can use with `?` outside of the macro for early returns.
- The `catch` macro is removed since we don't have to worry about how some macros might use `return` in confusing ways.
- No hidden use of `unsafe` around the most dangerous code! These macros are all very unsafe to use and all callers need to have their own `unsafe` blocks and should ideally document how safety has be considered.
- An infallible JNI function, like GetVersion, can now be called without getting a redundant `Result` to unwrap.
- The macros take `JNIEnv` and `JavaVM` arguments instead of raw pointers which means we don't need `null` pointer checks for each function call.
- Adds more `// Safety:` comments
- Added missing null checks for a number of function calls (e.g. is_assignable_from() and is_instance_of())

The version namespacing has highlighed several places where the jni crate was not checking the version appropriately.

This now makes it so JNI 1.2 is the minimum supported version of JNI since we couldn't even call ExceptionCheck without JNI 1.2

The following functions are now infallible:
  - `JNIEnv::get_version`
  - `JNIEnv::exception_check`
  - `JNIEnv::exception_clear`
  - `JNIEnv::exception_describe`
  - `JNIEnv::is_same_object`
  - `JNIEnv::delete_local_ref`
  - `WeakRef::is_same_object`
  - `WeakRef::is_weak_ref_to_same_object`
  - `WeakRef::is_garbage_collected`

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Change is covered by [automated tests](https://github.com/jni-rs/jni-rs/blob/master/CONTRIBUTING.md#tests)
- [x] The [coding guidelines](https://github.com/jni-rs/jni-rs/blob/master/CONTRIBUTING.md#the-code-style) are followed
- [x] Public API has documentation
- [x] User-visible changes are mentioned in the Changelog
- [x] The continuous integration build passes

Fixes: #461
Fixes: #463