### PR TITLE
Fix deprecated `crate_type` in the Cargo.toml file of the example directory

### DIFF
--- a/example/mylib/Cargo.toml
+++ b/example/mylib/Cargo.toml
@@ -8,4 +8,4 @@ edition = "2021"
 jni = { path = "../../" }
 
 [lib]
-crate_type = ["cdylib"]
+crate-type = ["cdylib"]


### PR DESCRIPTION
## Overview

This pull request updates the `Cargo.toml` file in the example directory to replace the deprecated `crate_type` field with the correct `crate-type` notation. This change is in accordance with the latest Cargo specifications to eliminate warnings and ensure compatibility with future versions.

```shell
> cd example
> make
cd mylib && cargo build
warning: `crate_type` is deprecated in favor of `crate-type` and will not work in the 2024 edition
(in the `mylib` library target)
...
```

Fixes: #545

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Change is covered by [automated tests](https://github.com/jni-rs/jni-rs/blob/master/CONTRIBUTING.md#tests)
- [x] The [coding guidelines](https://github.com/jni-rs/jni-rs/blob/master/CONTRIBUTING.md#the-code-style) are followed
- [ ] Public API has documentation
- [ ] User-visible changes are mentioned in the Changelog
- [ ] The continuous integration build passes
