### PR TITLE
In `JavaVM::{new,with_libjvm}`, prevent libjvm from being unloaded.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - `JNIEnv::fatal_error` is now guaranteed not to panic or allocate, but requires the error message to be encoded ahead of time. ([#480](https://github.com/jni-rs/jni-rs/pull/480))
 - `JNIEnv::get_native_interface` has been removed since it's redundant and `JNIEnv::get_raw` is more consistent with other APIs.
 - `JavaVM::get_java_vm_pointer` has been renamed `JavaVM::get_raw` for consistency.
+- `JavaVM::new` and `JavaVM::with_libjvm` now prevent libjvm from being unloaded. This isn't necessary for HotSpot, but other JVMs could crash if we don't do this. ([#554](https://github.com/jni-rs/jni-rs/pull/554))
 
 ### Added
 - New functions for converting Rust `char` to and from Java `char` and `int` ([#427](https://github.com/jni-rs/jni-rs/issues/427) / [#434](https://github.com/jni-rs/jni-rs/pull/434))


### PR DESCRIPTION
## Overview

If libjvm is unloaded while it's running, the process will crash as soon as the JVM tries to do anything, since all of its code has been unloaded. `JavaVM::{new,with_libjvm}` does indeed unload libjvm, by dropping the `libloading::Library` that was used to load it. This PR solves that problem by using `std::mem::forget` on `libloading::Library`, which prevents libjvm from ever being unloaded.

Somehow, HotSpot seems to prevent itself from being unloaded. That's why our tests weren't failing. But I have no idea how it's doing that. See discussion in #550. In any case, other JVMs might not prevent themselves from being unloaded, so they could still crash.

It would be ideal if we could unload libjvm in `JavaVM::destroy`, but we can't. The `JavaVM` structure is `repr(transparent)`, so we can't store the `libloading::Library` there, nor does JNI offer any other place to store it. So, this PR plays it safe by simply preventing libjvm from being unloaded at all.

**Question:** Does `JavaVM` actually need to be `repr(transparent)`? If not, then we could store the `libloading::Library` inside it, and unload it in `JavaVM::destroy`.

Fixes #550

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Change is covered by [automated tests](https://github.com/jni-rs/jni-rs/blob/master/CONTRIBUTING.md#tests)
- [x] The [coding guidelines](https://github.com/jni-rs/jni-rs/blob/master/CONTRIBUTING.md#the-code-style) are followed
- [x] Public API has documentation
- [x] User-visible changes are mentioned in the Changelog
- [ ] The continuous integration build passes
