### PR TITLE
Improve performance of get_string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,11 +49,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - `JavaStr::from_env` has been removed because it was unsound (it could cause undefined behavior and was not marked `unsafe`). Use `JNIEnv::get_string` or `JNIEnv::get_string_unchecked` instead. ([#510](https://github.com/jni-rs/jni-rs/issues/510) / [#512](https://github.com/jni-rs/jni-rs/pull/512))
 - `JavaStr::get_raw` has been renamed to `as_ptr`. ([#510](https://github.com/jni-rs/jni-rs/issues/510) / [#512](https://github.com/jni-rs/jni-rs/pull/512))
 - `JavaStr`, `JNIStr`, and `JNIString` no longer coerce to `CStr`, because using `CStr::to_str` will often have incorrect results. You can still get a `CStr`, but must use the new `as_cstr` method to do so. ([#510](https://github.com/jni-rs/jni-rs/issues/510) / [#512](https://github.com/jni-rs/jni-rs/pull/512))
+- `JNIEnv::get_string` performance is improved by caching an expensive class lookup, and using a faster instanceof check.
 
 ## [0.21.1] — 2023-03-08
 
 ### Fixes
 - Compilation is fixed for architectures with a C ABI that has unsigned `char` types. ([#419](https://github.com/jni-rs/jni-rs/pull/419))
+- `JNIEnv::get_string` no longer leaks local references. ([#528](https://github.com/jni-rs/jni-rs/pull/528))
 
 ## [0.21.0] — 2023-02-13
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,7 @@ java-locator = { version = "0.1", optional = true }
 jni-sys = "0.4"
 libloading = { version = "0.8", optional = true }
 log = "0.4.4"
+once_cell = "1.19.0"
 static_assertions = "1"
 thiserror = "1.0.20"
 


### PR DESCRIPTION
## Overview

Speeds up `get_string` in two ways:

1. Cache the `java/lang/String` class instead of calling `FindClass` repeatedly.
2. Use `IsInstanceOf` instead of `GetObjectClass` + `IsAssignableFrom`. `java/lang/String` is final, so these are equivalent.

Running the benchmark on my machine, change 1:

```
jni_get_string          time:   [445.86 ns 448.89 ns 454.23 ns]
                        change: [-53.617% -45.104% -39.388%] (p = 0.00 < 0.05)
                        Performance has improved.
```

Changes 1+2:
```
jni_get_string          time:   [406.30 ns 406.37 ns 406.45 ns]
                        change: [-9.6565% -9.1695% -8.8758%] (p = 0.00 < 0.05)
                        Performance has improved.
```

Also incidentally fixes #528.

**Questions/notes**

* I don't write Rust, so sorry if I made any basic errors.
* I tried to use `std::OnceLock`, but `get_or_try_init` is not yet stable, and I couldn't find a neat way to handle errors, hence pulling in `once_cell`. Open to ideas here.
* Let me know your thoughts on the changelog and doc changes.

Thanks!

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Change is covered by [automated tests](https://github.com/jni-rs/jni-rs/blob/master/CONTRIBUTING.md#tests)
- [x] The [coding guidelines](https://github.com/jni-rs/jni-rs/blob/master/CONTRIBUTING.md#the-code-style) are followed
- [x] Public API has documentation
- [x] User-visible changes are mentioned in the Changelog
- [ ] The continuous integration build passes
  - TBD 
