### PR TITLE
Improve performance of get_string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - New functions for converting Rust `char` to and from Java `char` and `int` ([#427](https://github.com/jni-rs/jni-rs/issues/427) / [#434](https://github.com/jni-rs/jni-rs/pull/434))
 - `JNIEnv::call_nonvirtual_method` and `JNIEnv::call_nonvirtual_method_unchecked` to call non-virtual method. ([#454](https://github.com/jni-rs/jni-rs/issues/454))
 - `JavaStr`, `JNIStr`, and `JNIString` have several new methods and traits, most notably a `to_str` method that converts to a regular Rust string. ([#510](https://github.com/jni-rs/jni-rs/issues/510) / [#512](https://github.com/jni-rs/jni-rs/pull/512))
+- Added dependency on `once_cell` version `1.19.0` for lazy initialization in `JNIEnv::get_string`.
 
 ### Changed
 - `JValueGen` has been removed. `JValue` and `JValueOwned` are now separate, unrelated, non-generic types. ([#429](https://github.com/jni-rs/jni-rs/pull/429))
@@ -49,6 +50,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - `JavaStr::from_env` has been removed because it was unsound (it could cause undefined behavior and was not marked `unsafe`). Use `JNIEnv::get_string` or `JNIEnv::get_string_unchecked` instead. ([#510](https://github.com/jni-rs/jni-rs/issues/510) / [#512](https://github.com/jni-rs/jni-rs/pull/512))
 - `JavaStr::get_raw` has been renamed to `as_ptr`. ([#510](https://github.com/jni-rs/jni-rs/issues/510) / [#512](https://github.com/jni-rs/jni-rs/pull/512))
 - `JavaStr`, `JNIStr`, and `JNIString` no longer coerce to `CStr`, because using `CStr::to_str` will often have incorrect results. You can still get a `CStr`, but must use the new `as_cstr` method to do so. ([#510](https://github.com/jni-rs/jni-rs/issues/510) / [#512](https://github.com/jni-rs/jni-rs/pull/512))
+- `JNIEnv::get_string` performance is improved by caching an expensive class lookup, and using a faster instanceof check.
 
 ### Fixed
 - `JNIEnv::get_string` no longer leaks local references. ([#528](https://github.com/jni-rs/jni-rs/pull/528), [#557](https://github.com/jni-rs/jni-rs/pull/557))
@@ -57,6 +59,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixes
 - Compilation is fixed for architectures with a C ABI that has unsigned `char` types. ([#419](https://github.com/jni-rs/jni-rs/pull/419))
+- `JNIEnv::get_string` no longer leaks local references. ([#528](https://github.com/jni-rs/jni-rs/pull/528))
 
 ## [0.21.0] — 2023-02-13
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,7 @@ java-locator = { version = "0.1", optional = true }
 jni-sys = "0.4"
 libloading = { version = "0.8", optional = true }
 log = "0.4.4"
+once_cell = "1.19.0"
 static_assertions = "1"
 thiserror = "2"
 

--- a/src/wrapper/jnienv.rs
+++ b/src/wrapper/jnienv.rs
@@ -9,6 +9,7 @@ use std::{
 };
 
 use jni_sys::jobject;
+use once_cell::sync::OnceCell;
 
 use crate::{
     descriptors::Desc,
@@ -1904,10 +1905,9 @@ impl<'local> JNIEnv<'local> {
     ///
     /// # Performance
     ///
-    /// This function has a large relative performance impact compared to
-    /// [`get_string_unchecked`][Self::get_string_unchecked]. For example it
-    /// may be about five times slower than `get_string_unchecked` for a very
-    /// short string. This performance penalty comes from the extra validation
+    /// This function has some relative performance impact compared to
+    /// [`get_string_unchecked`][Self::get_string_unchecked].
+    /// This performance penalty comes from the extra validation
     /// performed by this function. If and only if you can guarantee that your
     /// `obj` is of the class `java.lang.String`, use `get_string_unchecked` to
     /// skip this extra validation.
@@ -1919,10 +1919,13 @@ impl<'local> JNIEnv<'local> {
         &mut self,
         obj: &'obj_ref JString<'other_local>,
     ) -> Result<JavaStr<'local, 'other_local, 'obj_ref>> {
-        let string_class = AutoLocal::new(self.find_class("java/lang/String")?, self);
-        let obj_class = self.get_object_class(obj)?;
-        let obj_class = self.auto_local(obj_class);
-        if !self.is_assignable_from(string_class, obj_class)? {
+        static STRING_CLASS: OnceCell<GlobalRef> = OnceCell::new();
+        let string_class = STRING_CLASS.get_or_try_init(|| {
+            let string_class_local = self.find_class("java/lang/String")?;
+            self.new_global_ref(string_class_local)
+        })?;
+
+        if !self.is_instance_of(obj, string_class)? {
             return Err(JniCall(JniError::InvalidArguments));
         }
 


### PR DESCRIPTION
## Overview

(Sorry for the false start in #530)

Speeds up `get_string` in two ways:

1. Cache the `java/lang/String` class instead of calling `FindClass` repeatedly.
2. Use `IsInstanceOf` instead of `GetObjectClass` + `IsAssignableFrom`. `java/lang/String` is final, so these are equivalent.

Running the benchmark on my machine, change 1:

```
jni_get_string          time:   [445.86 ns 448.89 ns 454.23 ns]
                        change: [-53.617% -45.104% -39.388%] (p = 0.00 < 0.05)
                        Performance has improved.
```

Changes 1+2:
```
jni_get_string          time:   [406.30 ns 406.37 ns 406.45 ns]
                        change: [-9.6565% -9.1695% -8.8758%] (p = 0.00 < 0.05)
                        Performance has improved.
```

Fixes #529. Also incidentally fixes #527.

Add new dependency to changelog

**Questions/notes**

* I don't write Rust, so sorry if I made any basic errors.
* I tried to use `std::OnceLock`, but `get_or_try_init` is not yet stable, and I couldn't find a neat way to handle errors, hence pulling in `once_cell`. Open to ideas here.
* Let me know your thoughts on the changelog and doc changes.

Thanks!

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Change is covered by [automated tests](https://github.com/jni-rs/jni-rs/blob/master/CONTRIBUTING.md#tests)
- [x] The [coding guidelines](https://github.com/jni-rs/jni-rs/blob/master/CONTRIBUTING.md#the-code-style) are followed
- [x] Public API has documentation
- [x] User-visible changes are mentioned in the Changelog
- [ ] The continuous integration build passes
  - TBD 