### PR TITLE
Fix CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,19 +9,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v2
-      - name: Install rust
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          components: rustfmt
-          profile: minimal
-          override: true
+        uses: actions/checkout@v4
+      - name: Toolchain Info
+        run: rustup show active-toolchain
       - name: Run rustfmt
-        uses: actions-rs/cargo@v1
-        with:
-          command: fmt
-          args: --all -- --check
+        run: cargo fmt --all -- --check
 
   # Static analyzer.
   clippy:
@@ -29,27 +21,19 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v2
-      - name: Install rust
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          components: clippy
-          profile: minimal
-          override: true
-      - name: Run clippy
-        uses: actions-rs/clippy-check@v1
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          args: --all --tests --all-features -- -D warnings
+        uses: actions/checkout@v4
+      - name: Toolchain Info
+        run: rustup show active-toolchain
+      - name: Run Clippy
+        run: cargo clippy --all-targets --all-features -- -D warnings
 
   # Security audit.
   audit:
     name: Security audit
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions-rs/audit-check@v1
+      - uses: actions/checkout@v4
+      - uses: rustsec/audit-check@v1.4.1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
 
@@ -68,26 +52,17 @@ jobs:
             os: windows-latest
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v2
-      - name: Install rust
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          profile: minimal
-          override: true
+        uses: actions/checkout@v4
+      - name: Toolchain Info
+        run: rustup show active-toolchain
       - name: Install java
         uses: actions/setup-java@v1
         with:
           java-version: '1.8.0'
       - name: Build
-        uses: actions-rs/cargo@v1
-        with:
-          command: build
-          args: --examples --all
+        run: cargo build --examples --all
       - name: Test default features
-        uses: actions-rs/cargo@v1
-        with:
-          command: test
+        run: cargo test
       - name: Shellcheck
         if: runner.os == 'Linux'
         run: .github/workflows/shellcheck.sh

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,10 @@ exclude = [
     "/test_profile",
 ]
 
+[[bench]]
+name = "api_calls"
+harness = false
+
 [dependencies]
 cfg-if = "1.0.0"
 cesu8 = "1.1.0"
@@ -39,6 +43,7 @@ thiserror = "1.0.20"
 walkdir = "2"
 
 [dev-dependencies]
+criterion = { version = "0.4", features = ["html_reports"] }
 assert_matches = "1.5.0"
 lazy_static = "1"
 rusty-fork = "0.3.0"

--- a/benches/api_calls.rs
+++ b/benches/api_calls.rs
@@ -50,6 +50,7 @@ fn jni_hash_safe(env: &mut JNIEnv, obj: &JObject) -> jint {
     v.i().unwrap()
 }
 
+#[allow(clippy::too_many_arguments)]
 fn jni_local_date_time_of_safe<'local>(
     env: &mut JNIEnv<'local>,
     year: jint,

--- a/benches/api_calls.rs
+++ b/benches/api_calls.rs
@@ -1,11 +1,10 @@
 #![cfg(feature = "invocation")]
-#![feature(test)]
-
-extern crate test;
 
 use jni_sys::jvalue;
 use lazy_static::lazy_static;
 
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use jni::objects::GlobalRef;
 use jni::{
     descriptors::Desc,
     objects::{JClass, JMethodID, JObject, JStaticMethodID, JValue},
@@ -13,6 +12,8 @@ use jni::{
     sys::jint,
     InitArgsBuilder, JNIEnv, JNIVersion, JavaVM,
 };
+use std::rc::Rc;
+use std::sync::Arc;
 
 static CLASS_MATH: &str = "java/lang/Math";
 static CLASS_OBJECT: &str = "java/lang/Object";
@@ -123,77 +124,74 @@ where
     v.l().unwrap()
 }
 
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use jni::objects::GlobalRef;
-    use std::rc::Rc;
-    use std::sync::Arc;
-    use test::{black_box, Bencher};
+lazy_static! {
+    static ref VM: JavaVM = {
+        let args = InitArgsBuilder::new()
+            .version(JNIVersion::V1_8)
+            .build()
+            .unwrap();
+        JavaVM::new(args).unwrap()
+    };
+}
 
