### PR TITLE
Removes the `CStr` coercion from `strings::*`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 - New functions for converting Rust `char` to and from Java `char` and `int` ([#427](https://github.com/jni-rs/jni-rs/issues/427) / [#434](https://github.com/jni-rs/jni-rs/pull/434))
 - `JNIEnv::call_nonvirtual_method` and `JNIEnv::call_nonvirtual_method_unchecked` to call non-virtual method. ([#454](https://github.com/jni-rs/jni-rs/issues/454))
+- `JavaStr`, `JNIStr`, and `JNIString` have several new methods and traits, most notably a `to_str` method that converts to a regular Rust string. ([#510](https://github.com/jni-rs/jni-rs/issues/510) / [#512](https://github.com/jni-rs/jni-rs/pull/512))
 
 ### Changed
 - `JValueGen` has been removed. `JValue` and `JValueOwned` are now separate, unrelated, non-generic types. ([#429](https://github.com/jni-rs/jni-rs/pull/429))
@@ -45,6 +46,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - `get_object_class` borrows the `JNIEnv` mutably because it creates a new local reference. ([#456](https://github.com/jni-rs/jni-rs/pull/456))
 - `get/set_field_unchecked` have been marked as unsafe since they can lead to undefined behaviour if the given types don't match the field type ([#457](https://github.com/jni-rs/jni-rs/pull/457))
 - `get/set/take_rust_field` no longer require a mutable `JNIEnv` reference since they don't return any new local references to the caller ([#455](https://github.com/jni-rs/jni-rs/issues/455))
+- `JavaStr::from_env` has been removed because it was unsound (it could cause undefined behavior and was not marked `unsafe`). Use `JNIEnv::get_string` or `JNIEnv::get_string_unchecked` instead. ([#510](https://github.com/jni-rs/jni-rs/issues/510) / [#512](https://github.com/jni-rs/jni-rs/pull/512))
+- `JavaStr::get_raw` has been renamed to `as_ptr`. ([#510](https://github.com/jni-rs/jni-rs/issues/510) / [#512](https://github.com/jni-rs/jni-rs/pull/512))
+- `JavaStr`, `JNIStr`, and `JNIString` no longer coerce to `CStr`, because using `CStr::to_str` will often have incorrect results. You can still get a `CStr`, but must use the new `as_cstr` method to do so. ([#510](https://github.com/jni-rs/jni-rs/issues/510) / [#512](https://github.com/jni-rs/jni-rs/pull/512))
 
 ## [0.21.1] — 2023-03-08
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -213,7 +213,10 @@ mod wrapper {
     /// Wrappers for object pointers returned from the JVM.
     pub mod objects;
 
-    /// String types for going to/from java strings.
+    /// Handling of strings in Java's [modified UTF-8] encoding, including
+    /// conversion to and from Rust strings (which use standard UTF-8).
+    ///
+    /// [modified UTF-8]: https://en.wikipedia.org/wiki/UTF-8#Modified_UTF-8
     pub mod strings;
 
     /// Actual communication with the JVM.

--- a/src/wrapper/strings/ffi_str.rs
+++ b/src/wrapper/strings/ffi_str.rs
@@ -7,54 +7,44 @@ use std::{
 use cesu8::{from_java_cesu8, to_java_cesu8};
 use log::debug;
 
-use crate::wrapper::strings::ffi_str;
-
 #[cfg(doc)]
-use std::ops::Deref;
+use crate::wrapper::strings::JavaStr;
 
-/// An owned, null-terminated string, encoded in Java's [Modified UTF-8].
+/// An owned null-terminated string (like [`CString`]) encoded in Java's
+/// [modified UTF-8].
 ///
-/// Most JNI functions that accept or return strings, such as [`NewStringUTF`],
-/// expect or produce strings encoded this way.
+/// This type is intended for constructing Java strings from Rust code. To use
+/// it, first construct an ordinary Rust [`str`] or [`String`], then use
+/// [`JNIString::new`] to convert it to the encoding that Java expects.
 ///
-/// This type plays a similar role as [`CString`]. Its borrowed counterpart is
-/// [`JNIStr`], which this type [dereferences][Deref] to.
+/// As with `CString`, this type has a borrowed counterpart, [`JNIStr`], that
+/// it coerces to.
 ///
-/// Ordinary Rust strings ([`String`], <code>&amp;[str]</code>, or any other
-/// type implementing <code>[AsRef]&lt;str&gt;</code>) can be converted to this
-/// type using `.into()`. Specifically, this type implements
-/// <code>[From]&lt;T&gt; where T: AsRef&lt;str&gt;</code>.
-///
-/// [Modified UTF-8]: https://docs.oracle.com/en/java/javase/11/docs/specs/jni/types.html#modified-utf-8-strings
-/// [`NewStringUTF`]: https://docs.oracle.com/en/java/javase/11/docs/specs/jni/functions.html#newstringutf
+/// [modified UTF-8]: https://en.wikipedia.org/wiki/UTF-8#Modified_UTF-8
 pub struct JNIString {
     internal: CString,
 }
 
-/// A borrowed, null-terminated string, encoded in Java's [Modified UTF-8].
+/// A borrowed null-terminated string (like [`CStr`]) encoded in Java's
+/// [modified UTF-8].
 ///
-/// Most JNI functions that accept or return strings, such as [`NewStringUTF`],
-/// expect or produce strings encoded this way.
+/// As with `CStr` and [`str`], instances of `JNIStr` cannot be created
+/// directly, but can be borrowed from either [`JNIString`] (for constructing a
+/// Java string in Rust code) or [`JavaStr`] (which refers to an existing Java
+/// string).
 ///
-/// This type plays a similar role as (and [dereferences][Deref] to) [`CStr`].
-/// Its owned counterpart is [`JNIString`].
+/// To convert a `JNIStr` into an ordinary Rust string, use the
+/// [`to_str`][Self::to_str] method. To get a view of the modified UTF-8
+/// encoding of the `JNIStr`, use the [`as_cstr`][Self::as_cstr] method to get
+/// a `CStr`, then call its [`to_bytes`][CStr::to_bytes] method.
 ///
+/// Note that, as with `CStr`, this type is **not** `repr(C)`. See [the
+/// `CStr` documentation][CStr] for an explanation of what that means. (This
+/// type is `repr(transparent)`, but it wraps around a `CStr`, not a raw
+/// pointer.)
 ///
-/// # Instantiating
-///
-/// There are two main ways to create a `JNIStr` from a string.
-///
-/// The simplest way is to convert an ordinary Rust string to `JNIString`,
-/// which implements <code>[From]&lt;&amp;[str]&gt;</code> and dereferences to
-/// this type. The downside is that this conversion has a run-time cost.
-///
-/// If you have a `CStr` that you are certain is already encoded in Modified
-/// UTF-8, you can instead use [`JNIStr::from_cstr_unchecked`] to convert it
-/// to a `JNIStr` at no run-time cost. The downside is that this is `unsafe`;
-/// see the “safety” section of that method's documentation for details.
-///
-/// [Modified UTF-8]: https://docs.oracle.com/en/java/javase/11/docs/specs/jni/types.html#modified-utf-8-strings
-/// [`NewStringUTF`]: https://docs.oracle.com/en/java/javase/11/docs/specs/jni/functions.html#newstringutf
+/// [modified UTF-8]: https://en.wikipedia.org/wiki/UTF-8#Modified_UTF-8
+#[repr(transparent)] // needed because `JNIStr` gets pointer-punned from `CStr`.
 pub struct JNIStr {
     internal: CStr,
 }
@@ -63,15 +53,7 @@ impl ::std::ops::Deref for JNIString {
     type Target = JNIStr;
 
     fn deref(&self) -> &Self::Target {
-        unsafe { &*(self.internal.as_bytes_with_nul() as *const [u8] as *const ffi_str::JNIStr) }
-    }
-}
-
-impl ::std::ops::Deref for JNIStr {
-    type Target = CStr;
-
-    fn deref(&self) -> &Self::Target {
-        &self.internal
+        unsafe { JNIStr::from_ptr(self.internal.as_ptr()) }
     }
 }
 
@@ -87,9 +69,15 @@ where
     }
 }
 
+impl From<JNIString> for CString {
+    fn from(string: JNIString) -> Self {
+        string.into_cstring()
+    }
+}
+
 impl<'str_ref> From<&'str_ref JNIStr> for Cow<'str_ref, str> {
     fn from(other: &'str_ref JNIStr) -> Cow<'str_ref, str> {
-        let bytes = other.to_bytes();
+        let bytes = other.as_cstr().to_bytes();
         match from_java_cesu8(bytes) {
             Ok(s) => s,
             Err(e) => {
@@ -100,29 +88,111 @@ impl<'str_ref> From<&'str_ref JNIStr> for Cow<'str_ref, str> {
     }
 }
 
+impl<'str_ref> From<&'str_ref JNIStr> for &'str_ref CStr {
+    fn from(value: &'str_ref JNIStr) -> Self {
+        &value.internal
+    }
+}
+
+impl<'str_ref> From<&'str_ref JNIString> for Cow<'str_ref, JNIStr> {
+    /// Converts `&JNIString` into `Cow::<&JNIStr>::Borrowed`. Zero-cost.
+    fn from(string: &'str_ref JNIString) -> Self {
+        Cow::Borrowed(string)
+    }
+}
+
 impl From<JNIString> for String {
     fn from(other: JNIString) -> String {
-        Cow::from(other.borrowed()).into_owned()
+        other.to_str().into_owned()
     }
 }
 
 impl JNIString {
-    /// Get the borrowed version of the JNIString. Equivalent to
-    /// `CString::borrowed`.
+    /// Converts a Rust string (in standard UTF-8 encoding) into a
+    /// Java-compatible string (in Java's [modified UTF-8] encoding).
+    ///
+    /// [modified UTF-8]: https://en.wikipedia.org/wiki/UTF-8#Modified_UTF-8
+    pub fn new(string: impl AsRef<str>) -> Self {
+        string.into()
+    }
+
+    /// Converts a `CString` into a `JNIString`.
+    ///
+    /// This method is zero-cost.
+    ///
+    ///
+    /// # Safety
+    ///
+    /// The `string` must be in [modified UTF-8] encoding.
+    ///
+    /// [modified UTF-8]: https://en.wikipedia.org/wiki/UTF-8#Modified_UTF-8
+    pub unsafe fn from_cstring(string: CString) -> Self {
+        Self { internal: string }
+    }
+
+    /// Converts a `JNIString` into a `CString`.
+    ///
+    /// This method is zero-cost.
+    pub fn into_cstring(self) -> CString {
+        self.internal
+    }
+
+    /// Borrows this `JNIString` as a `&JNIStr`.
+    ///
+    /// This is the `JNIString` equivalent to [`CString::as_c_str`].
+    ///
+    /// Note that `&JNIString` also coerces to `&JNIStr`, even without calling
+    /// this method. For example:
+    ///
+    /// ```rust,no_run
+    /// # use jni::strings::{JNIStr, JNIString};
+    /// let string: JNIString;
+    /// # string = unimplemented!();
+    ///
+    /// // This works…
+    /// let borrowed: &JNIStr = string.borrowed();
+    ///
+    /// // …and so does this.
+    /// let borrowed: &JNIStr = &string;
+    /// ```
     pub fn borrowed(&self) -> &JNIStr {
         self
     }
 }
 
 impl JNIStr {
-    /// Construct a reference to a `JNIStr` from a pointer. Equivalent to `CStr::from_ptr`.
+    /// Constructs a reference to a `JNIStr` from a pointer.
+    ///
+    /// This is the [`JNIStr`] equivalent to [`CStr::from_ptr`].
     ///
     /// # Safety
     ///
-    /// Expects a valid pointer to a null-terminated C string and does not perform any lifetime
-    /// checks for the resulting value.
-    pub unsafe fn from_ptr<'jni_str>(ptr: *const c_char) -> &'jni_str JNIStr {
+    /// `ptr` must fulfill all of the safety requirements for `CStr::from_ptr`.
+    /// See that method's documentation for details.
+    ///
+    /// Briefly, `ptr` must be a valid, non-null pointer to a null-terminated
+    /// (C-style) string, and must not be mutated or become invalid during the
+    /// lifetime `'a`.
+    ///
+    /// In addition, the string pointed to by `ptr` must be in [modified UTF-8]
+    /// encoding.
+    ///
+    /// [modified UTF-8]: https://en.wikipedia.org/wiki/UTF-8#Modified_UTF-8
+    pub unsafe fn from_ptr<'a>(ptr: *const c_char) -> &'a JNIStr {
         &*(CStr::from_ptr(ptr) as *const CStr as *const JNIStr)
+    }
+
+    /// Returns a pointer to the string.
+    ///
+    /// The pointer points to a null-terminated string in [modified UTF-8]
+    /// encoding. It is non-null and valid for as long as `self` is.
+    ///
+    /// This is equivalent to calling
+    /// <code>self.[as_cstr][JNIStr::as_cstr]().[as_ptr][CStr::as_ptr]()</code>.
+    ///
+    /// [modified UTF-8]: https://en.wikipedia.org/wiki/UTF-8#Modified_UTF-8
+    pub fn as_ptr(&self) -> *const c_char {
+        self.as_cstr().as_ptr()
     }
 
     /// Converts a `&CStr` to a `&JNIStr` without checking for validity.
@@ -139,6 +209,51 @@ impl JNIStr {
         // The reason we don't just use `from_ptr` here is that `CStr::from_ptr` is not yet a `const fn`.
         &*(cstr as *const CStr as *const JNIStr)
     }
+
+    /// Returns a `CStr` view of the string.
+    ///
+    /// To get a view of the raw bytes of the string, call this method, then
+    /// [`CStr::to_bytes`].
+    ///
+    ///
+    /// # Warning: Not UTF-8
+    ///
+    /// Keep in mind that the returned `CStr` does *not* use standard UTF-8
+    /// encoding. Instead, it uses Java's [modified UTF-8] encoding, which
+    /// differs in how the code point U+0000, and code points greater than
+    /// U+FFFF, are encoded.
+    ///
+    /// Do not call [`to_str`][CStr::to_str] or `to_string_lossy` on the `CStr`
+    /// returned by this method. Doing so will not properly convert the
+    /// encoding, potentially resulting in an error or a garbled string.
+    ///
+    /// To convert to a Rust string, use the [`JNIStr::to_str`] method instead.
+    ///
+    /// [modified UTF-8]: https://en.wikipedia.org/wiki/UTF-8#Modified_UTF-8
+    pub fn as_cstr(&self) -> &CStr {
+        &self.internal
+    }
+
+    /// Converts this [modified UTF-8] string to an ordinary Rust string (which
+    /// uses standard UTF-8 encoding).
+    ///
+    /// Standard UTF-8 and modified UTF-8 differ in how they encode the code
+    /// point U+0000 and code points greater than U+FFFF. This method checks if
+    /// the string contains any such code points, and converts them into
+    /// standard UTF-8 encoding.
+    ///
+    /// If the string contains only code points between U+0001 and U+FFFF, then
+    /// it does not need to be changed, and so this method will return
+    /// [`Cow::Borrowed`]. Otherwise, this method will perform the conversion
+    /// into a new string, and return [`Cow::Owned`].
+    ///
+    /// There is also an implementation of `From<&JNIStr>` for `Cow<str>`,
+    /// which has the same effect as this method.
+    ///
+    /// [modified UTF-8]: https://en.wikipedia.org/wiki/UTF-8#Modified_UTF-8
+    pub fn to_str(&self) -> Cow<str> {
+        self.into()
+    }
 }
 
 // impls for CoW
@@ -152,10 +267,20 @@ impl ToOwned for JNIStr {
     type Owned = JNIString;
 
     fn to_owned(&self) -> JNIString {
-        unsafe {
-            JNIString {
-                internal: CString::from_vec_unchecked(self.to_bytes().to_vec()),
-            }
+        JNIString {
+            internal: CString::from(self.as_cstr()),
         }
+    }
+}
+
+impl AsRef<JNIStr> for JNIStr {
+    fn as_ref(&self) -> &JNIStr {
+        self
+    }
+}
+
+impl AsRef<JNIStr> for JNIString {
+    fn as_ref(&self) -> &JNIStr {
+        self
     }
 }

--- a/tests/invocation_character_encoding.rs
+++ b/tests/invocation_character_encoding.rs
@@ -2,6 +2,8 @@
 
 #![cfg(feature = "invocation")]
 
+use std::borrow::Cow;
+
 use jni::{objects::JString, InitArgsBuilder, JavaVM};
 
 #[test]
@@ -37,7 +39,7 @@ fn invocation_character_encoding() {
         .into();
 
     let prop_value_str = env.get_string(&prop_value).unwrap();
-    let prop_value_str: &str = prop_value_str.to_str().unwrap();
+    let prop_value_str: Cow<str> = prop_value_str.to_str();
 
     assert_eq!("\u{00a0}", prop_value_str);
 }

--- a/tests/jni_api.rs
+++ b/tests/jni_api.rs
@@ -229,7 +229,7 @@ pub fn with_local_frame() {
     let s = env
         .get_string(&s)
         .expect("The object returned from the local frame must remain valid");
-    assert_eq!(s.to_str().unwrap(), "Test");
+    assert_eq!(s.to_str(), "Test");
 }
 
 #[test]
@@ -357,7 +357,7 @@ pub fn call_new_object_unchecked_ok() {
 
     let jstr = JString::from(val);
     let javastr = env.get_string(&jstr).unwrap();
-    let rstr = javastr.to_str().unwrap();
+    let rstr = javastr.to_str();
     assert_eq!(rstr, TESTING_OBJECT_STR);
 }
 


### PR DESCRIPTION
## Overview

This PR fixes #510. It removes the `CStr` coercion from `strings::*`, replacing it with an `as_cstr` method, and adds a `to_str` method that properly transcodes modified UTF-8 into standard UTF-8.

The new `as_cstr` method's documentation contains a warning not to use `to_str` or `to_string_lossy` on the returned `CStr`, and to use `JNIStr::to_str` instead.

This PR also adds several new methods and trait implementations to `strings::*`, makes `JNIString` and `JavaStr` to coerce to `JNIStr` instead, and expands the documentation. Hopefully, this will make the `strings` module easier to use.

Fixes: #510

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Change is covered by [automated tests](https://github.com/jni-rs/jni-rs/blob/master/CONTRIBUTING.md#tests)
- [x] The [coding guidelines](https://github.com/jni-rs/jni-rs/blob/master/CONTRIBUTING.md#the-code-style) are followed
- [x] Public API has documentation
- [x] User-visible changes are mentioned in the Changelog
- [x] The continuous integration build passes
