### PR TITLE
link the Maven Rust plugin

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -175,6 +175,7 @@
 //! - Consider [GraalVM][projects-graalvm] — a recently released VM that gives zero-cost
 //!   interoperability between various languages (including Java and [Rust][graalvm-rust] compiled
 //!   into LLVM-bitcode)
+//! - See a [plugin](https://github.com/questdb/rust-maven-plugin/) for invoking cargo from Java Maven builds
 //!
 //! [Invocation API]: https://docs.oracle.com/en/java/javase/11/docs/specs/jni/invocation.html
 //! [jni-spec]: https://docs.oracle.com/en/java/javase/11/docs/specs/jni/index.html


### PR DESCRIPTION
I believe this plugin can be useful for jni-rs crate users. 

Full Disclosure: I work for QuestDB - the company that maintains the plugin.

PS: We also wrote about our experience from integrating Java and Rust. I believe it is also very useful, but I wasn't sure whether it's something you would want to link from the crate docs: https://questdb.io/blog/leveraging-rust-in-our-high-performance-java-database/