-    lazy_static! {
-        static ref VM: JavaVM = {
-            let args = InitArgsBuilder::new()
-                .version(JNIVersion::V1_8)
-                .build()
-                .unwrap();
-            JavaVM::new(args).unwrap()
-        };
-    }
-
-    #[bench]
-    fn native_call_function(b: &mut Bencher) {
+fn native_call_function(c: &mut Criterion) {
+    c.bench_function("native_call_function", |b| {
         b.iter(|| {
             let _ = native_abs(black_box(-3));
-        });
-    }
+        })
+    });
+}
 
-    #[bench]
-    fn jni_call_static_abs_method_safe(b: &mut Bencher) {
-        let mut env = VM.attach_current_thread().unwrap();
+fn jni_call_static_abs_method_safe(c: &mut Criterion) {
+    let mut env = VM.attach_current_thread().unwrap();
 
-        b.iter(|| jni_abs_safe(&mut env, -3));
-    }
+    c.bench_function("jni_call_static_abs_method_safe", |b| {
+        b.iter(|| jni_abs_safe(&mut env, -3))
+    });
+}
 
-    #[bench]
-    fn jni_call_static_abs_method_unchecked_str(b: &mut Bencher) {
-        let mut env = VM.attach_current_thread().unwrap();
-        let class = CLASS_MATH;
-        let method_id = env
-            .get_static_method_id(class, METHOD_MATH_ABS, SIG_MATH_ABS)
-            .unwrap();
+fn jni_call_static_abs_method_unchecked_str(c: &mut Criterion) {
+    let mut env = VM.attach_current_thread().unwrap();
+    let class = CLASS_MATH;
+    let method_id = env
+        .get_static_method_id(class, METHOD_MATH_ABS, SIG_MATH_ABS)
+        .unwrap();
 
-        b.iter(|| jni_int_call_static_unchecked(&mut env, class, method_id, -3));
-    }
+    c.bench_function("jni_call_static_abs_method_unchecked_str", |b| {
+        b.iter(|| jni_int_call_static_unchecked(&mut env, class, method_id, -3))
+    });
+}
 
-    #[bench]
-    fn jni_call_static_abs_method_unchecked_jclass(b: &mut Bencher) {
-        let mut env = VM.attach_current_thread().unwrap();
-        let class = Desc::<JClass>::lookup(CLASS_MATH, &mut env).unwrap();
-        let method_id = env
-            .get_static_method_id(&class, METHOD_MATH_ABS, SIG_MATH_ABS)
-            .unwrap();
+fn jni_call_static_abs_method_unchecked_jclass(c: &mut Criterion) {
+    let mut env = VM.attach_current_thread().unwrap();
+    let class = Desc::<JClass>::lookup(CLASS_MATH, &mut env).unwrap();
+    let method_id = env
+        .get_static_method_id(&class, METHOD_MATH_ABS, SIG_MATH_ABS)
+        .unwrap();
 
-        b.iter(|| jni_int_call_static_unchecked(&mut env, &class, method_id, -3));
-    }
+    c.bench_function("jni_call_static_abs_method_unchecked_jclass", |b| {
+        b.iter(|| jni_int_call_static_unchecked(&mut env, &class, method_id, -3))
+    });
+}
 
-    #[bench]
-    fn jni_call_static_date_time_method_safe(b: &mut Bencher) {
-        let mut env = VM.attach_current_thread().unwrap();
+fn jni_call_static_date_time_method_safe(c: &mut Criterion) {
+    let mut env = VM.attach_current_thread().unwrap();
+    c.bench_function("jni_call_static_date_time_method_safe", |b| {
         b.iter(|| {
             let obj = jni_local_date_time_of_safe(&mut env, 1, 1, 1, 1, 1, 1, 1);
             env.delete_local_ref(obj);
-        });
-    }
+        })
+    });
+}
 
