### PR TITLE
Fix a local reference leak in `JNIEnv::get_string`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,7 +51,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - `JavaStr`, `JNIStr`, and `JNIString` no longer coerce to `CStr`, because using `CStr::to_str` will often have incorrect results. You can still get a `CStr`, but must use the new `as_cstr` method to do so. ([#510](https://github.com/jni-rs/jni-rs/issues/510) / [#512](https://github.com/jni-rs/jni-rs/pull/512))
 
 ### Fixed
-- `JNIEnv::get_string` no longer leaks local references. ([#527](https://github.com/jni-rs/jni-rs/issues/527))
+- `JNIEnv::get_string` no longer leaks local references. ([#528](https://github.com/jni-rs/jni-rs/pull/528), [#557](https://github.com/jni-rs/jni-rs/pull/557))
 
 ## [0.21.1] — 2023-03-08
 

--- a/src/wrapper/jnienv.rs
+++ b/src/wrapper/jnienv.rs
@@ -1921,6 +1921,7 @@ impl<'local> JNIEnv<'local> {
     ) -> Result<JavaStr<'local, 'other_local, 'obj_ref>> {
         let string_class = AutoLocal::new(self.find_class("java/lang/String")?, self);
         let obj_class = self.get_object_class(obj)?;
+        let obj_class = self.auto_local(obj_class);
         if !self.is_assignable_from(string_class, obj_class)? {
             return Err(JniCall(JniError::InvalidArguments));
         }


### PR DESCRIPTION
## Overview

This PR fixes a leak of local references in `JNIEnv::get_string`. Specifically, it does a `find_class` and does not delete the resulting `JClass`.

Fixes #556

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Change is covered by [automated tests](https://github.com/jni-rs/jni-rs/blob/master/CONTRIBUTING.md#tests)
- [x] The [coding guidelines](https://github.com/jni-rs/jni-rs/blob/master/CONTRIBUTING.md#the-code-style) are followed
- [x] Public API has documentation
- [x] User-visible changes are mentioned in the Changelog
- [x] The continuous integration build passes
