### PR TITLE
Simplify JavaType to not capture Object + Array details (unused)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - `JNIEnv::define_class` takes a `name: Option<>` instead of having a separate `define_unnamed_class` API.
 - `JNIEnv::define_class_bytearray` was renamed to `JNIEnv::define_class_jbyte` and is identical to `define_class` except for taking a `&[jbyte]` slice instead of `&[u8]`, which is a convenience if you have a `JByteArray` or `AutoElements<JByteArray>`.
 - `AutoElements` was simplified to only be parameterized by one lifetime for the array reference, and accepts any `AsRef<JPrimitiveArray<T>>` as a reference. ([#508](https://github.com/jni-rs/jni-rs/pull/508))
+- `JavaType` was simplified to not capture object names or array details (like `ReturnType`) since these details don't affect `JValue` type checks and had a hidden cost that was redundant.
 
 ### Removed
 - `JavaVM::attach_current_thread_as_daemon` (and general support for 'daemon' threads) has been removed, since their semantics are inherently poorly defined and unsafe (the distinction relates to the poorly defined limbo state after calling `JavaDestroyVM`, where it becomes undefined to touch the JVM) ([#593](https://github.com/jni-rs/jni-rs/pull/593))

--- a/src/wrapper/jnienv.rs
+++ b/src/wrapper/jnienv.rs
@@ -1527,7 +1527,7 @@ impl<'local> JNIEnv<'local> {
         use super::signature::Primitive::{
             Boolean, Byte, Char, Double, Float, Int, Long, Short, Void,
         };
-        use ReturnType::{Array, Object, Primitive};
+        use JavaType::{Array, Object, Primitive};
 
         let class = class.lookup(self)?;
 
@@ -1605,7 +1605,7 @@ impl<'local> JNIEnv<'local> {
         use super::signature::Primitive::{
             Boolean, Byte, Char, Double, Float, Int, Long, Short, Void,
         };
-        use ReturnType::{Array, Object, Primitive};
+        use JavaType::{Array, Object, Primitive};
 
         let method_id = method_id.lookup(self)?.as_ref().into_raw();
 
@@ -1673,7 +1673,7 @@ impl<'local> JNIEnv<'local> {
         use super::signature::Primitive::{
             Boolean, Byte, Char, Double, Float, Int, Long, Short, Void,
         };
-        use ReturnType::{Array, Object, Primitive};
+        use JavaType::{Array, Object, Primitive};
 
         let method_id = method_id.lookup(self)?.as_ref().into_raw();
         let class = class.lookup(self)?;
@@ -1766,7 +1766,7 @@ impl<'local> JNIEnv<'local> {
             .zip(args.iter())
             .all(|(exp, act)| match exp {
                 JavaType::Primitive(p) => act.primitive_type() == Some(*p),
-                JavaType::Object(_) | JavaType::Array(_) => act.primitive_type().is_none(),
+                JavaType::Object | JavaType::Array => act.primitive_type().is_none(),
             });
         if !base_types_match {
             return Err(Error::InvalidArgList(parsed));
@@ -1821,7 +1821,7 @@ impl<'local> JNIEnv<'local> {
             .zip(args.iter())
             .all(|(exp, act)| match exp {
                 JavaType::Primitive(p) => act.primitive_type() == Some(*p),
-                JavaType::Object(_) | JavaType::Array(_) => act.primitive_type().is_none(),
+                JavaType::Object | JavaType::Array => act.primitive_type().is_none(),
             });
         if !base_types_match {
             return Err(Error::InvalidArgList(parsed));
@@ -1883,7 +1883,7 @@ impl<'local> JNIEnv<'local> {
             .zip(args.iter())
             .all(|(exp, act)| match exp {
                 JavaType::Primitive(p) => act.primitive_type() == Some(*p),
-                JavaType::Object(_) | JavaType::Array(_) => act.primitive_type().is_none(),
+                JavaType::Object | JavaType::Array => act.primitive_type().is_none(),
             });
         if !base_types_match {
             return Err(Error::InvalidArgList(parsed));
@@ -1934,7 +1934,7 @@ impl<'local> JNIEnv<'local> {
                 .zip(ctor_args.iter())
                 .all(|(exp, act)| match exp {
                     JavaType::Primitive(p) => act.primitive_type() == Some(*p),
-                    JavaType::Object(_) | JavaType::Array(_) => act.primitive_type().is_none(),
+                    JavaType::Object | JavaType::Array => act.primitive_type().is_none(),
                 });
         if !base_types_match {
             return Err(Error::InvalidArgList(parsed));
@@ -2845,7 +2845,7 @@ impl<'local> JNIEnv<'local> {
         use super::signature::Primitive::{
             Boolean, Byte, Char, Double, Float, Int, Long, Short, Void,
         };
-        use ReturnType::{Array, Object, Primitive};
+        use JavaType::{Array, Object, Primitive};
 
         let obj = obj.as_ref();
         let obj = null_check!(obj, "get_field_typed obj argument")?;
@@ -2979,7 +2979,7 @@ impl<'local> JNIEnv<'local> {
         let wrong_type = Err(Error::WrongJValueType(val.type_name(), "see java field"));
 
         match field_ty {
-            JavaType::Object(_) | JavaType::Array(_) if val_primitive.is_some() => wrong_type,
+            JavaType::Object | JavaType::Array if val_primitive.is_some() => wrong_type,
             JavaType::Primitive(p) if val_primitive != Some(p) => wrong_type,
             JavaType::Primitive(_) if val_primitive.is_none() => wrong_type,
             _ => {
@@ -3031,7 +3031,7 @@ impl<'local> JNIEnv<'local> {
 
         let ret = match ty {
             Primitive(Void) => Err(Error::WrongJValueType("void", "see java field")),
-            Object(_) | Array(_) => {
+            Object | Array => {
                 let obj = field!(GetStaticObjectField);
                 let obj = unsafe { JObject::from_raw(obj) };
                 Ok(JValueOwned::from(obj))


### PR DESCRIPTION
There was a redundant cost associated with tracking lots of heap allocated Strings for `JavaType::Object` names as well as `Box<>`ing all the type information for `JavaType::Array` elements.

In practice JNI only really needs to be able to differentiate primitive types and reference types and doesn't ever need to know the class type details, except when the signature strings are used for method ID lookups.

When we check that `JValue` types match a signature we were ignoring the extra details for `Object` and `Array` types.

`ReturnType` is now an alias for `JavaType` and it would probably make sense to migrate all APIs to use `JavaType` directly and just leave ReturnType as a deprecated alias.

Benchmark results with this change, for JNI calls:

```
jni_call_static_abs_method_safe
                        time:   [848.96 ns 849.61 ns 850.29 ns]
                        change: [-6.3767% -6.2255% -6.0593%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 8 outliers among 100 measurements (8.00%)
  2 (2.00%) low mild
  4 (4.00%) high mild
  2 (2.00%) high severe

jni_call_static_abs_method_unchecked_str
                        time:   [392.39 ns 392.63 ns 392.91 ns]
                        change: [-2.6014% -2.5046% -2.3942%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 3 outliers among 100 measurements (3.00%)
  3 (3.00%) high severe

jni_call_static_abs_method_unchecked_jclass
                        time:   [93.632 ns 93.681 ns 93.730 ns]
                        change: [-2.2758% -2.1803% -2.0923%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 1 outliers among 100 measurements (1.00%)
  1 (1.00%) low mild

jni_call_static_date_time_method_safe
                        time:   [1.4292 µs 1.4318 µs 1.4352 µs]
                        change: [-12.195% -11.572% -10.890%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 13 outliers among 100 measurements (13.00%)
  1 (1.00%) low mild
  5 (5.00%) high mild
  7 (7.00%) high severe

jni_call_static_date_time_method_unchecked_jclass
                        time:   [162.18 ns 162.43 ns 162.71 ns]
                        change: [+0.2313% +0.5647% +0.9108%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 6 outliers among 100 measurements (6.00%)
  3 (3.00%) high mild
  3 (3.00%) high severe

jni_call_object_hash_method_safe
                        time:   [482.89 ns 483.26 ns 483.72 ns]
                        change: [-6.3748% -6.2237% -6.0736%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 6 outliers among 100 measurements (6.00%)
  3 (3.00%) high mild
  3 (3.00%) high severe

jni_call_object_hash_method_unchecked
                        time:   [96.500 ns 96.594 ns 96.702 ns]
                        change: [-4.8300% -4.6026% -4.3562%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 6 outliers among 100 measurements (6.00%)
  3 (3.00%) high mild
  3 (3.00%) high severe
```

Fixes: #499
Closes: #534

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Change is covered by [automated tests](https://github.com/jni-rs/jni-rs/blob/master/CONTRIBUTING.md#tests)
- [x] The [coding guidelines](https://github.com/jni-rs/jni-rs/blob/master/CONTRIBUTING.md#the-code-style) are followed
- [x] Public API has documentation
- [x] User-visible changes are mentioned in the Changelog
- [x] The continuous integration build passes