-    #[bench]
-    fn jni_call_static_date_time_method_unchecked_jclass(b: &mut Bencher) {
-        let mut env = VM.attach_current_thread().unwrap();
-        let class = Desc::<JClass>::lookup(CLASS_LOCAL_DATE_TIME, &mut env).unwrap();
-        let method_id = env
-            .get_static_method_id(&class, METHOD_LOCAL_DATE_TIME_OF, SIG_LOCAL_DATE_TIME_OF)
-            .unwrap();
+fn jni_call_static_date_time_method_unchecked_jclass(c: &mut Criterion) {
+    let mut env = VM.attach_current_thread().unwrap();
+    let class = Desc::<JClass>::lookup(CLASS_LOCAL_DATE_TIME, &mut env).unwrap();
+    let method_id = env
+        .get_static_method_id(&class, METHOD_LOCAL_DATE_TIME_OF, SIG_LOCAL_DATE_TIME_OF)
+        .unwrap();
 
+    c.bench_function("jni_call_static_date_time_method_unchecked_jclass", |b| {
         b.iter(|| {
             let obj = jni_object_call_static_unchecked(
                 &mut env,
@@ -210,180 +208,192 @@ mod tests {
                 ],
             );
             env.delete_local_ref(obj);
-        });
-    }
+        })
+    });
+}
 
-    #[bench]
-    fn jni_call_object_hash_method_safe(b: &mut Bencher) {
-        let mut env = VM.attach_current_thread().unwrap();
-        let s = env.new_string("").unwrap();
-        let obj = black_box(JObject::from(s));
+fn jni_call_object_hash_method_safe(c: &mut Criterion) {
+    let mut env = VM.attach_current_thread().unwrap();
+    let s = env.new_string("").unwrap();
+    let obj = black_box(JObject::from(s));
 
-        b.iter(|| jni_hash_safe(&mut env, &obj));
-    }
+    c.bench_function("jni_call_object_hash_method_safe", |b| {
+        b.iter(|| jni_hash_safe(&mut env, &obj))
+    });
+}
 
-    #[bench]
-    fn jni_call_object_hash_method_unchecked(b: &mut Bencher) {
-        let mut env = VM.attach_current_thread().unwrap();
-        let s = env.new_string("").unwrap();
-        let obj = black_box(JObject::from(s));
-        let obj_class = env.get_object_class(&obj).unwrap();
-        let method_id = env
-            .get_method_id(&obj_class, METHOD_OBJECT_HASH_CODE, SIG_OBJECT_HASH_CODE)
-            .unwrap();
+fn jni_call_object_hash_method_unchecked(c: &mut Criterion) {
+    let mut env = VM.attach_current_thread().unwrap();
+    let s = env.new_string("").unwrap();
+    let obj = black_box(JObject::from(s));
+    let obj_class = env.get_object_class(&obj).unwrap();
+    let method_id = env
+        .get_method_id(&obj_class, METHOD_OBJECT_HASH_CODE, SIG_OBJECT_HASH_CODE)
+        .unwrap();
 
-        b.iter(|| jni_int_call_unchecked(&mut env, &obj, method_id));
-    }
+    c.bench_function("jni_call_object_hash_method_unchecked", |b| {
+        b.iter(|| jni_int_call_unchecked(&mut env, &obj, method_id))
+    });
+}
 
-    #[bench]
-    fn jni_new_object_str(b: &mut Bencher) {
-        let mut env = VM.attach_current_thread().unwrap();
-        let class = CLASS_OBJECT;
+fn jni_new_object_str(c: &mut Criterion) {
+    let mut env = VM.attach_current_thread().unwrap();
+    let class = CLASS_OBJECT;
 
+    c.bench_function("jni_new_object_str", |b| {
         b.iter(|| {
             let obj = env.new_object(class, SIG_OBJECT_CTOR, &[]).unwrap();
             env.delete_local_ref(obj);
-        });
-    }
+        })
+    });
+}
 
