### PR TITLE
Make `JNIEnv::exception_occurred` infallible too.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   - `JNIEnv::exception_check`
   - `JNIEnv::exception_clear`
   - `JNIEnv::exception_describe`
+  - `JNIEnv::exception_occurred` ([#517](https://github.com/jni-rs/jni-rs/issues/517)
   - `JNIEnv::is_same_object`
   - `JNIEnv::delete_local_ref`
   - `WeakRef::is_same_object`

--- a/src/wrapper/jnienv.rs
+++ b/src/wrapper/jnienv.rs
@@ -591,9 +591,13 @@ impl<'local> JNIEnv<'local> {
     ///
     /// An exception is in this state from the time it gets thrown and
     /// not caught in a java function until `exception_clear` is called.
-    pub fn exception_occurred(&mut self) -> Result<JThrowable<'local>> {
+    pub fn exception_occurred(&mut self) -> Option<JThrowable<'local>> {
         let throwable = unsafe { jni_call_unchecked!(self, v1_1, ExceptionOccurred) };
-        Ok(unsafe { JThrowable::from_raw(throwable) })
+        if throwable.is_null() {
+            None
+        } else {
+            Some(unsafe { JThrowable::from_raw(throwable) })
+        }
     }
 
     /// Print exception information to the console.


### PR DESCRIPTION
Cherry picked from #498