### PR TITLE
Add wrappers for ToReflectedMethod

### DIFF
--- a/src/wrapper/jnienv.rs
+++ b/src/wrapper/jnienv.rs
@@ -2548,6 +2548,53 @@ impl<'local> JNIEnv<'local> {
         }
     }
 
+    /// Convert a [`JMethodID`] into a [`JObject`] with the corresponding
+    /// `java.lang.reflect.Method` or `java.lang.reflect.Constructor` instance.
+    pub fn to_reflected_method<'other_local>(
+        &mut self,
+        class: impl Desc<'local, JClass<'other_local>>,
+        method_id: impl Desc<'local, JMethodID>,
+    ) -> Result<JObject<'local>> {
+        self.to_reflected_method_base(class, method_id, JMethodID::into_raw, false)
+    }
+
+    /// Convert a [`JStaticMethodID`] into a [`JObject`] with the corresponding
+    /// `java.lang.reflect.Method` instance.
+    pub fn to_reflected_static_method<'other_local>(
+        &mut self,
+        class: impl Desc<'local, JClass<'other_local>>,
+        method_id: impl Desc<'local, JStaticMethodID>,
+    ) -> Result<JObject<'local>> {
+        self.to_reflected_method_base(class, method_id, JStaticMethodID::into_raw, true)
+    }
+
+    fn to_reflected_method_base<'other_local, M>(
+        &mut self,
+        class: impl Desc<'local, JClass<'other_local>>,
+        method_id: impl Desc<'local, M>,
+        to_jmethodid: impl FnOnce(M) -> crate::sys::jmethodID,
+        is_static: bool,
+    ) -> Result<JObject<'local>>
+    where
+        M: Copy,
+    {
+        let class = class.lookup(self)?;
+
+        let method_id = to_jmethodid(*method_id.lookup(self)?.as_ref());
+
+        unsafe {
+            jni_call_check_ex_and_null_ret!(
+                self,
+                v1_2,
+                ToReflectedMethod,
+                class.as_ref().as_raw(),
+                method_id,
+                is_static
+            )
+            .map(|jobject| JObject::from_raw(jobject))
+        }
+    }
+
     /// Get a field without checking the provided type against the actual field.
     ///
     /// # Safety

--- a/tests/jni_api.rs
+++ b/tests/jni_api.rs
@@ -474,6 +474,77 @@ pub fn call_static_method_with_bad_args_errs() {
 }
 
 #[test]
+pub fn get_reflected_method_from_id() {
+    let mut env = attach_current_thread();
+
+    let ctor_method_id = env
+        .get_method_id(INTEGER_CLASS, "<init>", "(Ljava/lang/String;)V")
+        .expect("constructor from string exists");
+    let ctor = env
+        .to_reflected_method(INTEGER_CLASS, ctor_method_id)
+        .unwrap();
+
+    let value = {
+        let jstr = env.new_string("55").unwrap();
+        let vargs = env
+            .new_object_array(1, "java/lang/Object", jstr)
+            .expect("can create array");
+
+        env.call_method(
+            ctor,
+            "newInstance",
+            "([Ljava/lang/Object;)Ljava/lang/Object;",
+            &[JValue::from(&vargs)],
+        )
+        .expect("can invoke Constructor.newInstance")
+        .l()
+        .expect("return value is an Integer")
+    };
+
+    let int_value = env
+        .call_method(value, "intValue", "()I", &[])
+        .unwrap()
+        .i()
+        .unwrap();
+    assert_eq!(int_value, 55);
+}
+
+#[test]
+pub fn get_reflected_static_method_from_id() {
+    let mut env = attach_current_thread();
+
+    let x = JValue::from(-10);
+    let math_class = env.find_class(MATH_CLASS).unwrap();
+    let abs_method_id = env
+        .get_static_method_id(&math_class, MATH_ABS_METHOD_NAME, MATH_ABS_SIGNATURE)
+        .unwrap();
+
+    let abs_method = env
+        .to_reflected_static_method(&math_class, abs_method_id)
+        .unwrap();
+
+    let arg = env.new_object(INTEGER_CLASS, "(I)V", &[x]).unwrap();
+    let vargs = env.new_object_array(1, "java/lang/Object", arg).unwrap();
+    let val = env
+        .call_method(
+            abs_method,
+            "invoke",
+            "(Ljava/lang/Object;[Ljava/lang/Object;)Ljava/lang/Object;",
+            &[JValue::from(&JObject::null()), JValue::from(&vargs)],
+        )
+        .expect("can call Method.invoke")
+        .l()
+        .expect("return value is an int");
+    let val = env
+        .call_method(val, "intValue", "()I", &[])
+        .unwrap()
+        .i()
+        .unwrap();
+
+    assert_eq!(val, 10);
+}
+
+#[test]
 pub fn java_byte_array_from_slice() {
     let env = attach_current_thread();
     let buf: &[u8] = &[1, 2, 3];


### PR DESCRIPTION
## Overview

Add methods to JNIEnv that allow retrieving a JObject representing the java.lang.reflect.Method or java.lang.reflect.Constructor for a JMethodID or JStaticMethodID.

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Change is covered by [automated tests](https://github.com/jni-rs/jni-rs/blob/master/CONTRIBUTING.md#tests)
- [x] The [coding guidelines](https://github.com/jni-rs/jni-rs/blob/master/CONTRIBUTING.md#the-code-style) are followed
- [x] Public API has documentation
- [ ] User-visible changes are mentioned in the Changelog
- [ ] The continuous integration build passes