-    #[bench]
-    fn jni_new_object_by_id_str(b: &mut Bencher) {
-        let mut env = VM.attach_current_thread().unwrap();
-        let class = CLASS_OBJECT;
-        let ctor_id = env
-            .get_method_id(class, METHOD_CTOR, SIG_OBJECT_CTOR)
-            .unwrap();
+fn jni_new_object_by_id_str(c: &mut Criterion) {
+    let mut env = VM.attach_current_thread().unwrap();
+    let class = CLASS_OBJECT;
+    let ctor_id = env
+        .get_method_id(class, METHOD_CTOR, SIG_OBJECT_CTOR)
+        .unwrap();
 
+    c.bench_function("jni_new_object_by_id_str", |b| {
         b.iter(|| {
             let obj = unsafe { env.new_object_unchecked(class, ctor_id, &[]) }.unwrap();
             env.delete_local_ref(obj);
-        });
-    }
+        })
+    });
+}
 
-    #[bench]
-    fn jni_new_object_jclass(b: &mut Bencher) {
-        let mut env = VM.attach_current_thread().unwrap();
-        let class = Desc::<JClass>::lookup(CLASS_OBJECT, &mut env).unwrap();
+fn jni_new_object_jclass(c: &mut Criterion) {
+    let mut env = VM.attach_current_thread().unwrap();
+    let class = Desc::<JClass>::lookup(CLASS_OBJECT, &mut env).unwrap();
 
+    c.bench_function("jni_new_object_jclass", |b| {
         b.iter(|| {
             let obj = env.new_object(&class, SIG_OBJECT_CTOR, &[]).unwrap();
             env.delete_local_ref(obj);
-        });
-    }
+        })
+    });
+}
 
-    #[bench]
-    fn jni_new_object_by_id_jclass(b: &mut Bencher) {
-        let mut env = VM.attach_current_thread().unwrap();
-        let class = Desc::<JClass>::lookup(CLASS_OBJECT, &mut env).unwrap();
-        let ctor_id = env
-            .get_method_id(&class, METHOD_CTOR, SIG_OBJECT_CTOR)
-            .unwrap();
+fn jni_new_object_by_id_jclass(c: &mut Criterion) {
+    let mut env = VM.attach_current_thread().unwrap();
+    let class = Desc::<JClass>::lookup(CLASS_OBJECT, &mut env).unwrap();
+    let ctor_id = env
+        .get_method_id(&class, METHOD_CTOR, SIG_OBJECT_CTOR)
+        .unwrap();
 
+    c.bench_function("jni_new_object_by_id_jclass", |b| {
         b.iter(|| {
             let obj = unsafe { env.new_object_unchecked(&class, ctor_id, &[]) }.unwrap();
             env.delete_local_ref(obj);
-        });
-    }
+        })
+    });
+}
 
-    #[bench]
-    fn jni_new_global_ref(b: &mut Bencher) {
-        let mut env = VM.attach_current_thread().unwrap();
-        let class = CLASS_OBJECT;
-        let obj = env.new_object(class, SIG_OBJECT_CTOR, &[]).unwrap();
-        let global_ref = env.new_global_ref(&obj).unwrap();
-        env.delete_local_ref(obj);
+fn jni_new_global_ref(c: &mut Criterion) {
+    let mut env = VM.attach_current_thread().unwrap();
+    let class = CLASS_OBJECT;
+    let obj = env.new_object(class, SIG_OBJECT_CTOR, &[]).unwrap();
+    let global_ref = env.new_global_ref(&obj).unwrap();
+    env.delete_local_ref(obj);
 
-        b.iter(|| env.new_global_ref(&global_ref).unwrap());
-    }
+    c.bench_function("jni_new_global_ref", |b| {
+        b.iter(|| env.new_global_ref(&global_ref).unwrap())
+    });
+}
 
