### PR TITLE
Bump `windows-sys` version to `0.59.0`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,7 +46,7 @@ lazy_static = "1"
 rusty-fork = "0.3.0"
 
 [target.'cfg(windows)'.dependencies]
-windows-sys = { version = "0.48.0", features = ["Win32_Globalization"] }
+windows-sys = { version = "0.59.0", features = ["Win32_Globalization"] }
 
 [target.'cfg(windows)'.dev-dependencies]
 bytemuck = "1.13.0"


### PR DESCRIPTION
## Overview

<!-- Please describe your changes here and list any open questions you might have. -->
Bump `windows-sys` version to `0.59.0`

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Change is covered by [automated tests](https://github.com/jni-rs/jni-rs/blob/master/CONTRIBUTING.md#tests)
- [x] The [coding guidelines](https://github.com/jni-rs/jni-rs/blob/master/CONTRIBUTING.md#the-code-style) are followed
- [x] Public API has documentation
- [x] User-visible changes are mentioned in the Changelog
- [x] The continuous integration build passes
