### PR TITLE
JNIString + JNIStr ergonomic improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -92,6 +92,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `JavaVM::with_env` and `JavaVM::with_env_with_capacity` added as methods to borrow a `JNIEnv` that is already attached to the current thread, after pushing a new JNI stack frame ([#570](https://github.com/jni-rs/jni-rs/pull/570))
 - `JavaVM::with_env_current_frame` added to borrow a `JNIEnv` for the top JNI stack frame (i.e. without pushing a new JNI stack frame) ([#570](https://github.com/jni-rs/jni-rs/pull/570))
 - `JNIEnv::to_reflected_method` and `JNIEnv::to_reflected_static_method` for retrieving the Java reflection API instance for a method or constructor. ([#579](https://github.com/jni-rs/jni-rs/pull/579))
+- `JNIStr` now implements `Debug`, `PartialEq`, `Eq`, `PartialOrd`, `Ord` and `Hash`
+- `JNIString` now implements `Debug`, `PartialEq`, `Eq`, `PartialOrd`, `Ord`, `Hash` and `Clone`
+- `PartialEq<&JNIStr> for JNIString` allows `JNIStr` and `JNIString` to be compared.
+- `From<&JNIStr>` and `From<JavaStr>` implementations for `JNIString`.
+- `JNIStr::from_cstr` safely does a zero-copy cast of a `CStr` to a `JNIStr` after a `const` modified-utf8 encoding validation (with a panic on failure)
+- `AsRef<JNIStr>` is implemented for `CStr` (based on `JNIStr::from_cstr`) allows use of literals like `c"java/lang/Foo"` to be passed to JNI APIs without needing to be copied.
+- `JNIStr::to_bytes` gives access to a `&[u8]` slice over the bytes of a JNI string (like `CStr::to_bytes`)
 
 ### Fixed
 - `JNIEnv::get_string` no longer leaks local references. ([#528](https://github.com/jni-rs/jni-rs/pull/528), [#557](https://github.com/jni-rs/jni-rs/pull/557))

--- a/src/wrapper/strings/java_str.rs
+++ b/src/wrapper/strings/java_str.rs
@@ -3,10 +3,13 @@ use std::{borrow::Cow, marker::PhantomData, os::raw::c_char};
 
 use log::warn;
 
-use crate::{env::JNIEnv, errors::*, objects::JString, strings::JNIStr, JavaVM};
-
-#[cfg(doc)]
-use crate::strings::JNIString;
+use crate::{
+    env::JNIEnv,
+    errors::*,
+    objects::JString,
+    strings::{JNIStr, JNIString},
+    JavaVM,
+};
 
 /// Represents the bytes of a string in the JVM, in Java's [modified UTF-8]
 /// encoding.
@@ -194,6 +197,13 @@ impl<'other_local: 'obj_ref, 'obj_ref: 'java_str, 'java_str>
 {
     fn from(other: &'java_str JavaStr) -> &'java_str JNIStr {
         unsafe { JNIStr::from_ptr(other.internal) }
+    }
+}
+
+impl<'other_local: 'obj_ref, 'obj_ref> From<JavaStr<'_, 'other_local, 'obj_ref>> for JNIString {
+    fn from(other: JavaStr) -> JNIString {
+        let jni_str: &JNIStr = &other;
+        jni_str.to_owned()
     }
 }
 

--- a/tests/ui/fail/const-jnistr-from-cstr.rs
+++ b/tests/ui/fail/const-jnistr-from-cstr.rs
@@ -1,0 +1,5 @@
+use jni::strings::JNIStr;
+
+fn main() {
+    const INVALID_MUTF8_CSTR: &JNIStr = JNIStr::from_cstr(c"invalid mutf8: 🦀");
+}

--- a/tests/ui/fail/const-jnistr-from-cstr.stderr
+++ b/tests/ui/fail/const-jnistr-from-cstr.stderr
@@ -1,0 +1,11 @@
+error[E0080]: evaluation panicked: JNIStr::from_cstr: input is not valid modified UTF-8
+ --> tests/ui/fail/const-jnistr-from-cstr.rs:4:41
+  |
+4 |     const INVALID_MUTF8_CSTR: &JNIStr = JNIStr::from_cstr(c"invalid mutf8: 🦀");
+  |                                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `main::INVALID_MUTF8_CSTR` failed inside this call
+  |
+note: inside `JNIStr::from_cstr`
+ --> src/wrapper/strings/ffi_str.rs
+  |
+  |             panic!("JNIStr::from_cstr: input is not valid modified UTF-8");
+  |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the failure occurred here


### PR DESCRIPTION
- `JNIStr` now implements `Debug`, `PartialEq`, `Eq`, `PartialOrd`, `Ord` and `Hash`
- `JNIString` now implements `Debug`, `PartialEq`, `Eq`, `PartialOrd`, `Ord`, `Hash` and `Clone`
- `PartialEq<&JNIStr> for JNIString` allows `JNIStr` and `JNIString` to be compared.
- `From<&JNIStr>` and `From<JavaStr>` implementations for `JNIString`.
- `JNIStr::from_cstr` safely does a zero-copy cast of a `CStr` to a `JNIStr` after a `const` modified-utf8 encoding validation (with a panic on failure)
- `AsRef<JNIStr>` is implemented for `CStr` (based on `JNIStr::from_cstr`) allows use of literals like `c"java/lang/Foo"` to be passed to JNI APIs without needing to be copied.
- `JNIStr::to_bytes` gives access to a `&[u8]` slice over the bytes of a JNI string (like `CStr::to_bytes`)

These changes lay some groundwork before looking to migrate usage of `Into<JNIString>` over to `AsRef<JNIStr>`, re: #610

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Change is covered by [automated tests](https://github.com/jni-rs/jni-rs/blob/master/CONTRIBUTING.md#tests)
- [x] The [coding guidelines](https://github.com/jni-rs/jni-rs/blob/master/CONTRIBUTING.md#the-code-style) are followed
- [x] Public API has documentation
- [x] User-visible changes are mentioned in the Changelog
- [x] The continuous integration build passes
