### PR TITLE
Implement JObjectRef for JPrimitiveArray and JObjectArray

### DIFF
--- a/src/wrapper/objects/auto_elements.rs
+++ b/src/wrapper/objects/auto_elements.rs
@@ -100,7 +100,7 @@ mod type_array_sealed {
 }
 
 /// A sealed trait to define type array access/release for primitive JNI types
-pub trait TypeArray: type_array_sealed::TypeArraySealed {}
+pub trait TypeArray: type_array_sealed::TypeArraySealed + Send + Sync {}
 
 impl TypeArray for jint {}
 impl TypeArray for jlong {}

--- a/src/wrapper/objects/jobject_array.rs
+++ b/src/wrapper/objects/jobject_array.rs
@@ -1,5 +1,5 @@
 use crate::{
-    objects::JObject,
+    objects::{JObject, JObjectRef},
     sys::{jobject, jobjectArray},
 };
 
@@ -71,5 +71,22 @@ impl JObjectArray<'_> {
     /// Unwrap to the raw jni type.
     pub const fn into_raw(self) -> jobjectArray {
         self.0.into_raw() as jobjectArray
+    }
+}
+
+impl JObjectRef for JObjectArray<'_> {
+    type Kind<'env> = JObjectArray<'env>;
+    type GlobalKind = JObjectArray<'static>;
+
+    fn as_raw(&self) -> jobject {
+        self.0.as_raw()
+    }
+
+    unsafe fn from_local_raw<'env>(local_ref: jobject) -> Self::Kind<'env> {
+        JObjectArray::from_raw(local_ref)
+    }
+
+    unsafe fn from_global_raw(global_ref: jobject) -> Self::GlobalKind {
+        JObjectArray::from_raw(global_ref)
     }
 }


### PR DESCRIPTION
To allow these type to be wrapped in a GlobalRef or AutoLocal, these reference types now implement JObjectRef.

### Definition of Done

- [x] There are no TODOs left in the code
- [ ] Change is covered by [automated tests](https://github.com/jni-rs/jni-rs/blob/master/CONTRIBUTING.md#tests)
- [x] The [coding guidelines](https://github.com/jni-rs/jni-rs/blob/master/CONTRIBUTING.md#the-code-style) are followed
- [x] Public API has documentation
- [x] User-visible changes are mentioned in the Changelog
- [ ] The continuous integration build passes