-    /// Checks the overhead of checking if exception has occurred.
-    ///
-    /// Such checks are required each time a Java method is called, but
-    /// can be omitted if we call a JNI method that returns an error status.
-    ///
-    /// See also #58
-    #[bench]
-    fn jni_check_exception(b: &mut Bencher) {
-        let env = VM.attach_current_thread().unwrap();
+/// Checks the overhead of checking if exception has occurred.
+///
+/// Such checks are required each time a Java method is called, but
+/// can be omitted if we call a JNI method that returns an error status.
+///
+/// See also #58
+fn jni_check_exception(c: &mut Criterion) {
+    let env = VM.attach_current_thread().unwrap();
 
-        b.iter(|| env.exception_check());
-    }
+    c.bench_function("jni_check_exception", |b| b.iter(|| env.exception_check()));
+}
 
-    #[bench]
-    fn jni_get_java_vm(b: &mut Bencher) {
-        let env = VM.attach_current_thread().unwrap();
+fn jni_get_java_vm(c: &mut Criterion) {
+    let env = VM.attach_current_thread().unwrap();
 
+    c.bench_function("jni_get_java_vm", |b| {
         b.iter(|| {
             let _jvm = env.get_java_vm().unwrap();
-        });
-    }
+        })
+    });
+}
 
-    #[bench]
-    fn jni_get_string(b: &mut Bencher) {
-        let mut env = VM.attach_current_thread().unwrap();
-        let string = env.new_string(TEST_STRING_UNICODE).unwrap();
+fn jni_get_string(c: &mut Criterion) {
+    let mut env = VM.attach_current_thread().unwrap();
+    let string = env.new_string(TEST_STRING_UNICODE).unwrap();
 
+    c.bench_function("jni_get_string", |b| {
         b.iter(|| {
             let s: String = env.get_string(&string).unwrap().into();
             assert_eq!(s, TEST_STRING_UNICODE);
-        });
-    }
+        })
+    });
+}
 
-    #[bench]
-    fn jni_get_string_unchecked(b: &mut Bencher) {
-        let env = VM.attach_current_thread().unwrap();
-        let string = env.new_string(TEST_STRING_UNICODE).unwrap();
+fn jni_get_string_unchecked(c: &mut Criterion) {
+    let env = VM.attach_current_thread().unwrap();
+    let string = env.new_string(TEST_STRING_UNICODE).unwrap();
 
+    c.bench_function("jni_get_string_unchecked", |b| {
         b.iter(|| {
             let s: String = unsafe { env.get_string_unchecked(&string) }.unwrap().into();
             assert_eq!(s, TEST_STRING_UNICODE);
-        });
-    }
+        })
+    });
+}
 
-    /// A benchmark measuring Push/PopLocalFrame overhead.
-    ///
-    /// Such operations are *required* if one attaches a long-running
-    /// native thread to the JVM because there is no 'return-from-native-method'
-    /// event when created local references are freed, hence no way for
-    /// the JVM to know that the local references are no longer used in the native code.
-    #[bench]
-    fn jni_noop_with_local_frame(b: &mut Bencher) {
-        // Local frame size actually doesn't matter since JVM does not preallocate anything.
-        const LOCAL_FRAME_SIZE: i32 = 32;
-        let mut env = VM.attach_current_thread().unwrap();
+/// A benchmark measuring Push/PopLocalFrame overhead.
+///
+/// Such operations are *required* if one attaches a long-running
+/// native thread to the JVM because there is no 'return-from-native-method'
+/// event when created local references are freed, hence no way for
+/// the JVM to know that the local references are no longer used in the native code.
+fn jni_noop_with_local_frame(c: &mut Criterion) {
+    // Local frame size actually doesn't matter since JVM does not preallocate anything.
+    const LOCAL_FRAME_SIZE: i32 = 32;
+    let mut env = VM.attach_current_thread().unwrap();
+    c.bench_function("jni_noop_with_local_frame", |b| {
         b.iter(|| {
             env.with_local_frame(LOCAL_FRAME_SIZE, |_| -> Result<_, jni::errors::Error> {
                 Ok(())
             })
             .unwrap()
-        });
-    }
+        })
+    });
+}
 
