### PR TITLE
Remove unused JavaType::Method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - The 'Executor' API has been removed (`AttachGuard::with_env` can be used instead) ([#570](https://github.com/jni-rs/jni-rs/pull/570))
 - `JNIEnv::from_raw`, `JNIEnv::from_raw_unchecked` and `JNIEnv::unsafe_clone` have been removed, since the API no longer exposes the `JNIEnv` type by-value, it must always be borrowed from an `AttachGuard`. ([#570](https://github.com/jni-rs/jni-rs/pull/570))
 - `Error::NullDeref` and `Error::JavaVMMethodNotFound` have been removed since they were unused.
+- `JavaType::Method` was removed since a method signature isn't a type, and all usage was being matched as unreachable or an error.
 
 ### Added
 - New functions for converting Rust `char` to and from Java `char` and `int` ([#427](https://github.com/jni-rs/jni-rs/issues/427) / [#434](https://github.com/jni-rs/jni-rs/pull/434))

--- a/src/wrapper/jnienv.rs
+++ b/src/wrapper/jnienv.rs
@@ -1772,9 +1772,6 @@ impl<'local> JNIEnv<'local> {
             .all(|(exp, act)| match exp {
                 JavaType::Primitive(p) => act.primitive_type() == Some(*p),
                 JavaType::Object(_) | JavaType::Array(_) => act.primitive_type().is_none(),
-                JavaType::Method(_) => {
-                    unreachable!("JavaType::Method(_) should not come from parsing a method sig")
-                }
             });
         if !base_types_match {
             return Err(Error::InvalidArgList(parsed));
@@ -1830,9 +1827,6 @@ impl<'local> JNIEnv<'local> {
             .all(|(exp, act)| match exp {
                 JavaType::Primitive(p) => act.primitive_type() == Some(*p),
                 JavaType::Object(_) | JavaType::Array(_) => act.primitive_type().is_none(),
-                JavaType::Method(_) => {
-                    unreachable!("JavaType::Method(_) should not come from parsing a method sig")
-                }
             });
         if !base_types_match {
             return Err(Error::InvalidArgList(parsed));
@@ -1895,9 +1889,6 @@ impl<'local> JNIEnv<'local> {
             .all(|(exp, act)| match exp {
                 JavaType::Primitive(p) => act.primitive_type() == Some(*p),
                 JavaType::Object(_) | JavaType::Array(_) => act.primitive_type().is_none(),
-                JavaType::Method(_) => {
-                    unreachable!("JavaType::Method(_) should not come from parsing a method sig")
-                }
             });
         if !base_types_match {
             return Err(Error::InvalidArgList(parsed));
@@ -1949,9 +1940,6 @@ impl<'local> JNIEnv<'local> {
                 .all(|(exp, act)| match exp {
                     JavaType::Primitive(p) => act.primitive_type() == Some(*p),
                     JavaType::Object(_) | JavaType::Array(_) => act.primitive_type().is_none(),
-                    JavaType::Method(_) => {
-                        unreachable!("JavaType::Method(_) should not come from parsing a ctor sig")
-                    }
                 });
         if !base_types_match {
             return Err(Error::InvalidArgList(parsed));
@@ -2935,10 +2923,6 @@ impl<'local> JNIEnv<'local> {
             JavaType::Object(_) | JavaType::Array(_) if val_primitive.is_some() => wrong_type,
             JavaType::Primitive(p) if val_primitive != Some(p) => wrong_type,
             JavaType::Primitive(_) if val_primitive.is_none() => wrong_type,
-            JavaType::Method(_) => Err(Error::WrongJValueType(
-                val.type_name(),
-                "cannot set field with method type",
-            )),
             _ => {
                 let class = self.get_object_class(obj)?.auto();
 
@@ -2967,7 +2951,7 @@ impl<'local> JNIEnv<'local> {
         use super::signature::Primitive::{
             Boolean, Byte, Char, Double, Float, Int, Long, Short, Void,
         };
-        use JavaType::{Array, Method, Object, Primitive};
+        use JavaType::{Array, Object, Primitive};
 
         let class = class.lookup(self)?;
         let field = field.lookup(self)?;
@@ -2988,7 +2972,6 @@ impl<'local> JNIEnv<'local> {
 
         let ret = match ty {
             Primitive(Void) => Err(Error::WrongJValueType("void", "see java field")),
-            Method(_) => Err(Error::WrongJValueType("Method", "see java field")),
             Object(_) | Array(_) => {
                 let obj = field!(GetStaticObjectField);
                 let obj = unsafe { JObject::from_raw(obj) };

--- a/src/wrapper/signature.rs
+++ b/src/wrapper/signature.rs
@@ -46,7 +46,6 @@ pub enum JavaType {
     Primitive(Primitive),
     Object(String),
     Array(Box<JavaType>),
-    Method(Box<TypeSignature>),
 }
 
 impl FromStr for JavaType {
@@ -74,7 +73,6 @@ impl fmt::Display for JavaType {
             JavaType::Primitive(ref ty) => ty.fmt(f),
             JavaType::Object(ref name) => write!(f, "L{name};"),
             JavaType::Array(ref ty) => write!(f, "[{ty}"),
-            JavaType::Method(ref m) => m.fmt(f),
         }
     }
 }


### PR DESCRIPTION
Since #599, the `JavaType` `FromStr` parser no longer parses a `TypeSignature` as a type and all references to `JavaType::Method` were either matching it as `unreachable` or treating it as a spurious error case.

