### PR TITLE
Specify platform-independent alternative to LD_LIBRARY_PATH

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -143,10 +143,9 @@
 //! That's it! Build your crate and try to run your Java class again.
 //!
 //! ... Same error as before you say? Well that's because JVM is looking for
-//! `mylib` in all the wrong places. This will differ by platform thanks to
-//! different linker/loader semantics, but on Linux, you can simply `export
-//! LD_LIBRARY_PATH=/path/to/mylib/target/debug`. Now, you should get the
-//! expected output `Hello, josh!` from your Java class.
+//! `mylib` in all the wrong places. To tell it where to look you can pass 
+//! this argument to `java`: `-Djava.library.path=/path/to/mylib/target/debug`.
+//! Now, you should get the expected output `Hello, josh!` from your Java class.
 //!
 //! ## Launching JVM from Rust
 //!


### PR DESCRIPTION
## Overview

<!-- Please describe your changes here and list any open questions you might have. -->

### Definition of Done

- [ ] There are no TODOs left in the code
- [ ] Change is covered by [automated tests](https://github.com/jni-rs/jni-rs/blob/master/CONTRIBUTING.md#tests)
- [ ] The [coding guidelines](https://github.com/jni-rs/jni-rs/blob/master/CONTRIBUTING.md#the-code-style) are followed
- [ ] Public API has documentation
- [ ] User-visible changes are mentioned in the Changelog
- [ ] The continuous integration build passes
