### PR TITLE
Fix platform-dependent ptr cast

### DIFF
--- a/src/wrapper/java_vm/vm.rs
+++ b/src/wrapper/java_vm/vm.rs
@@ -1,5 +1,6 @@
 use std::{
     cell::{Cell, RefCell},
+    os::raw::c_char,
     ptr,
     sync::atomic::{AtomicUsize, Ordering},
     thread::{current, Thread},
@@ -985,7 +986,7 @@ unsafe fn sys_attach_current_thread(
         name: config
             .name
             .as_ref()
-            .map(|s| s.as_ptr() as *mut i8)
+            .map(|s| s.as_ptr() as *mut c_char)
             .unwrap_or(ptr::null_mut()),
         group: config
             .group


### PR DESCRIPTION
## Overview

Building on certain architectures (e.g. aarch64) will fail due to mismatched raw ptr types:
```
error[E0308]: mismatched types
   --> ../jni-rs/src/wrapper/java_vm/vm.rs:985:15
    |
985 |           name: config
    |  _______________^
986 | |             .name
987 | |             .as_ref()
988 | |             .map(|s| s.as_ptr() as *mut i8)
989 | |             .unwrap_or(ptr::null_mut()),
    | |_______________________________________^ expected `*mut u8`, found `*mut i8`
    |
    = note: expected raw pointer `*mut u8`
               found raw pointer `*mut i8`
```

The ultimate c_char backing is platform-dependent and not always i8; `as *mut c_char` is also already used for this elsewhere in the code.

All tests except the invocation test `const-jnistr-from-cstr.rs` pass, but that appears unrelated.