### PR TITLE
Fix local reference leak in `JNIEnv::get_string`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - `JavaStr::get_raw` has been renamed to `as_ptr`. ([#510](https://github.com/jni-rs/jni-rs/issues/510) / [#512](https://github.com/jni-rs/jni-rs/pull/512))
 - `JavaStr`, `JNIStr`, and `JNIString` no longer coerce to `CStr`, because using `CStr::to_str` will often have incorrect results. You can still get a `CStr`, but must use the new `as_cstr` method to do so. ([#510](https://github.com/jni-rs/jni-rs/issues/510) / [#512](https://github.com/jni-rs/jni-rs/pull/512))
 
+### Fixed
+- `JNIEnv::get_string` no longer leaks local references. ([#527](https://github.com/jni-rs/jni-rs/issues/527))
+
 ## [0.21.1] — 2023-03-08
 
 ### Fixes

--- a/src/wrapper/jnienv.rs
+++ b/src/wrapper/jnienv.rs
@@ -1919,7 +1919,7 @@ impl<'local> JNIEnv<'local> {
         &mut self,
         obj: &'obj_ref JString<'other_local>,
     ) -> Result<JavaStr<'local, 'other_local, 'obj_ref>> {
-        let string_class = self.find_class("java/lang/String")?;
+        let string_class = AutoLocal::new(self.find_class("java/lang/String")?, self);
         let obj_class = self.get_object_class(obj)?;
         if !self.is_assignable_from(string_class, obj_class)? {
             return Err(JniCall(JniError::InvalidArguments));


### PR DESCRIPTION
## Overview

This PR fixes #527.

Note: Because there is no JNI function to get a count of how many local references are in the current frame, this change is, as far as I know, impossible to test in an automated fashion.

### Definition of Done

- [x] There are no TODOs left in the code
- ~~Change is covered by [automated tests](https://github.com/jni-rs/jni-rs/blob/master/CONTRIBUTING.md#tests)~~
- [x] The [coding guidelines](https://github.com/jni-rs/jni-rs/blob/master/CONTRIBUTING.md#the-code-style) are followed
- [x] Public API has documentation
- [x] User-visible changes are mentioned in the Changelog
- [x] The continuous integration build passes
