### PR TITLE
Global/WeakRef: simpler reference wrappers that don't erase types

### DIFF
--- a/benches/api_calls.rs
+++ b/benches/api_calls.rs
@@ -397,11 +397,14 @@ fn jni_with_local_frame_returning_global_to_local(c: &mut Criterion) {
     c.bench_function("jni_with_local_frame_returning_global_to_local", |b| {
         b.iter(|| {
             let global = env
-                .with_local_frame::<_, GlobalRef, jni::errors::Error>(LOCAL_FRAME_SIZE, |env| {
-                    let local = env.new_object(&class, SIG_OBJECT_CTOR, &[])?;
-                    let global = env.new_global_ref(local)?;
-                    Ok(global)
-                })
+                .with_local_frame::<_, GlobalRef<JObject<'static>>, jni::errors::Error>(
+                    LOCAL_FRAME_SIZE,
+                    |env| {
+                        let local = env.new_object(&class, SIG_OBJECT_CTOR, &[])?;
+                        let global = env.new_global_ref(local)?;
+                        Ok(global)
+                    },
+                )
                 .unwrap();
             let _local = env.new_local_ref(global).unwrap();
         })

--- a/example/mylib/src/lib.rs
+++ b/example/mylib/src/lib.rs
@@ -86,11 +86,11 @@ pub extern "system" fn Java_HelloWorld_factAndCallMeBack(
 
 struct Counter {
     count: i32,
-    callback: GlobalRef,
+    callback: GlobalRef<JObject<'static>>,
 }
 
 impl Counter {
-    pub fn new(callback: GlobalRef) -> Counter {
+    pub fn new(callback: GlobalRef<JObject<'static>>) -> Counter {
         Counter {
             count: 0,
             callback: callback,

--- a/src/wrapper/descriptors/class_desc.rs
+++ b/src/wrapper/descriptors/class_desc.rs
@@ -33,7 +33,9 @@ where
 // around `JObject`), but that may change in the future. Moreover, this
 // doesn't check if the global reference actually refers to a
 // `java.lang.Class` object.
-unsafe impl<'local, 'obj_ref> Desc<'local, JClass<'static>> for &'obj_ref GlobalRef {
+unsafe impl<'local, 'obj_ref> Desc<'local, JClass<'static>>
+    for &'obj_ref GlobalRef<JClass<'static>>
+{
     type Output = &'obj_ref JClass<'static>;
 
     fn lookup(self, _: &mut JNIEnv<'local>) -> Result<Self::Output> {

--- a/src/wrapper/descriptors/exception_desc.rs
+++ b/src/wrapper/descriptors/exception_desc.rs
@@ -1,7 +1,7 @@
 use crate::{
     descriptors::Desc,
     errors::*,
-    objects::{AutoLocal, JClass, JObject, JThrowable, JValue},
+    objects::{AutoLocal, JClass, JString, JThrowable, JValue},
     strings::JNIString,
     JNIEnv,
 };
@@ -16,7 +16,7 @@ where
     type Output = AutoLocal<'local, JThrowable<'local>>;
 
     fn lookup(self, env: &mut JNIEnv<'local>) -> Result<Self::Output> {
-        let jmsg: AutoLocal<JObject> = env.auto_local(env.new_string(self.1)?.into());
+        let jmsg: AutoLocal<JString> = env.auto_local(env.new_string(self.1)?);
         let obj: JThrowable = env
             .new_object(self.0, "(Ljava/lang/String;)V", &[JValue::from(&jmsg)])?
             .into();

--- a/src/wrapper/errors.rs
+++ b/src/wrapper/errors.rs
@@ -23,6 +23,8 @@ pub enum Error {
     InvalidCtorReturn,
     #[error("Invalid number or type of arguments passed to java method: {0}")]
     InvalidArgList(TypeSignature),
+    #[error("Object behind weak reference freed")]
+    ObjectFreed,
     #[error("Method not found: {name} {sig}")]
     MethodNotFound { name: String, sig: String },
     #[error("Field not found: {name} {sig}")]

--- a/src/wrapper/objects/auto_local.rs
+++ b/src/wrapper/objects/auto_local.rs
@@ -4,7 +4,11 @@ use std::{
     ptr,
 };
 
+use jni_sys::jobject;
+
 use crate::{objects::JObject, JNIEnv};
+
+use super::JObjectRef;
 
 /// Auto-delete wrapper for local refs.
 ///
@@ -145,5 +149,25 @@ where
 {
     fn deref_mut(&mut self) -> &mut Self::Target {
         &mut self.obj
+    }
+}
+
+impl<'local, T> JObjectRef for AutoLocal<'local, T>
+where
+    T: JObjectRef + Into<JObject<'local>>,
+{
+    type Kind<'env> = T::Kind<'env>;
+    type GlobalKind = T::GlobalKind;
+
+    fn as_raw(&self) -> jobject {
+        self.obj.as_raw()
+    }
+
+    unsafe fn from_local_raw<'env>(local_ref: jobject) -> Self::Kind<'env> {
+        T::from_local_raw(local_ref)
+    }
+
+    unsafe fn from_global_raw(global_ref: jobject) -> Self::GlobalKind {
+        T::from_global_raw(global_ref)
     }
 }

--- a/src/wrapper/objects/jclass.rs
+++ b/src/wrapper/objects/jclass.rs
@@ -1,5 +1,5 @@
 use crate::{
-    objects::JObject,
+    objects::{JObject, JObjectRef},
     sys::{jclass, jobject},
 };
 
@@ -73,5 +73,22 @@ impl JClass<'_> {
     /// Unwrap to the raw jni type.
     pub const fn into_raw(self) -> jclass {
         self.0.into_raw() as jclass
+    }
+}
+
+impl JObjectRef for JClass<'_> {
+    type Kind<'env> = JClass<'env>;
+    type GlobalKind = JClass<'static>;
+
+    fn as_raw(&self) -> jobject {
+        self.0.as_raw()
+    }
+
+    unsafe fn from_local_raw<'env>(local_ref: jobject) -> Self::Kind<'env> {
+        JClass::from_raw(local_ref)
+    }
+
+    unsafe fn from_global_raw(global_ref: jobject) -> Self::GlobalKind {
+        JClass::from_raw(global_ref)
     }
 }

--- a/src/wrapper/objects/jobject_ref.rs
+++ b/src/wrapper/objects/jobject_ref.rs
@@ -1,0 +1,101 @@
+use jni_sys::jobject;
+
+use crate::objects::JObject;
+
+#[cfg(doc)]
+use crate::objects::{AutoLocal, GlobalRef, JString};
+
+/// A trait for types that represents a JNI reference (could be local, global or
+/// weak global as well as wrapper types like [`AutoLocal`] and [`GlobalRef`])
+///
+///
+/// This makes it possible for APIs like [`JNIEnv::new_global_ref`] to be given
+/// a non-static local reference type like [`JString<'local>`] (or an
+/// [`AutoLocal`] wrapper) and return a [`GlobalRef`] that is instead
+/// parameterized by [`JString<'static>`].
+pub trait JObjectRef: Sized {
+    /// The generic associated [`Self::Kind`] type corresponds to the underlying
+    /// class type (such as [`JObject`] or [`JString`]), parameterized by the
+    /// lifetime that indicates whether the type holds a global reference
+    /// (`'static`) or a local reference that's tied to a JNI stack frame.
+    type Kind<'local>: JObjectRef + Default + Into<JObject<'local>> + AsRef<JObject<'local>>;
+    // XXX: the compiler blows up if we try and specify a Send + Sync bound
+    // here: "overflow evaluating the requirement..."
+    //where
+    //    Self::Kind<'static>: Send + Sync;
+    //
+    // As a workaround, we have a separate associated type
+
+    /// The associated `GlobalKind` type should be equivalent to
+    /// `Kind<'static>`, with the additional bound that ensures the type is
+    /// `Send + Sync`
+    type GlobalKind: JObjectRef
+        + Default
+        + Into<JObject<'static>>
+        + AsRef<JObject<'static>>
+        + Send
+        + Sync;
+
+    /// Returns the underlying, raw [`crate::sys::jobject`] reference.
+    fn as_raw(&self) -> jobject;
+
+    /// Returns `true` if this is a `null` object reference
+    fn is_null(&self) -> bool {
+        self.as_raw().is_null()
+    }
+
+    /// Returns `null` reference based on [`Self::Kind`]
+    fn null<'any>() -> Self::Kind<'any> {
+        Self::Kind::default()
+    }
+
+    /// Returns a new reference type based on [`Self::Kind`] for the given `local_ref` that is
+    /// tied to the JNI stack frame for the given lifetime.
+    ///
+    /// # Safety
+    ///
+    /// The given lifetime must associated with an AttachGuard or a JNIEnv and represent a
+    /// JNI stack frame.
+    ///
+    /// There must not be no other wrapper for the given `local_ref` reference (unless it is
+    /// `null`)
+    ///
+    /// You are responsible to knowing that `Self::Kind` is a suitable wrapper type for the
+    /// given `local_ref` reference. E.g. because the `local_ref` came from an `into_raw`
+    /// call from the same type.
+    ///
+    unsafe fn from_local_raw<'env>(local_ref: jobject) -> Self::Kind<'env>;
+
+    /// Returns a (`'static`) reference type based on [`Self::GlobalKind`] for the given `global_ref`.
+    ///
+    /// # Safety
+    ///
+    /// There must not be no other wrapper for the given `global_ref` reference (unless it is
+    /// `null`)
+    ///
+    /// You are responsible to knowing that `Self::GlobalKind` is a suitable wrapper type for the
+    /// given `global_ref` reference. E.g. because the `global_ref` came from an `into_raw`
+    /// call from the same type.
+    ///
+    unsafe fn from_global_raw(global_ref: jobject) -> Self::GlobalKind;
+}
+
+impl<T> JObjectRef for &T
+where
+    T: JObjectRef,
+{
+    type Kind<'local> = T::Kind<'local>;
+    type GlobalKind = T::GlobalKind;
+
+    fn as_raw(&self) -> jobject {
+        (*self).as_raw()
+    }
+
+    unsafe fn from_local_raw<'env>(local_ref: jobject) -> Self::Kind<'env> {
+        T::from_local_raw(local_ref)
+    }
+
+    unsafe fn from_global_raw(global_ref: jobject) -> Self::GlobalKind {
+        T::from_global_raw(global_ref)
+    }
+}

--- a/src/wrapper/objects/jstring.rs
+++ b/src/wrapper/objects/jstring.rs
@@ -3,6 +3,8 @@ use crate::{
     sys::{jobject, jstring},
 };
 
+use super::JObjectRef;
+
 /// Lifetime'd representation of a `jstring`. Just a `JObject` wrapped in a new
 /// class.
 #[repr(transparent)]
@@ -66,5 +68,22 @@ impl JString<'_> {
     /// Unwrap to the raw jni type.
     pub const fn into_raw(self) -> jstring {
         self.0.into_raw() as jstring
+    }
+}
+
+impl JObjectRef for JString<'_> {
+    type Kind<'env> = JString<'env>;
+    type GlobalKind = JString<'static>;
+
+    fn as_raw(&self) -> jobject {
+        self.0.as_raw()
+    }
+
+    unsafe fn from_local_raw<'env>(local_ref: jobject) -> Self::Kind<'env> {
+        JString::from_raw(local_ref)
+    }
+
+    unsafe fn from_global_raw(global_ref: jobject) -> Self::GlobalKind {
+        JString::from_raw(global_ref)
     }
 }

--- a/src/wrapper/objects/jthrowable.rs
+++ b/src/wrapper/objects/jthrowable.rs
@@ -3,6 +3,8 @@ use crate::{
     sys::{jobject, jthrowable},
 };
 
+use super::JObjectRef;
+
 /// Lifetime'd representation of a `jthrowable`. Just a `JObject` wrapped in a
 /// new class.
 #[repr(transparent)]
@@ -66,5 +68,22 @@ impl JThrowable<'_> {
     /// Unwrap to the raw jni type.
     pub const fn into_raw(self) -> jthrowable {
         self.0.into_raw() as jthrowable
+    }
+}
+
+impl JObjectRef for JThrowable<'_> {
+    type Kind<'env> = JThrowable<'env>;
+    type GlobalKind = JThrowable<'static>;
+
+    fn as_raw(&self) -> jobject {
+        self.0.as_raw()
+    }
+
+    unsafe fn from_local_raw<'env>(local_ref: jobject) -> Self::Kind<'env> {
+        JThrowable::from_raw(local_ref)
+    }
+
+    unsafe fn from_global_raw(global_ref: jobject) -> Self::GlobalKind {
+        JThrowable::from_raw(global_ref)
     }
 }

--- a/src/wrapper/objects/mod.rs
+++ b/src/wrapper/objects/mod.rs
@@ -14,6 +14,9 @@ pub use self::jfieldid::*;
 mod jstaticfieldid;
 pub use self::jstaticfieldid::*;
 
+mod jobject_ref;
+pub use self::jobject_ref::*;
+
 mod jobject;
 pub use self::jobject::*;
 


### PR DESCRIPTION
A `Global/WeakRef` is now a transparent wrapper over a 'static reference type like `JOBject`, `JClass` or `JString` that is itself a transparent wrapper over a `jni_sys::jobject` pointer.

Both are now parameterized, like `GlobalRef<JClass<'static>>` to preserve the type of reference that a Global or Weak reference represents.

E.g. a `GlobalRef<JClass<'static>>` will now deref to a `&JClass` and can be more easily used with APIs that require a `JClass` reference, or some other specific type of reference.

This introduces a `JObjectRef` trait that deals with mapping the Rust type for a local reference (like `JObject<'local>`) into a corresponding `'static` type that can be used when creating a corresponding Global/Weak reference.

Since we can guarantee that `JavaVM::singleton()` has been initialized at the point that `new_global_ref` or `new_weak_ref` is called we don't need to save a vm pointer internally and can assume it's safe to rely on `JavaVM::singleton()` in the `Drop` implementations (in case a reference is dropped from detached thread).

These types no longer implement `Clone`, since they no longer wrap a heap-allocated Arc around one reference and so copying the reference would involve a JNI call. Although we _could_ potentially use JNI from Clone (Since we can use JavaVM::singleton()) it didn't seem good that this could lead to unpredictable/hidden thread attachments, or potentially trigger some other JNI error that can't be propagated.

Both types now implement `Default`, which correspond to `null()` references.

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Change is covered by [automated tests](https://github.com/jni-rs/jni-rs/blob/master/CONTRIBUTING.md#tests)
- [x] The [coding guidelines](https://github.com/jni-rs/jni-rs/blob/master/CONTRIBUTING.md#the-code-style) are followed
- [x] Public API has documentation
- [x] User-visible changes are mentioned in the Changelog
- [x] The continuous integration build passes

Fixes: #571