-    /// A benchmark measuring Push/PopLocalFrame overhead while retuning a local reference
-    #[bench]
-    fn jni_with_local_frame_returning_local(b: &mut Bencher) {
-        // Local frame size actually doesn't matter since JVM does not preallocate anything.
-        const LOCAL_FRAME_SIZE: i32 = 32;
-        let mut env = VM.attach_current_thread().unwrap();
+/// A benchmark measuring Push/PopLocalFrame overhead while retuning a local reference
+fn jni_with_local_frame_returning_local(c: &mut Criterion) {
+    // Local frame size actually doesn't matter since JVM does not preallocate anything.
+    const LOCAL_FRAME_SIZE: i32 = 32;
+    let mut env = VM.attach_current_thread().unwrap();
 
-        let class = env.find_class(CLASS_OBJECT).unwrap();
+    let class = env.find_class(CLASS_OBJECT).unwrap();
+    c.bench_function("jni_with_local_frame_returning_local", |b| {
         b.iter(|| {
             env.with_local_frame_returning_local(LOCAL_FRAME_SIZE, |env| {
                 env.new_object(&class, SIG_OBJECT_CTOR, &[])
             })
-        });
-    }
+        })
+    });
+}
 
-    /// A benchmark measuring Push/PopLocalFrame overhead while retuning a global
-    /// object reference that then gets converted into a local reference before
-    /// dropping the global
-    #[bench]
-    fn jni_with_local_frame_returning_global_to_local(b: &mut Bencher) {
-        // Local frame size actually doesn't matter since JVM does not preallocate anything.
-        const LOCAL_FRAME_SIZE: i32 = 32;
-        let mut env = VM.attach_current_thread().unwrap();
+/// A benchmark measuring Push/PopLocalFrame overhead while retuning a global
+/// object reference that then gets converted into a local reference before
+/// dropping the global
+fn jni_with_local_frame_returning_global_to_local(c: &mut Criterion) {
+    // Local frame size actually doesn't matter since JVM does not preallocate anything.
+    const LOCAL_FRAME_SIZE: i32 = 32;
+    let mut env = VM.attach_current_thread().unwrap();
 
-        let class = env.find_class(CLASS_OBJECT).unwrap();
+    let class = env.find_class(CLASS_OBJECT).unwrap();
+    c.bench_function("jni_with_local_frame_returning_global_to_local", |b| {
         b.iter(|| {
             let global = env
                 .with_local_frame::<_, GlobalRef, jni::errors::Error>(LOCAL_FRAME_SIZE, |env| {
@@ -393,44 +403,76 @@ mod tests {
                 })
                 .unwrap();
             let _local = env.new_local_ref(global).unwrap();
-        });
-    }
+        })
+    });
+}
 
-    /// A benchmark of the overhead of attaching and detaching a native thread.
-    ///
-    /// It is *huge* — two orders of magnitude higher than calling a single
-    /// Java method using unchecked APIs (e.g., `jni_call_static_unchecked`).
-    ///
-    #[bench]
-    fn jvm_noop_attach_detach_native_thread(b: &mut Bencher) {
+/// A benchmark of the overhead of attaching and detaching a native thread.
+///
+/// It is *huge* — two orders of magnitude higher than calling a single
+/// Java method using unchecked APIs (e.g., `jni_call_static_unchecked`).
+///
+fn jvm_noop_attach_detach_native_thread(c: &mut Criterion) {
+    c.bench_function("jvm_noop_attach_detach_native_thread", |b| {
         b.iter(|| {
             let env = VM.attach_current_thread().unwrap();
             black_box(&env);
-        });
-    }
+        })
+    });
+}
 
