### PR TITLE
Bump thiserror to v2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,7 @@ jni-sys = "0.4"
 libloading = { version = "0.8", optional = true }
 log = "0.4.4"
 static_assertions = "1"
-thiserror = "1.0.20"
+thiserror = "2.0.0"
 
 [build-dependencies]
 walkdir = "2"


### PR DESCRIPTION
## Overview

This bumps `thiserror` to v2, removing the duplicate dependency with thiserror v1 when using popular crates like `rustls-platform-verifier`.

### Definition of Done

- [ ] There are no TODOs left in the code
- [ ] Change is covered by [automated tests](https://github.com/jni-rs/jni-rs/blob/master/CONTRIBUTING.md#tests)
- [ ] The [coding guidelines](https://github.com/jni-rs/jni-rs/blob/master/CONTRIBUTING.md#the-code-style) are followed
- [ ] Public API has documentation
- [ ] User-visible changes are mentioned in the Changelog
- [ ] The continuous integration build passes
