### PR TITLE
Add `JavaVM::get_raw` and remove `JNIEnv::get_native_interface`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   - `WeakRef::is_weak_ref_to_same_object`
   - `WeakRef::is_garbage_collected`
 - `JNIEnv::fatal_error` is now guaranteed not to panic or allocate, but requires the error message to be encoded ahead of time. ([#480](https://github.com/jni-rs/jni-rs/pull/480))
+- `JNIEnv::get_native_interface` has been removed since it's redundant and `JNIEnv::get_raw` is more consistent with other APIs.
+- `JavaVM::get_java_vm_pointer` has been renamed `JavaVM::get_raw` for consistency.
 
 ### Added
 - New functions for converting Rust `char` to and from Java `char` and `int` ([#427](https://github.com/jni-rs/jni-rs/issues/427) / [#434](https://github.com/jni-rs/jni-rs/pull/434))

--- a/src/wrapper/java_vm/vm.rs
+++ b/src/wrapper/java_vm/vm.rs
@@ -243,9 +243,8 @@ impl JavaVM {
         Ok(JavaVM(ptr))
     }
 
-    // TODO: rename this `.get_raw()` for consistency with `JNIEnv::get_raw()`
     /// Returns underlying `sys::JavaVM` interface.
-    pub fn get_java_vm_pointer(&self) -> *mut sys::JavaVM {
+    pub fn get_raw(&self) -> *mut sys::JavaVM {
         self.0
     }
 

--- a/src/wrapper/jnienv.rs
+++ b/src/wrapper/jnienv.rs
@@ -252,11 +252,6 @@ impl<'local> JNIEnv<'local> {
         self.internal
     }
 
-    /// Returns underlying `sys::JNIEnv` interface.
-    pub fn get_native_interface(&self) -> *mut sys::JNIEnv {
-        self.internal
-    }
-
     /// Duplicates this `JNIEnv`.
     ///
     /// # Safety

--- a/src/wrapper/macros.rs
+++ b/src/wrapper/macros.rs
@@ -85,7 +85,7 @@ macro_rules! java_vm_call_unchecked {
     ( $jvm:expr, $version:tt, $name:tt $(, $args:expr )*) => {{
         // Safety: we know that the pointer can't be null, since that's
         // checked in `from_raw()`
-        let jvm: *mut jni_sys::JavaVM = $jvm.get_java_vm_pointer();
+        let jvm: *mut jni_sys::JavaVM = $jvm.get_raw();
         ((*(*jvm)).$version.$name)(jvm $(, $args)*)
     }};
 }


### PR DESCRIPTION
`JavaVM::get_java_vm_pointer` has been renamed `JavaVM::get_raw` for consistency.

`JNIEnv::get_native_interface` has been removed since it's redundant and `JNIEnv::get_raw` is more consistent with other APIs.


