### PR TITLE
Guarantee that `JNIEnv::fatal_error` will not panic or allocate. Expa…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   - `WeakRef::is_same_object`
   - `WeakRef::is_weak_ref_to_same_object`
   - `WeakRef::is_garbage_collected`
+- `JNIEnv::fatal_error` is now guaranteed not to panic or allocate, but requires the error message to be encoded ahead of time. ([#480](https://github.com/jni-rs/jni-rs/pull/480))
 
 ### Added
 - New functions for converting Rust `char` to and from Java `char` and `int` ([#427](https://github.com/jni-rs/jni-rs/issues/427) / [#434](https://github.com/jni-rs/jni-rs/pull/434))


### PR DESCRIPTION
## Overview

This PR adds a guarantee that `JNIEnv::fatal_error` will not panic or allocate.

This is needed in order to write a panic handler for native methods without the “`fatal_error` can panic” problem described in https://github.com/jni-rs/jni-rs/issues/432#issuecomment-1470934365.

This has the downside (and breaking change) that `fatal_error` now takes a parameter of the exact type `&JNIStr`, which makes it somewhat more cumbersome to use. This PR expands `fatal_error`'s documentation to explain how to use it the easy way (like in the current version of the `jni` crate), as well as how to prepare an error message string in a way that's `unsafe` but panic- and allocation-free.

This PR also expands the documentation of `JNIStr` and `JNIString`.

Note that CI testing has failed on this PR because `jni-sys` 0.4 is not in crates.io yet.

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Change is covered by [automated tests](https://github.com/jni-rs/jni-rs/blob/master/CONTRIBUTING.md#tests)
- [x] The [coding guidelines](https://github.com/jni-rs/jni-rs/blob/master/CONTRIBUTING.md#the-code-style) are followed
- [x] Public API has documentation
- [x] User-visible changes are mentioned in the Changelog
- [ ] The continuous integration build passes (NA; see above)
