### PR TITLE
Remove special-case (unsafe) `Desc<JClass>` impl for old `GlobalRef`

### DIFF
--- a/src/wrapper/descriptors/class_desc.rs
+++ b/src/wrapper/descriptors/class_desc.rs
@@ -2,7 +2,7 @@ use crate::{
     descriptors::Desc,
     env::JNIEnv,
     errors::*,
-    objects::{AutoLocal, GlobalRef, IntoAutoLocal as _, JClass, JObject},
+    objects::{AutoLocal, IntoAutoLocal as _, JClass},
     strings::JNIString,
 };
 
@@ -17,29 +17,6 @@ where
     }
 }
 
-// Note: We don't implement `Desc<JClass>` for `&JObject` as a transmute like for `GlobalRef`
-//
-// Considering that the APIs that return a class return a `JClass` it shouldn't
-// usually be necessary unless the `JClass` got type erased (like with GlobalRef)
-//
-// Implementing `Desc<JClass>` for `&JObject` as a simple cast would also make
-// it a lot easier to mistakenly pass an object instance in places where a class
-// is required.
-
-// This conversion assumes that the `GlobalRef` is a pointer to a class object.
-
-// TODO: Generify `GlobalRef` and get rid of this `impl`. The transmute is
-// sound-ish at the moment (`JClass` is currently `repr(transparent)`
-// around `JObject`), but that may change in the future. Moreover, this
-// doesn't check if the global reference actually refers to a
-// `java.lang.Class` object.
-unsafe impl<'local, 'obj_ref> Desc<'local, JClass<'static>>
-    for &'obj_ref GlobalRef<JClass<'static>>
-{
-    type Output = &'obj_ref JClass<'static>;
-
-    fn lookup(self, _: &mut JNIEnv<'local>) -> Result<Self::Output> {
-        let obj: &JObject<'static> = self.as_ref();
-        Ok(unsafe { std::mem::transmute::<&JObject<'_>, &JClass<'_>>(obj) })
-    }
-}
+// Note: we don't implement `Desc<JClass>` for `&JObject` as a simple cast would
+// make it a lot easier to mistakenly pass an object instance in places where a
+// class is required.

--- a/src/wrapper/descriptors/desc.rs
+++ b/src/wrapper/descriptors/desc.rs
@@ -1,7 +1,7 @@
 use crate::{
     env::JNIEnv,
     errors::*,
-    objects::{AutoLocal, JObject},
+    objects::{AutoLocal, GlobalRef, JObject, JObjectRef},
 };
 
 #[cfg(doc)]
@@ -129,5 +129,23 @@ where
 
     fn lookup(self, _: &mut JNIEnv<'local>) -> Result<Self::Output> {
         Ok(self)
+    }
+}
+
+unsafe impl<'local, 'obj_ref, T> Desc<'local, T> for &'obj_ref GlobalRef<T>
+where
+    T: JObjectRef
+        + AsRef<T>
+        + AsRef<JObject<'static>>
+        + Into<JObject<'static>>
+        + Default
+        + Send
+        + Sync
+        + 'static,
+{
+    type Output = &'obj_ref T;
+
+    fn lookup(self, _: &mut JNIEnv<'local>) -> Result<Self::Output> {
+        Ok(self.as_ref())
     }
 }

--- a/tests/descriptors.rs
+++ b/tests/descriptors.rs
@@ -1,0 +1,24 @@
+#![cfg(feature = "invocation")]
+
+mod util;
+use util::attach_current_thread;
+
+use jni::{
+    descriptors::Desc,
+    objects::{AutoLocal, JClass},
+};
+
+#[test]
+fn test_descriptors() {
+    attach_current_thread(|env| {
+        let class_local = env.find_class("java/lang/String").unwrap();
+        let class_as_ref = Desc::<JClass>::lookup(&class_local, env).unwrap();
+        let class_global = env.new_global_ref(class_as_ref).unwrap();
+        let _class_as_ref = Desc::<JClass>::lookup(&class_global, env).unwrap();
+        let class_auto: AutoLocal<_> = Desc::<JClass>::lookup("java/lang/String", env).unwrap();
+        let _class_as_ref = Desc::<JClass>::lookup(&class_auto, env).unwrap();
+
+        Ok(())
+    })
+    .unwrap();
+}


### PR DESCRIPTION
Now that `GlobalRef` no longer erases the reference type that it wraps we can have a blanket `Desc<T>` implementation for `&GlobalRef<T>`, like we do for `AutoLocal`. This avoids the `unsafe` `transmute` that was required while `GlobalRef` erased its inner reference type.

