### PR TITLE
Return `JObjectRef` from `JNIEnv::with_local_frame_returning_local`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `JNIEnv::define_class_bytearray` was renamed to `JNIEnv::define_class_jbyte` and is identical to `define_class` except for taking a `&[jbyte]` slice instead of `&[u8]`, which is a convenience if you have a `JByteArray` or `AutoElements<JByteArray>`.
 - `AutoElements` was simplified to only be parameterized by one lifetime for the array reference, and accepts any `AsRef<JPrimitiveArray<T>>` as a reference. ([#508](https://github.com/jni-rs/jni-rs/pull/508))
 - `JavaType` was simplified to not capture object names or array details (like `ReturnType`) since these details don't affect `JValue` type checks and had a hidden cost that was redundant.
+- `JNIEnv::with_local_frame_returning_local` can now return any kind of `JObjectRef` local reference, not just `JObject`
 
 ### Removed
 - `JavaVM::attach_current_thread_as_daemon` (and general support for 'daemon' threads) has been removed, since their semantics are inherently poorly defined and unsafe (the distinction relates to the poorly defined limbo state after calling `JavaDestroyVM`, where it becomes undefined to touch the JVM) ([#593](https://github.com/jni-rs/jni-rs/pull/593))

--- a/benches/api_calls.rs
+++ b/benches/api_calls.rs
@@ -425,7 +425,7 @@ fn jni_with_local_frame_returning_local(c: &mut Criterion) {
         let class = env.find_class(CLASS_OBJECT).unwrap();
         c.bench_function("jni_with_local_frame_returning_local", |b| {
             b.iter(|| {
-                env.with_local_frame_returning_local(LOCAL_FRAME_SIZE, |env| {
+                env.with_local_frame_returning_local::<_, JObject, _>(LOCAL_FRAME_SIZE, |env| {
                     env.new_object(&class, SIG_OBJECT_CTOR, &[])
                 })
             })

--- a/tests/jni_api.rs
+++ b/tests/jni_api.rs
@@ -256,7 +256,7 @@ attach_current_thread(|env| {
 pub fn with_local_frame() {
     attach_current_thread(|env| {
         let s = env
-            .with_local_frame_returning_local::<_, jni::errors::Error>(16, |env| {
+            .with_local_frame_returning_local::<_, JObject, jni::errors::Error>(16, |env| {
                 let res = env.new_string("Test")?;
                 Ok(res.into())
             })
@@ -1303,7 +1303,7 @@ fn short_lifetime_with_local_frame() {
 fn short_lifetime_with_local_frame_sub_fn<'local>(
     env: &'_ mut JNIEnv<'local>,
 ) -> Result<JObject<'local>, Error> {
-    env.with_local_frame_returning_local(16, |env| {
+    env.with_local_frame_returning_local::<_, JObject, _>(16, |env| {
         env.new_object(INTEGER_CLASS, "(I)V", &[JValue::from(5)])
     })
 }

--- a/tests/jni_weak_refs.rs
+++ b/tests/jni_weak_refs.rs
@@ -111,7 +111,7 @@ fn weak_ref_is_actually_weak() {
 
         for _ in 0..100 {
             let obj_local = unwrap(
-                env.with_local_frame_returning_local(2, |env| {
+                env.with_local_frame_returning_local::<_, JObject, _>(2, |env| {
                     env.new_object("java/lang/Object", "()V", &[])
                 }),
                 env,


### PR DESCRIPTION
This make the return type for `with_local_frame_returning_local` generic, so that it can return any local `JObjectRef` reference - not just `JObject`.

This avoids the need for awkward upcasts and down casts when returning anything more specific, like a `JString` or `JClass`.

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Change is covered by [automated tests](https://github.com/jni-rs/jni-rs/blob/master/CONTRIBUTING.md#tests)
- [x] The [coding guidelines](https://github.com/jni-rs/jni-rs/blob/master/CONTRIBUTING.md#the-code-style) are followed
- [x] Public API has documentation
- [x] User-visible changes are mentioned in the Changelog
- [x] The continuous integration build passes
