### PR TITLE
Generalize class + methodID caching + enable safe downcasting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -92,13 +92,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `JavaVM::with_env` and `JavaVM::with_env_with_capacity` added as methods to borrow a `JNIEnv` that is already attached to the current thread, after pushing a new JNI stack frame ([#570](https://github.com/jni-rs/jni-rs/pull/570))
 - `JavaVM::with_env_current_frame` added to borrow a `JNIEnv` for the top JNI stack frame (i.e. without pushing a new JNI stack frame) ([#570](https://github.com/jni-rs/jni-rs/pull/570))
 - `JNIEnv::to_reflected_method` and `JNIEnv::to_reflected_static_method` for retrieving the Java reflection API instance for a method or constructor. ([#579](https://github.com/jni-rs/jni-rs/pull/579))
-- `JNIStr` now implements `Debug`, `PartialEq`, `Eq`, `PartialOrd`, `Ord` and `Hash`
-- `JNIString` now implements `Debug`, `PartialEq`, `Eq`, `PartialOrd`, `Ord`, `Hash` and `Clone`
-- `PartialEq<&JNIStr> for JNIString` allows `JNIStr` and `JNIString` to be compared.
-- `From<&JNIStr>` and `From<JavaStr>` implementations for `JNIString`.
+- `JNIStr` now implements `Debug`, `PartialEq`, `Eq`, `PartialOrd`, `Ord` and `Hash` ([#615](https://github.com/jni-rs/jni-rs/pull/615))
+- `JNIString` now implements `Debug`, `PartialEq`, `Eq`, `PartialOrd`, `Ord`, `Hash` and `Clone` ([#615](https://github.com/jni-rs/jni-rs/pull/615))
+- `PartialEq<&JNIStr> for JNIString` allows `JNIStr` and `JNIString` to be compared. ([#615](https://github.com/jni-rs/jni-rs/pull/615))
+- `From<&JNIStr>` and `From<JavaStr>` implementations for `JNIString`. ([#615](https://github.com/jni-rs/jni-rs/pull/615))
 - `JNIStr::from_cstr` safely does a zero-copy cast of a `CStr` to a `JNIStr` after a `const` modified-utf8 encoding validation (with a panic on failure)
-- `AsRef<JNIStr>` is implemented for `CStr` (based on `JNIStr::from_cstr`) allows use of literals like `c"java/lang/Foo"` to be passed to JNI APIs without needing to be copied.
-- `JNIStr::to_bytes` gives access to a `&[u8]` slice over the bytes of a JNI string (like `CStr::to_bytes`)
+- `AsRef<JNIStr>` is implemented for `CStr` (based on `JNIStr::from_cstr`) allows use of literals like `c"java/lang/Foo"` to be passed to JNI APIs without needing to be copied. ([#615](https://github.com/jni-rs/jni-rs/pull/615))
+- `JNIStr::to_bytes` gives access to a `&[u8]` slice over the bytes of a JNI string (like `CStr::to_bytes`) ([#615](https://github.com/jni-rs/jni-rs/pull/615))
+- `JThread` as a `JObjectRef` wrapper for `java.lang.Thread` references ([#612](https://github.com/jni-rs/jni-rs/pull/612))
+- `JClassLoader` as a `JObjectRef` wrapper for `java.lang.ClassLoader` references ([#612](https://github.com/jni-rs/jni-rs/pull/612))
+- `LoaderContext` + `LoaderContext::load_class` for loading classes, depending on available context ([#612](https://github.com/jni-rs/jni-rs/pull/612))
+- `JObjectRef::load_class` exposes a cached `GlobalRef<JClass>` for all `JObjectRef` implementations ([#612](https://github.com/jni-rs/jni-rs/pull/612))
+- `JNIEnv::new_cast_global_ref` acts like `new_global_ref` with a type cast ([#612](https://github.com/jni-rs/jni-rs/pull/612))
+- `JNIEnv::cast_global` takes an owned `GlobalRef<From>` and returns a `GlobalRef<To>` ([#612](https://github.com/jni-rs/jni-rs/pull/612))
+- `JNIEnv::new_cast_local_ref` acts like `new_local_ref` with a type cast ([#612](https://github.com/jni-rs/jni-rs/pull/612))
+- `JNIEnv::cast_local` takes an owned local reference and returns a newly type cast wrapper ([#612](https://github.com/jni-rs/jni-rs/pull/612))
+- `JNIEnv::as_cast` borrows any `From: JObjectRef` (global or local) reference and returns  a `Cast<To>` that will Deref into `&To` ([#612](https://github.com/jni-rs/jni-rs/pull/612))
 
 ### Fixed
 - `JNIEnv::get_string` no longer leaks local references. ([#528](https://github.com/jni-rs/jni-rs/pull/528), [#557](https://github.com/jni-rs/jni-rs/pull/557))

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,7 @@ log = "0.4.4"
 once_cell = "1.19.0"
 static_assertions = "1"
 thiserror = "2"
+paste = "1"
 
 [build-dependencies]
 walkdir = "2"

--- a/benches/api_calls.rs
+++ b/benches/api_calls.rs
@@ -386,7 +386,7 @@ fn jni_get_string_unchecked(c: &mut Criterion) {
 
         c.bench_function("jni_get_string_unchecked", |b| {
             b.iter(|| {
-                let s: String = unsafe { env.get_string_unchecked(&string) }.unwrap().into();
+                let s: String = env.get_string(&string).unwrap().into();
                 assert_eq!(s, TEST_STRING_UNICODE);
             })
         });

--- a/src/wrapper/descriptors/exception_desc.rs
+++ b/src/wrapper/descriptors/exception_desc.rs
@@ -2,7 +2,7 @@ use crate::{
     descriptors::Desc,
     env::JNIEnv,
     errors::*,
-    objects::{AutoLocal, IntoAutoLocal as _, JClass, JThrowable, JValue},
+    objects::{AutoLocal, IntoAutoLocal as _, JClass, JObject, JThrowable, JValue},
     strings::JNIString,
 };
 
@@ -16,12 +16,11 @@ where
     type Output = AutoLocal<'local, JThrowable<'local>>;
 
     fn lookup(self, env: &mut JNIEnv<'local>) -> Result<Self::Output> {
-        //let guard = unsafe { JavaVM::get_env_attachment() };
         let jmsg = env.new_string(self.1)?.auto();
-        let obj: JThrowable = env
-            .new_object(self.0, "(Ljava/lang/String;)V", &[JValue::from(&jmsg)])?
-            .into();
-        Ok(obj.auto())
+        let obj: JObject =
+            env.new_object(self.0, "(Ljava/lang/String;)V", &[JValue::from(&jmsg)])?;
+        let throwable = env.cast_local::<JThrowable>(obj)?;
+        Ok(throwable.auto())
     }
 }
 

--- a/src/wrapper/errors.rs
+++ b/src/wrapper/errors.rs
@@ -19,12 +19,16 @@ pub enum Error {
     UninitializedJavaVM,
     #[error("Invalid JValue type cast: {0}. Actual type: {1}")]
     WrongJValueType(&'static str, &'static str),
+    #[error("Invalid object type")]
+    WrongObjectType,
     #[error("Invalid constructor return type (must be void)")]
     InvalidCtorReturn,
     #[error("Invalid number or type of arguments passed to java method: {0}")]
     InvalidArgList(TypeSignature),
     #[error("Object behind weak reference freed")]
     ObjectFreed,
+    #[error("Class not found: {name:?}")]
+    ClassNotFound { name: &'static str },
     #[error("Method not found: {name} {sig}")]
     MethodNotFound { name: String, sig: String },
     #[error("Field not found: {name} {sig}")]

--- a/src/wrapper/macros.rs
+++ b/src/wrapper/macros.rs
@@ -16,9 +16,8 @@ macro_rules! jni_call_unchecked {
 
 /// Calls a JNIEnv function, then checks for a pending exception
 ///
-/// This only checks for an exception, it doesn't map an exception into
-/// an Error and it doesn't clear the exception and so the exception will
-/// be thrown if the native code returns to the JVM.
+/// This only checks for an exception, it doesn't clear the exception and so the
+/// exception will be thrown if the native code returns to the JVM.
 ///
 /// Returns `Err` if there is a pending exception after the call.
 macro_rules! jni_call_check_ex {

--- a/src/wrapper/objects/cast.rs
+++ b/src/wrapper/objects/cast.rs
@@ -1,0 +1,113 @@
+use std::{marker::PhantomData, ops::Deref};
+
+use crate::{
+    env::JNIEnv,
+    errors::{Error, Result},
+    objects::{JObject, JObjectRef},
+};
+
+/// Represents a runtime checked (via `IsInstanceOf`) cast of a reference from one type to another
+///
+/// This borrows a reference and implements `Deref` for the target type.
+///
+/// This can be used to cast global or local references.
+///
+/// See: [JNIEnv::as_cast]
+///
+#[repr(transparent)]
+pub struct Cast<'any, 'from, To: JObjectRef> {
+    _from: PhantomData<&'from JObject<'any>>,
+
+    // SAFETY: We know that this hidden wrapper has no `Drop` side effects,
+    // since that's a pre-condition for implementing `JObjectRef`
+    to: To::Kind<'any>,
+}
+
+impl<'any, 'from, To: JObjectRef> Cast<'any, 'from, To> {
+    /// Creates a new cast from one object type to another.
+    ///
+    /// This can be used to cast global or local references.
+    ///
+    /// Returns [Error::WrongObjectType] if the object is not of the expected type.
+    pub(crate) fn new<'env_local, From: JObjectRef + AsRef<JObject<'any>>>(
+        from: &'from From,
+        env: &JNIEnv<'env_local>,
+    ) -> Result<Self>
+    where
+        'any: 'from,
+    {
+        let from: &JObject = from.as_ref();
+        if from.is_null() {
+            return Ok(Self {
+                _from: PhantomData,
+                to: To::null(),
+            });
+        }
+
+        if env.is_instance_of_cast_type::<To>(from)? {
+            // Safety:
+            // - We have just checked that `from` is an instance of `T`
+            // - Although we are creating a second wrapper for the raw reference, we will be
+            //   borrowing the original wrapper (so the caller won't own two wrappers around the
+            //   same reference) and this wrapper will be hidden.
+            // - A pre-condition of `JObjectRef` is that `T::Kind` must not have any `Drop` side
+            //   effects so we don't have to worry that creating a second wrapper could lead to a
+            //   double free when dropped.
+            // - We're allowed to potentially create a `JObject::Kind` wrapper for a `'static`
+            //   global reference in this situation where we're not giving ownership of the cast
+            //   wrapper and we're borrowing from the original reference.
+            unsafe {
+                Ok(Self {
+                    _from: PhantomData,
+                    to: To::from_raw::<'any>(from.as_raw()),
+                })
+            }
+        } else {
+            Err(Error::WrongObjectType)
+        }
+    }
+
+    /// Creates a new cast from one object type to another without a runtime check.
+    ///
+    /// # Safety
+    ///
+    /// The caller must ensure that `from` is an instance of `To`.
+    pub unsafe fn new_unchecked<'env_local, From: JObjectRef + AsRef<JObject<'any>>>(
+        from: &'from From,
+    ) -> Self
+    where
+        'any: 'from,
+    {
+        // Safety:
+        // - The caller has promised that `from` is an instance of `T`, or null
+        // - Although we are creating a second wrapper for the raw reference, we will be
+        //   borrowing the original wrapper (so the caller won't own two wrappers around the
+        //   same reference) and this wrapper will be hidden.
+        // - A pre-condition of `JObjectRef` is that `T::Kind` must not have any `Drop` side
+        //   effects so we don't have to worry that creating a second wrapper could lead to a
+        //   double free when dropped.
+        // - We're allowed to potentially create a `JObject::Kind` wrapper for a `'static`
+        //   global reference in this situation where we're not giving ownership of the cast
+        //   wrapper and we're borrowing from the original reference.
+        unsafe {
+            Self {
+                _from: PhantomData,
+                to: To::from_raw::<'any>(from.as_raw()),
+            }
+        }
+    }
+}
+
+impl<'local, 'from, To: JObjectRef> Deref for Cast<'local, 'from, To> {
+    type Target = To::Kind<'local>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.to
+    }
+}
+
+impl<'local, 'from, To: JObjectRef> AsRef<To::Kind<'local>> for Cast<'local, 'from, To> {
+    fn as_ref(&self) -> &To::Kind<'local> {
+        &self.to
+    }
+}

--- a/src/wrapper/objects/jclass_loader.rs
+++ b/src/wrapper/objects/jclass_loader.rs
@@ -1,0 +1,163 @@
+use std::ops::Deref;
+
+use once_cell::sync::OnceCell;
+
+use crate::{
+    env::JNIEnv,
+    errors::Result,
+    objects::{GlobalRef, JClass, JMethodID, JObject, JValue, LoaderContext},
+    signature::JavaType,
+    strings::JNIStr,
+    sys::{jclass, jobject},
+    JavaVM,
+};
+
+use super::JObjectRef;
+
+/// A `java.lang.ClassLoader` reference
+#[repr(transparent)]
+#[derive(Debug, Default)]
+pub struct JClassLoader<'local>(JObject<'local>);
+
+impl<'local> AsRef<JClassLoader<'local>> for JClassLoader<'local> {
+    fn as_ref(&self) -> &JClassLoader<'local> {
+        self
+    }
+}
+
+impl<'local> AsRef<JObject<'local>> for JClassLoader<'local> {
+    fn as_ref(&self) -> &JObject<'local> {
+        self
+    }
+}
+
+impl<'local> ::std::ops::Deref for JClassLoader<'local> {
+    type Target = JObject<'local>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl<'local> From<JClassLoader<'local>> for JObject<'local> {
+    fn from(other: JClassLoader<'local>) -> JObject<'local> {
+        other.0
+    }
+}
+
+struct JClassLoaderAPI {
+    class: GlobalRef<JClass<'static>>,
+    load_class_method: JMethodID,
+}
+
+impl JClassLoaderAPI {
+    fn get(vm: &JavaVM) -> Result<&'static Self> {
+        static JCLASS_LOADER_API: OnceCell<JClassLoaderAPI> = OnceCell::new();
+        JCLASS_LOADER_API.get_or_try_init(|| {
+            vm.with_env_current_frame(|env| {
+                // NB: Self::CLASS_NAME is a binary name with dots, not slashes
+                let class = env.find_class("java/lang/ClassLoader")?;
+                let class = env.new_global_ref(&class).unwrap();
+                let load_class_method = env.get_method_id(
+                    &class,
+                    "loadClass",
+                    "(Ljava/lang/String;)Ljava/lang/Class;",
+                )?;
+                Ok(Self {
+                    class,
+                    load_class_method,
+                })
+            })
+        })
+    }
+}
+
+impl JClassLoader<'_> {
+    /// Creates a [`JClass`] that wraps the given `raw` [`jclass`]
+    ///
+    /// # Safety
+    ///
+    /// `raw` may be a null pointer. If `raw` is not a null pointer, then:
+    ///
+    /// * `raw` must be a valid raw JNI local reference.
+    /// * There must not be any other `JObject` representing the same local reference.
+    /// * The lifetime `'local` must not outlive the local reference frame that the local reference
+    ///   was created in.
+    pub const unsafe fn from_raw(raw: jclass) -> Self {
+        Self(JObject::from_raw(raw as jobject))
+    }
+
+    /// Returns the raw JNI pointer.
+    pub const fn as_raw(&self) -> jclass {
+        self.0.as_raw() as jclass
+    }
+
+    /// Unwrap to the raw jni type.
+    pub const fn into_raw(self) -> jclass {
+        self.0.into_raw() as jclass
+    }
+
+    /// Loads a class by name using this class loader.
+    ///
+    /// This is a Java method binding for `java.lang.ClassLoader.loadClass(String)`.
+    ///
+    /// # Throws
+    ///
+    /// `ClassNotFoundException` if the class cannot be found.
+    pub fn load_class<'local>(
+        &self,
+        name: &JNIStr,
+        env: &mut JNIEnv<'local>,
+    ) -> Result<JClass<'local>> {
+        let vm = env.get_java_vm();
+        let api = JClassLoaderAPI::get(&vm)?;
+
+        let name = env.new_string(name)?;
+
+        // SAFETY:
+        // - we know that `self` is a valid `JClassLoader` reference and `load_class_method` is a valid method ID.
+        // - we know that `loadClass` returns a valid `Class` reference.
+        let cls_obj = unsafe {
+            let cls = env
+                .call_method_unchecked(
+                    self,
+                    api.load_class_method,
+                    JavaType::Object,
+                    &[JValue::Object(&name).as_jni()],
+                )?
+                .l()?;
+            JClass::from_raw(cls.into_raw())
+        };
+        Ok(cls_obj)
+    }
+}
+
+// SAFETY: JClassLoader is a transparent JObject wrapper with no Drop side effects
+unsafe impl JObjectRef for JClassLoader<'_> {
+    const CLASS_NAME: &'static str = "java.lang.ClassLoader";
+
+    type Kind<'env> = JClassLoader<'env>;
+    type GlobalKind = JClassLoader<'static>;
+
+    fn as_raw(&self) -> jobject {
+        self.0.as_raw()
+    }
+
+    fn lookup_class<'vm>(
+        vm: &'vm JavaVM,
+        _loader_context: LoaderContext,
+    ) -> crate::errors::Result<impl Deref<Target = GlobalRef<JClass<'static>>> + 'vm> {
+        // As a special-case; we ignore loader_context just to be clear that there's no risk of
+        // recursion. (`LoaderContext::load_class` depends on the `JClassLoaderAPI`)
+        let api = JClassLoaderAPI::get(vm)?;
+        Ok(&api.class)
+    }
+
+    unsafe fn from_raw<'env>(local_ref: jobject) -> Self::Kind<'env> {
+        JClassLoader::from_raw(local_ref)
+    }
+
+    unsafe fn from_global_raw(global_ref: jobject) -> Self::GlobalKind {
+        JClassLoader::from_raw(global_ref)
+    }
+}

--- a/src/wrapper/objects/jstring.rs
+++ b/src/wrapper/objects/jstring.rs
@@ -1,6 +1,13 @@
+use std::ops::Deref;
+
+use once_cell::sync::OnceCell;
+
 use crate::{
-    objects::JObject,
+    env::JNIEnv,
+    errors::Result,
+    objects::{GlobalRef, JClass, JMethodID, JObject, LoaderContext},
     sys::{jobject, jstring},
+    JavaVM,
 };
 
 use super::JObjectRef;
@@ -37,16 +44,31 @@ impl<'local> From<JString<'local>> for JObject<'local> {
     }
 }
 
-impl<'local> From<JObject<'local>> for JString<'local> {
-    fn from(other: JObject) -> Self {
-        unsafe { Self::from_raw(other.into_raw()) }
-    }
+struct JStringAPI {
+    class: GlobalRef<JClass<'static>>,
+    intern_method: JMethodID,
 }
 
-impl<'local, 'obj_ref> From<&'obj_ref JObject<'local>> for &'obj_ref JString<'local> {
-    fn from(other: &'obj_ref JObject<'local>) -> Self {
-        // Safety: `JString` is `repr(transparent)` around `JObject`.
-        unsafe { &*(other as *const JObject<'local> as *const JString<'local>) }
+impl JStringAPI {
+    fn get<'any_local>(
+        vm: &JavaVM,
+        loader_context: &LoaderContext<'any_local, '_>,
+    ) -> Result<&'static Self> {
+        static JSTRING_API: OnceCell<JStringAPI> = OnceCell::new();
+        JSTRING_API.get_or_try_init(|| {
+            vm.with_env_current_frame(|env| {
+                let class = loader_context.load_class_for_type::<JString>(true, env)?;
+                let class = env.new_global_ref(&class).unwrap();
+                let intern_method = env
+                    .get_method_id(&class, "intern", "()Ljava/lang/String;")
+                    .expect("JString.intern method not found");
+
+                Ok(Self {
+                    class,
+                    intern_method,
+                })
+            })
+        })
     }
 }
 
@@ -69,9 +91,33 @@ impl JString<'_> {
     pub const fn into_raw(self) -> jstring {
         self.0.into_raw() as jstring
     }
+
+    /// Returns a canonical, interned version of this string.
+    pub fn intern<'local>(&self, env: &mut JNIEnv<'local>) -> Result<JString<'local>> {
+        let vm = env.get_java_vm();
+        let api = JStringAPI::get(&vm, &LoaderContext::None)?;
+
+        // Safety: We know that `intern` is a valid method on `java/lang/String` that has no
+        // arguments and it returns a valid `String` instance.
+        let interned = unsafe {
+            let interned = env
+                .call_method_unchecked(
+                    self,
+                    api.intern_method,
+                    crate::signature::ReturnType::Object,
+                    &[],
+                )?
+                .l()?;
+            JString::from_raw(interned.into_raw() as jstring)
+        };
+        Ok(interned)
+    }
 }
 
-impl JObjectRef for JString<'_> {
+// SAFETY: JString is a transparent JObject wrapper with no Drop side effects
+unsafe impl JObjectRef for JString<'_> {
+    const CLASS_NAME: &'static str = "java.lang.String";
+
     type Kind<'env> = JString<'env>;
     type GlobalKind = JString<'static>;
 
@@ -79,7 +125,15 @@ impl JObjectRef for JString<'_> {
         self.0.as_raw()
     }
 
-    unsafe fn from_local_raw<'env>(local_ref: jobject) -> Self::Kind<'env> {
+    fn lookup_class<'vm>(
+        vm: &'vm JavaVM,
+        loader_context: LoaderContext,
+    ) -> crate::errors::Result<impl Deref<Target = GlobalRef<JClass<'static>>> + 'vm> {
+        let api = JStringAPI::get(vm, &loader_context)?;
+        Ok(&api.class)
+    }
+
+    unsafe fn from_raw<'env>(local_ref: jobject) -> Self::Kind<'env> {
         JString::from_raw(local_ref)
     }
 

--- a/src/wrapper/objects/jthread.rs
+++ b/src/wrapper/objects/jthread.rs
@@ -1,0 +1,217 @@
+use std::ops::Deref;
+
+use once_cell::sync::OnceCell;
+
+use crate::{
+    env::JNIEnv,
+    errors::Result,
+    objects::{
+        GlobalRef, JClass, JClassLoader, JMethodID, JObject, JStaticMethodID, JValue, LoaderContext,
+    },
+    sys::{jobject, jthrowable},
+    JavaVM,
+};
+
+use super::JObjectRef;
+
+/// Lifetime'd representation of a `jthrowable`. Just a `JObject` wrapped in a
+/// new class.
+#[repr(transparent)]
+#[derive(Default)]
+pub struct JThread<'local>(JObject<'local>);
+
+impl<'local> AsRef<JThread<'local>> for JThread<'local> {
+    fn as_ref(&self) -> &JThread<'local> {
+        self
+    }
+}
+
+impl<'local> AsRef<JObject<'local>> for JThread<'local> {
+    fn as_ref(&self) -> &JObject<'local> {
+        self
+    }
+}
+
+impl<'local> ::std::ops::Deref for JThread<'local> {
+    type Target = JObject<'local>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl<'local> From<JThread<'local>> for JObject<'local> {
+    fn from(other: JThread) -> JObject {
+        other.0
+    }
+}
+
+struct JThreadAPI {
+    class: GlobalRef<JClass<'static>>,
+    current_thread_method: JStaticMethodID,
+    get_context_class_loader_method: JMethodID,
+    set_context_class_loader_method: JMethodID,
+}
+impl JThreadAPI {
+    fn get(vm: &JavaVM) -> Result<&'static Self> {
+        static JTHREAD_API: OnceCell<JThreadAPI> = OnceCell::new();
+        JTHREAD_API.get_or_try_init(|| {
+            vm.with_env_current_frame(|env| {
+                // NB: Self::CLASS_NAME is a binary name with dots, not slashes
+                let class = env.find_class("java/lang/Thread")?;
+                let class = env.new_global_ref(&class).unwrap();
+                let current_thread_method = env
+                    .get_static_method_id(&class, "currentThread", "()Ljava/lang/Thread;")
+                    .expect("Thread.currentThread method not found");
+                let get_context_class_loader_method = env
+                    .get_method_id(&class, "getContextClassLoader", "()Ljava/lang/ClassLoader;")
+                    .expect("Thread.getContextClassLoader method not found");
+                let set_context_class_loader_method = env
+                    .get_method_id(
+                        &class,
+                        "setContextClassLoader",
+                        "(Ljava/lang/ClassLoader;)V",
+                    )
+                    .expect("Thread.setContextClassLoader method not found");
+                Ok(Self {
+                    class,
+                    current_thread_method,
+                    get_context_class_loader_method,
+                    set_context_class_loader_method,
+                })
+            })
+        })
+    }
+}
+
+impl JThread<'_> {
+    /// Creates a [`JThread`] that wraps the given `raw` [`jthrowable`]
+    ///
+    /// # Safety
+    ///
+    /// `raw` may be a null pointer. If `raw` is not a null pointer, then:
+    ///
+    /// * `raw` must be a valid raw JNI local reference.
+    /// * There must not be any other `JObject` representing the same local reference.
+    /// * The lifetime `'local` must not outlive the local reference frame that the local reference
+    ///   was created in.
+    pub const unsafe fn from_raw(raw: jthrowable) -> Self {
+        Self(JObject::from_raw(raw as jobject))
+    }
+
+    /// Unwrap to the raw jni type.
+    pub const fn into_raw(self) -> jthrowable {
+        self.0.into_raw() as jthrowable
+    }
+
+    /// Get the message of the throwable by calling the `getMessage` method.
+    pub fn current_thread<'local>(env: &mut JNIEnv<'_>) -> Result<JThread<'local>> {
+        let vm = env.get_java_vm();
+        let api = JThreadAPI::get(&vm)?;
+
+        // Safety: We know that `currentThread` is a valid method on `java/lang/Thread` that has no
+        // arguments and it returns a valid `Thread` instance.
+        unsafe {
+            let message = env
+                .call_static_method_unchecked(
+                    &api.class,
+                    api.current_thread_method,
+                    crate::signature::ReturnType::Object,
+                    &[],
+                )?
+                .l()?;
+            Ok(JThread::from_raw(message.into_raw()))
+        }
+    }
+
+    /// Gets the context class loader for this thread.
+    ///
+    /// This is a Java method binding for `java.lang.Thread#getContextClassLoader()`.
+    ///
+    /// # Throws
+    ///
+    /// Throws `SecurityException` if the current thread can't access its context class loader.
+    pub fn get_context_class_loader<'local>(
+        &self,
+        env: &mut JNIEnv<'local>,
+    ) -> Result<JClassLoader<'local>> {
+        let vm = env.get_java_vm();
+        let api = JThreadAPI::get(&vm)?;
+
+        // Safety: We know that `getContextClassLoader` is a valid method on `java/lang/Thread` that has no
+        // arguments and it returns a valid `ClassLoader` instance.
+        unsafe {
+            let cause = env
+                .call_method_unchecked(
+                    self,
+                    api.get_context_class_loader_method,
+                    crate::signature::ReturnType::Object,
+                    &[],
+                )?
+                .l()?;
+            Ok(JClassLoader::from_raw(cause.into_raw()))
+        }
+    }
+
+    /// Sets the context class loader for this thread.
+    ///
+    /// The `loader` may be `null` to indicate the system class loader.
+    ///
+    /// This is a Java method binding for `java.lang.Thread#setContextClassLoader(java.lang.ClassLoader)`.
+    ///
+    /// # Throws
+    ///
+    /// Throws `SecurityException` if the current thread can't access its context class loader.
+    pub fn set_context_class_loader<'loader_local, 'env_local>(
+        &self,
+        loader: &JClassLoader<'loader_local>,
+        env: &mut JNIEnv<'env_local>,
+    ) -> Result<JClassLoader<'env_local>> {
+        let vm = env.get_java_vm();
+        let api = JThreadAPI::get(&vm)?;
+
+        // Safety: We know that `getContextClassLoader` is a valid method on `java/lang/Thread` that has no
+        // arguments and it returns a valid `ClassLoader` instance.
+        unsafe {
+            let cause = env
+                .call_method_unchecked(
+                    self,
+                    api.set_context_class_loader_method,
+                    crate::signature::ReturnType::Object,
+                    &[JValue::Object(loader.as_ref()).as_jni()],
+                )?
+                .l()?;
+            Ok(JClassLoader::from_raw(cause.into_raw()))
+        }
+    }
+}
+
+// SAFETY: JThread is a transparent JObject wrapper with no Drop side effects
+unsafe impl JObjectRef for JThread<'_> {
+    const CLASS_NAME: &'static str = "java.lang.Thread";
+
+    type Kind<'env> = JThread<'env>;
+    type GlobalKind = JThread<'static>;
+
+    fn as_raw(&self) -> jobject {
+        self.0.as_raw()
+    }
+
+    fn lookup_class<'vm>(
+        vm: &'vm JavaVM,
+        _loader_context: LoaderContext,
+    ) -> crate::errors::Result<impl Deref<Target = GlobalRef<JClass<'static>>> + 'vm> {
+        // As a special-case; we ignore loader_context just to be clear that there's no risk of
+        // recursion. (`LoaderContext::load_class` depends on the `JThreadAPI`)
+        let api = JThreadAPI::get(vm)?;
+        Ok(&api.class)
+    }
+
+    unsafe fn from_raw<'env>(local_ref: jobject) -> Self::Kind<'env> {
+        JThread::from_raw(local_ref)
+    }
+
+    unsafe fn from_global_raw(global_ref: jobject) -> Self::GlobalKind {
+        JThread::from_raw(global_ref)
+    }
+}

--- a/src/wrapper/objects/mod.rs
+++ b/src/wrapper/objects/mod.rs
@@ -1,3 +1,6 @@
+mod cast;
+pub use self::cast::*;
+
 // wrappers arount jni pointer types that add lifetimes and other functionality.
 mod jvalue;
 pub use self::jvalue::*;
@@ -26,6 +29,9 @@ pub use self::jthrowable::*;
 mod jclass;
 pub use self::jclass::*;
 
+mod jclass_loader;
+pub use self::jclass_loader::*;
+
 mod jstring;
 pub use self::jstring::*;
 
@@ -37,6 +43,9 @@ pub use self::jlist::*;
 
 mod jbytebuffer;
 pub use self::jbytebuffer::*;
+
+mod jthread;
+pub use self::jthread::*;
 
 // For storing a reference to a java object
 mod global_ref;

--- a/tests/invocation_character_encoding.rs
+++ b/tests/invocation_character_encoding.rs
@@ -27,7 +27,7 @@ fn invocation_character_encoding() {
         let prop_name = env.new_string("nbsp").unwrap();
 
         println!("calling getProperty");
-        let prop_value: JString = env
+        let prop_value = env
             .call_static_method(
                 "java/lang/System",
                 "getProperty",
@@ -36,9 +36,8 @@ fn invocation_character_encoding() {
             )
             .unwrap()
             .l()
-            .unwrap()
-            .into();
-
+            .unwrap();
+        let prop_value = env.cast_local::<JString>(prop_value)?;
         let prop_value_str = env.get_string(&prop_value).unwrap();
         let prop_value_str: Cow<str> = prop_value_str.to_str();
 

--- a/tests/jmap.rs
+++ b/tests/jmap.rs
@@ -29,7 +29,7 @@ pub fn jmap_push_and_iterate() {
         unwrap(
             map.iter(env).and_then(|mut iter| {
                 while let Some(e) = iter.next(env)? {
-                    let s = JString::from(e.0);
+                    let s = env.cast_local::<JString>(e.0)?;
                     let s = env.get_string(&s)?;
                     collected.push(String::from(s));
                 }

--- a/tests/threads_attach_config.rs
+++ b/tests/threads_attach_config.rs
@@ -29,10 +29,10 @@ fn attach_config() {
                         .unwrap()
                         .l()
                         .unwrap();
-                    let name: JString = env
+                    let name = env
                         .call_method(thread, "getName", "()Ljava/lang/String;", &[])?
-                        .l()?
-                        .into();
+                        .l()?;
+                    let name = env.cast_local::<JString>(name).unwrap();
                     let name = env.get_string(&name)?;
                     assert_eq!(name.as_cstr(), c"test-thread");
                     Ok(())


### PR DESCRIPTION
This adds a safe way to cast references with these new APIs:

- `JNIEnv::new_cast_global_ref` - acts like `new_global_ref` with a cast
- `JNIEnv::cast_global` takes a `GlobalRef<From>` and returns a `GlobalRef<To>`
- `JNIEnv::new_cast_local_ref` - acts like `new_local_ref` with a cast
- `JNIEnv::cast_local` takes a `From: JObjectRef` and returns a `To: JObjectRef`
- `JNIEnv::as_cast` borrows a `From: JObjectRef` (local or global) and returns  a `Cast<To>` that will Deref into `&To`

These are built on an internal `JNIEnv::is_instance_of_type<T: JObjectRef>()` utility that checks the validity of a cast via the `JObjectRef` trait.

This adds a `const CLASS_NAME` to `JObjectRef` and `lookup_class` method that can lookup a globally cached `GlobalRef<JClass>` for any reference type.

 `JObjectRef` has been made `unsafe` with a documented safety requirement to ensure that the associated `Kind` and `GlobalKind` types should be transparent JObject or jobject wrappers that have no `Drop` side effects. This allows `as_cast` to create a hidden `JObjectRef::Kind` wrapper within `Cast` without worrying about `Drop` side effects.

`JObjectRef::from_local_raw` has been rename to `from_raw` and the documentation clarifies that it's OK to create a transient `Kind<'static>` wrapper for a global reference, so long as the temporary view (such as `Cast`) borrows the original reference.

It introduces a `LoaderContext` + `LoaderContext::load_class` API for loading a class depending on the available context.

`JThread` and `JClassLoader` wrapper types for `java.lang.Thread` and `java.lang.ClassLoader` have been added so that `LoaderContext::load_class` can look for a `ClassLoader` via `Thread.currentThread().getContextClassLoader()`.

The `is_instance_of_type` implementation works by calling `JObjectRef::lookup_class` for the target, cast type and then uses `IsInstanceOf` to check the given object reference being cast.

The implementation of `is_instance_of_type` will provide a reference to the object being cast as context (via `LoaderContext::FromObject`) so that `load_class` should always be able to find a suitable loader for an application class (if the cast is valid).

# Singleton API Cache Pattern

As `JObjectRef::lookup_class()` is expected to return a borrowed `GlobalRef<JClass>`; this introduces a new convention for how different reference types cache a singleton with a global `JClass` reference along with `MethodID`s.

For example this is how the `JClass` and `JMethodID`s are cached for `JString`:

```rust
struct JStringAPI {
    class: GlobalRef<JClass<'static>>,
    intern_method: JMethodID,
}

impl JStringAPI {
    fn get<'any_local>(
        vm: &JavaVM,
        loader_context: &LoaderContext<'any_local, '_>,
    ) -> Result<&'static Self> {
        static JSTRING_API: OnceCell<JStringAPI> = OnceCell::new();
        JSTRING_API.get_or_try_init(|| {
            vm.with_env_current_frame(|env| {
                let class = loader_context.load_class_for_type::<JString>(true, env)?;
                let class = env.new_global_ref(&class).unwrap();
                let intern_method = env
                    .get_method_id(&class, c"intern", c"()Ljava/lang/String;")
                    .expect("JString.intern method not found");

                Ok(Self {
                    class,
                    intern_method,
                })
            })
        })
    }
}
```

and then the `JObjectRef::lookup_class` implementation can typically look like:

```rust
    fn lookup_class<'vm>(
        vm: &'vm JavaVM,
        loader_context: LoaderContext,
    ) -> crate::errors::Result<impl Deref<Target = GlobalRef<JClass<'static>>> + 'vm> {
        let api = JStringAPI::get(vm, &loader_context)?;
        Ok(&api.class)
    }
```

# LoaderContext

Actual class lookups are handled by `LoaderContext::load_class` which will first prefer to find a `ClassLoader` and call `Class.forName(name, false, loader)` before falling back to `FindClass`

If the `LoaderContext` has a direct reference to a `ClassLoader` then that's the only thing checked.

Otherwise, `load_class()` will first attempt to find a loader with `Thread.currentThread().getContextClassLoader()` and otherwise if the `LoaderContext` has a `FromObject` reference it will look up that object's associated `ClassLoader.

# Removed `unsafe` `From<>` downcasts

This removes the various `From<>` trait implementations, such as a `JClass::from`, `JString::from`, `JThrowable::from` that allowed safe code to make unchecked downcasts of `JObject` references.

# JNIEnv::get_string_unchecked became safe

As a side-effect of now being able to trust the Rust reference types (I.e. a `JString` is guaranteed to represent a `java.lang.String`) the special-case explicit type checks in `get_string` became redundant and the implementation became equivalent to `get_string_unchecked` which could be marked as deprecated.

Fixes: #515

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Change is covered by [automated tests](https://github.com/jni-rs/jni-rs/blob/master/CONTRIBUTING.md#tests)
- [x] The [coding guidelines](https://github.com/jni-rs/jni-rs/blob/master/CONTRIBUTING.md#the-code-style) are followed
- [x] Public API has documentation
- [x] User-visible changes are mentioned in the Changelog
- [x] The continuous integration build passes
