### PR TITLE
Expose `AttachConfig` for controlling thread attachment details

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,6 +86,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - `AttachGuard::from_unowned` added as a low-level (unsafe) way to represent a thread attachment with a raw `jni_sys::JNIEnv` pointer ([#570](https://github.com/jni-rs/jni-rs/pull/570))
 - `AttachConfig` exposes fine-grained control over thread attachment including `Thread` name, `ThreadGroup` and whether scoped or permanent. ([#606](https://github.com/jni-rs/jni-rs/pull/606))
 - `JavaVM::attach_current_thread_guard` is a low-level (unsafe) building block for attaching threads that exposes the `AttachGuard` and `AttachConfig` control. ([#606](https://github.com/jni-rs/jni-rs/pull/606))
+- `JavaVM::attach_current_thread_with_config` is a safe building block for attaching threads that hides the `AttachGuard` but exposes `AttachConfig` control. ([#606](https://github.com/jni-rs/jni-rs/pull/606))
 - `JavaVM::with_env` and `JavaVM::with_env_with_capacity` added as methods to borrow a `JNIEnv` that is already attached to the current thread, after pushing a new JNI stack frame ([#570](https://github.com/jni-rs/jni-rs/pull/570))
 - `JavaVM::with_env_current_frame` added to borrow a `JNIEnv` for the top JNI stack frame (i.e. without pushing a new JNI stack frame) ([#570](https://github.com/jni-rs/jni-rs/pull/570))
 - `JNIEnv::to_reflected_method` and `JNIEnv::to_reflected_static_method` for retrieving the Java reflection API instance for a method or constructor. ([#579](https://github.com/jni-rs/jni-rs/pull/579))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -84,6 +84,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - `JavaVM::is_thread_attached` can query whether the current thread is attached to the Java VM ([#570](https://github.com/jni-rs/jni-rs/pull/570))
 - `JNIEnvUnowned` is an FFI-safe type that can be used to capture a `jni_sys::JNIEnv` pointer given to native methods and give it a named lifetime (this can then be temporarily upgraded to a `&mut JNIEnv` reference via `JNIEnvUnowned::with_env`) ([#570](https://github.com/jni-rs/jni-rs/pull/570))
 - `AttachGuard::from_unowned` added as a low-level (unsafe) way to represent a thread attachment with a raw `jni_sys::JNIEnv` pointer ([#570](https://github.com/jni-rs/jni-rs/pull/570))
+- `AttachConfig` exposes fine-grained control over thread attachment including `Thread` name, `ThreadGroup` and whether scoped or permanent. ([#606](https://github.com/jni-rs/jni-rs/pull/606))
+- `JavaVM::attach_current_thread_guard` is a low-level (unsafe) building block for attaching threads that exposes the `AttachGuard` and `AttachConfig` control. ([#606](https://github.com/jni-rs/jni-rs/pull/606))
 - `JavaVM::with_env` and `JavaVM::with_env_with_capacity` added as methods to borrow a `JNIEnv` that is already attached to the current thread, after pushing a new JNI stack frame ([#570](https://github.com/jni-rs/jni-rs/pull/570))
 - `JavaVM::with_env_current_frame` added to borrow a `JNIEnv` for the top JNI stack frame (i.e. without pushing a new JNI stack frame) ([#570](https://github.com/jni-rs/jni-rs/pull/570))
 - `JNIEnv::to_reflected_method` and `JNIEnv::to_reflected_static_method` for retrieving the Java reflection API instance for a method or constructor. ([#579](https://github.com/jni-rs/jni-rs/pull/579))

--- a/tests/threads_attach_config.rs
+++ b/tests/threads_attach_config.rs
@@ -1,0 +1,45 @@
+#![cfg(feature = "invocation")]
+
+use std::thread::spawn;
+
+use jni::{objects::JString, AttachConfig};
+
+mod util;
+use util::jvm;
+
+// Tests that an `AttachConfig` can be used to configure the name of the JVM `Thread`
+#[test]
+fn attach_config() {
+    let jvm = jvm();
+
+    let thread = spawn({
+        move || {
+            jvm.attach_current_thread_with_config(
+                || AttachConfig::new().name("test-thread"),
+                None,
+                |env| -> jni::errors::Result<_> {
+                    // Get the current Thread and query the name
+                    let thread = env
+                        .call_static_method(
+                            "java/lang/Thread",
+                            "currentThread",
+                            "()Ljava/lang/Thread;",
+                            &[],
+                        )
+                        .unwrap()
+                        .l()
+                        .unwrap();
+                    let name: JString = env
+                        .call_method(thread, "getName", "()Ljava/lang/String;", &[])?
+                        .l()?
+                        .into();
+                    let name = env.get_string(&name)?;
+                    assert_eq!(name.as_cstr(), c"test-thread");
+                    Ok(())
+                },
+            )
+        }
+    });
+
+    let _ = thread.join().unwrap();
+}


### PR DESCRIPTION
An `AttachConfig` enables control over the `Thread` name in the JVM as well as the `ThreadGroup` that the thread is associated with.

`AttachConfig` can also configure whether the attachment is `scoped` or not, which controls whether we create a permanent TLS attachment or an `AttachGuard::from_owned` attachment that will detach when dropped.

This adds a low-level (`unsafe`) `attach_current_thread_guard` API and a safe `attach_current_thread_with_config` wrapper API that both accept an `AttachConfig`.

`attach_current_thread_guard` provides a lower-level escape hatch that gives full control over the thread attachment but is `unsafe` because it also directly exposes the `AttachGuard` that the caller must manage safely.

This also adds a safe `attach_current_thread_with_config` wrapper that hides the `AttachGuard` but still exposes the `AttachConfig` and lets the caller control whether a new JNI stack frame should be created before calling their closure.

The API is a little less ergonomic than `attach_current_thread` but exposes full control over the attachment while still being safe.

`attach_current_thread_with_config` is now used in the implementation of both `attach_current_thread` and `attach_current_thread_for_scope`

A unit test has been added that demonstrates setting and verifying the `Thread` name when attaching a thread.

Fixes: #268
Fixes: #543
Addresses: #488

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Change is covered by [automated tests](https://github.com/jni-rs/jni-rs/blob/master/CONTRIBUTING.md#tests)
- [x] The [coding guidelines](https://github.com/jni-rs/jni-rs/blob/master/CONTRIBUTING.md#the-code-style) are followed
- [x] Public API has documentation
- [x] User-visible changes are mentioned in the Changelog
- [x] The continuous integration build passes
