### PR TITLE
Add `JavaVM::singleton()` getter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - `JNIEnv::call_nonvirtual_method` and `JNIEnv::call_nonvirtual_method_unchecked` to call non-virtual method. ([#454](https://github.com/jni-rs/jni-rs/issues/454))
 - `JavaStr`, `JNIStr`, and `JNIString` have several new methods and traits, most notably a `to_str` method that converts to a regular Rust string. ([#510](https://github.com/jni-rs/jni-rs/issues/510) / [#512](https://github.com/jni-rs/jni-rs/pull/512))
 - Added dependency on `once_cell` version `1.19.0` for lazy initialization in `JNIEnv::get_string`.
+- `JavaVM::singleton()` lets you acquire the `JavaVM` for the process when you know that the `JavaVM` singleton has been initialized
 
 ### Changed
 - `JValueGen` has been removed. `JValue` and `JValueOwned` are now separate, unrelated, non-generic types. ([#429](https://github.com/jni-rs/jni-rs/pull/429))

--- a/benches/api_calls.rs
+++ b/benches/api_calls.rs
@@ -320,7 +320,7 @@ fn jni_get_java_vm(c: &mut Criterion) {
 
     c.bench_function("jni_get_java_vm", |b| {
         b.iter(|| {
-            let _jvm = env.get_java_vm().unwrap();
+            let _jvm = env.get_java_vm();
         })
     });
 }

--- a/example/mylib/src/lib.rs
+++ b/example/mylib/src/lib.rs
@@ -150,7 +150,7 @@ pub extern "system" fn Java_HelloWorld_asyncComputation(
     // `JNIEnv` cannot be sent across thread boundaries. To be able to use JNI
     // functions in other threads, we must first obtain the `JavaVM` interface
     // which, unlike `JNIEnv` is `Send`.
-    let jvm = env.get_java_vm().unwrap();
+    let jvm = env.get_java_vm();
 
     // We need to obtain global reference to the `callback` object before sending
     // it to the thread, to prevent it from being collected by the GC.

--- a/src/wrapper/errors.rs
+++ b/src/wrapper/errors.rs
@@ -15,6 +15,8 @@ use crate::objects::{char_from_java_int, char_to_java, char_to_java_int, JValue,
 #[derive(Debug, Error)]
 #[non_exhaustive]
 pub enum Error {
+    #[error("JavaVM singleton uninitialized")]
+    UninitializedJavaVM,
     #[error("Invalid JValue type cast: {0}. Actual type: {1}")]
     WrongJValueType(&'static str, &'static str),
     #[error("Invalid constructor return type (must be void)")]


### PR DESCRIPTION
Since merging #531 we have committed to assuming that the JVM is a singleton that can never be unloaded/reloaded and these updated implementations.

Currently there are various places where we save temporary vm pointers (such as GlobalRef) that shouldn't be necessary if we can instead assume a VM must have already been initialized and its pointer is available globally.

This adds a `JavaVM::singleton()` API that can `clone()` a lazily initialized `JavaVM` stored in a static variable.

Currently `JavaVM::singleton()` is initialized when `JavaVM::from_raw` is called (which is used internally whenever we create a `JavaVM` wrapper).

As follows ups, the plan is:

- To ensure that `JNIEnv` depends on `JavaVM::singleton` being initialized (so it's easy for code to depend on `JavaVM::singleton` once they have observed a `JNIEnv` pointer)
- Update APIs like `GlobalRef` and `WeakRef` so they don't need to save an internal `JavaVM` pointer for their `Drop` implementations.

For now, code that has access to JNIEnv can ensure that JavaVM::singleton() is initialized by doing:

```rust
let _vm = env.get_java_vm();
```

For now the new `::singleton()` API isn't required internally but this PR lays groundwork for https://github.com/jni-rs/jni-rs/pull/570 and helps factor out at least one orthogonal change from the much more complex PR.

## Overview

<!-- Please describe your changes here and list any open questions you might have. -->

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Change is covered by [automated tests](https://github.com/jni-rs/jni-rs/blob/master/CONTRIBUTING.md#tests)
- [x] The [coding guidelines](https://github.com/jni-rs/jni-rs/blob/master/CONTRIBUTING.md#the-code-style) are followed
- [x] Public API has documentation
- [x] User-visible changes are mentioned in the Changelog
- [x] The continuous integration build passes
