### PR TITLE
Improve JNIEnv lifetime in with_local_frame

### DIFF
--- a/src/wrapper/jnienv.rs
+++ b/src/wrapper/jnienv.rs
@@ -1033,7 +1033,7 @@ impl<'local> JNIEnv<'local> {
     /// [`GlobalRef`] / [`Self::make_global`].
     pub fn with_local_frame<F, T, E>(&mut self, capacity: i32, f: F) -> std::result::Result<T, E>
     where
-        F: FnOnce(&mut JNIEnv) -> std::result::Result<T, E>,
+        F: FnOnce(&mut JNIEnv<'local>) -> std::result::Result<T, E>,
         E: From<Error>,
     {
         unsafe {


### PR DESCRIPTION
This tied the `JNIEnv` lifetime with the lifetime of the `JniEnv` itself instead of the `&self` lifetime