-    #[bench]
-    fn native_arc(b: &mut Bencher) {
-        let mut env = VM.attach_current_thread().unwrap();
-        let class = CLASS_OBJECT;
-        let obj = env.new_object(class, SIG_OBJECT_CTOR, &[]).unwrap();
-        let global_ref = env.new_global_ref(&obj).unwrap();
-        env.delete_local_ref(obj);
-        let arc = Arc::new(global_ref);
+fn native_arc(c: &mut Criterion) {
+    let mut env = VM.attach_current_thread().unwrap();
+    let class = CLASS_OBJECT;
+    let obj = env.new_object(class, SIG_OBJECT_CTOR, &[]).unwrap();
+    let global_ref = env.new_global_ref(&obj).unwrap();
+    env.delete_local_ref(obj);
+    let arc = Arc::new(global_ref);
 
+    c.bench_function("native_arc", |b| {
         b.iter(|| {
             let _ = black_box(Arc::clone(&arc));
-        });
-    }
+        })
+    });
+}
 
-    #[bench]
-    fn native_rc(b: &mut Bencher) {
-        let _env = VM.attach_current_thread().unwrap();
-        let env = VM.get_env().unwrap();
-        let rc = Rc::new(env);
+fn native_rc(c: &mut Criterion) {
+    let _env = VM.attach_current_thread().unwrap();
+    let env = unsafe { VM.get_env(JNIVersion::V1_4).unwrap() };
+    let rc = Rc::new(env);
 
+    c.bench_function("native_rc", |b| {
         b.iter(|| {
             let _ = black_box(Rc::clone(&rc));
-        });
-    }
+        })
+    });
 }
+
+criterion_group!(
+    benches,
+    native_call_function,
+    jni_call_static_abs_method_safe,
+    jni_call_static_abs_method_unchecked_str,
+    jni_call_static_abs_method_unchecked_jclass,
+    jni_call_static_date_time_method_safe,
+    jni_call_static_date_time_method_unchecked_jclass,
+    jni_call_object_hash_method_safe,
+    jni_call_object_hash_method_unchecked,
+    jni_new_object_str,
+    jni_new_object_by_id_str,
+    jni_new_object_jclass,
+    jni_new_object_by_id_jclass,
+    jni_new_global_ref,
+    jni_check_exception,
+    jni_get_java_vm,
+    jni_get_string,
+    jni_get_string_unchecked,
+    jni_noop_with_local_frame,
+    jni_with_local_frame_returning_local,
+    jni_with_local_frame_returning_global_to_local,
+    jvm_noop_attach_detach_native_thread,
+    native_arc,
+    native_rc
+);
+
+criterion_main!(benches);

--- a/src/wrapper/descriptors/mod.rs
+++ b/src/wrapper/descriptors/mod.rs
@@ -2,13 +2,9 @@ mod desc;
 pub use self::desc::*;
 
 mod class_desc;
-pub use self::class_desc::*;
 
 mod method_desc;
-pub use self::method_desc::*;
 
 mod field_desc;
-pub use self::field_desc::*;
 
 mod exception_desc;
-pub use self::exception_desc::*;

--- a/tests/jni_api.rs
+++ b/tests/jni_api.rs
@@ -355,7 +355,7 @@ pub fn call_new_object_unchecked_ok() {
     }
     .expect("JNIEnv#new_object_unchecked should return JValue");
 
-    let jstr = JString::try_from(val).expect("asd");
+    let jstr = JString::from(val);
     let javastr = env.get_string(&jstr).unwrap();
     let rstr = javastr.to_str().unwrap();
     assert_eq!(rstr, TESTING_OBJECT_STR);

--- a/tests/util/mod.rs
+++ b/tests/util/mod.rs
@@ -6,7 +6,9 @@ use jni::{
 };
 
 mod example_proxy;
-pub use self::example_proxy::AtomicIntegerProxy;
+
+#[allow(unused_imports)]
+pub use example_proxy::AtomicIntegerProxy;
 
 pub fn jvm() -> &'static Arc<JavaVM> {
     static mut JVM: Option<Arc<JavaVM>> = None;


### PR DESCRIPTION
Update to use `actions/checkout@v4` and avoid deprecated / archived `actions-rs` actions.

Fixes various Clippy lints

Additionally this ports benchmarks to Criterion to enable building benchmarks with a stable Rust toolchain, without needing `#[feature(test)]`

Note: The benchmarks depend on the JVM invocation API and can be run like

`cargo bench --features=invocation`
