### PR TITLE
Make JList a JObject wrapper, implementing JObjectRef

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `AutoElements` was simplified to only be parameterized by one lifetime for the array reference, and accepts any `AsRef<JPrimitiveArray<T>>` as a reference. ([#508](https://github.com/jni-rs/jni-rs/pull/508))
 - `JavaType` was simplified to not capture object names or array details (like `ReturnType`) since these details don't affect `JValue` type checks and had a hidden cost that was redundant.
 - `JNIEnv::with_local_frame_returning_local` can now return any kind of `JObjectRef` local reference, not just `JObject`
+- `JList` is a simpler, transparent reference wrapper implementing `JObjectRef`, like `JObject`, `JClass`, `JString` etc
+- `JList::add` returns the boolean returned by the Java API
+- `JList::remove` no longer returns an `Option` since there's nothing special about getting a `null` from the Java `remove` API.
+- `JList::pop` is deprecated since this doesn't map to standard Java `List` method.
+- `JList::iter` returns a `JIterator` instead of a `JListIter`
+- `JNIEnv::get_list` has been deprecated, in favor of `JList::cast_local`, or other generic `JNIEnv` `cast_local/cast_global` APIs.
 
 ### Removed
 - `JavaVM::attach_current_thread_as_daemon` (and general support for 'daemon' threads) has been removed, since their semantics are inherently poorly defined and unsafe (the distinction relates to the poorly defined limbo state after calling `JavaDestroyVM`, where it becomes undefined to touch the JVM) ([#593](https://github.com/jni-rs/jni-rs/pull/593))
@@ -110,6 +116,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `JNIEnv::cast_local` takes an owned local reference and returns a newly type cast wrapper ([#612](https://github.com/jni-rs/jni-rs/pull/612))
 - `JNIEnv::as_cast` borrows any `From: JObjectRef` (global or local) reference and returns  a `Cast<To>` that will Deref into `&To` ([#612](https://github.com/jni-rs/jni-rs/pull/612))
 - `JCollection`, `JSet` and `JIterator` reference wrappers for `java.util.Collection`, `java.util.Set` and `java.util.Iterator` interfaces.
+- `JList::remove_item` for removing a given value, by-reference, from the list (instead of by index).
+- `JList::clear` allows a list to be cleared.
+- `JList::is_empty` checks if a list is empty.
+- `JList::as_collection` casts a list into a `JCollection`
 
 ### Fixed
 - `JNIEnv::get_string` no longer leaks local references. ([#528](https://github.com/jni-rs/jni-rs/pull/528), [#557](https://github.com/jni-rs/jni-rs/pull/557))

--- a/src/wrapper/jnienv.rs
+++ b/src/wrapper/jnienv.rs
@@ -2273,21 +2273,18 @@ impl<'local> JNIEnv<'local> {
         Ok(obj)
     }
 
-    /// Cast a JObject to a `JList`. This won't throw exceptions or return errors
-    /// in the event that the object isn't actually a list, but the methods on
-    /// the resulting map object will.
-    pub fn get_list<'other_local_1, 'obj_ref>(
+    /// Cast a [JObject] to a [JList].
+    ///
+    /// Returns `Error::WrongObjectType` if the object is not a `java.util.List`.
+    #[deprecated(
+        since = "0.22.0",
+        note = "use JList::cast_local instead or JNIEnv::new_cast_local_ref/cast_local/as_cast_local or JNIEnv::new_cast_global_ref/cast_global/as_cast_global"
+    )]
+    pub fn get_list<'any_local>(
         &mut self,
-        obj: &'obj_ref JObject<'other_local_1>,
-    ) -> Result<JList<'local, 'other_local_1, 'obj_ref>>
-    where
-        'other_local_1: 'obj_ref,
-    {
-        // Runtime check that the 'local reference lifetime will be tied to
-        // JNIEnv lifetime for the top JNI stack frame
-        assert_eq!(self.level, JavaVM::thread_attach_guard_level());
-        let obj = null_check!(obj, "get_list obj argument")?;
-        JList::from_env(self, obj)
+        obj: impl JObjectRef + Into<JObject<'any_local>> + AsRef<JObject<'any_local>>,
+    ) -> Result<JList<'any_local>> {
+        JList::cast_local(obj, self)
     }
 
     /// Cast a JObject to a JMap. This won't throw exceptions or return errors

--- a/tests/jlist.rs
+++ b/tests/jlist.rs
@@ -1,0 +1,290 @@
+#![cfg(feature = "invocation")]
+
+use jni::{
+    objects::{IntoAutoLocal, JList, JString},
+    strings::JNIStr,
+    sys::jint,
+};
+
+mod util;
+use util::{attach_current_thread, unwrap};
+
+#[test]
+pub fn jlist_push_and_iterate() {
+    attach_current_thread(|env| {
+        let data = &[
+            JNIStr::from_cstr(c"hello"),
+            JNIStr::from_cstr(c"world"),
+            JNIStr::from_cstr(c"from"),
+            JNIStr::from_cstr(c"jlist"),
+            JNIStr::from_cstr(c"test"),
+        ];
+
+        // Create a new ArrayList
+        let list_object = unwrap(env.new_object(c"java/util/ArrayList", c"()V", &[]), env);
+        let list = unwrap(JList::cast_local(list_object, env), env);
+
+        // Add all strings to the list
+        unwrap(
+            data.iter().try_for_each(|s| {
+                let string = env.new_string(s)?;
+                let added = list.add(env, &string)?;
+                assert!(added);
+                Ok(())
+            }),
+            env,
+        );
+
+        // Verify the list size
+        let size = unwrap(list.size(env), env);
+        assert_eq!(size, data.len() as jint);
+
+        // Collect the values using the JList iterator
+        let mut collected = Vec::new();
+        unwrap(
+            list.iter(env).and_then(|iter| {
+                while let Some(obj) = iter.next(env)? {
+                    let s = env.cast_local::<JString>(obj)?;
+                    let s = env.get_string(&s)?;
+                    collected.push(s.to_owned());
+                }
+                Ok(())
+            }),
+            env,
+        );
+
+        let orig = data.to_vec();
+        assert_eq!(orig, collected);
+        Ok(())
+    })
+    .unwrap();
+}
+
+#[test]
+pub fn jlist_get_and_set() {
+    attach_current_thread(|env| {
+        // Create a new ArrayList
+        let list_object = unwrap(env.new_object(c"java/util/ArrayList", c"()V", &[]), env);
+        let list = unwrap(JList::cast_local(list_object, env), env);
+
+        // Add some initial elements
+        let hello_str = unwrap(env.new_string(c"hello"), env);
+        let world_str = unwrap(env.new_string(c"world"), env);
+
+        unwrap(list.add(env, &hello_str.into()), env);
+        unwrap(list.add(env, &world_str.into()), env);
+
+        // Test get method
+        let first = unwrap(list.get(env, 0), env);
+        assert!(first.is_some());
+        let first_obj = first.unwrap();
+        let first_jstring = unwrap(env.cast_local::<JString>(first_obj), env);
+        let first_str = unwrap(env.get_string(&first_jstring), env);
+        assert_eq!(first_str.to_str().as_ref(), "hello");
+
+        let second = unwrap(list.get(env, 1), env);
+        assert!(second.is_some());
+        let second_obj = second.unwrap();
+        let second_jstring = unwrap(env.cast_local::<JString>(second_obj), env);
+        let second_str = unwrap(env.get_string(&second_jstring), env);
+        assert_eq!(second_str.to_str().as_ref(), "world");
+
+        // Test get with invalid index (should throw IndexOutOfBoundsException)
+        let invalid = list.get(env, 10);
+        assert!(invalid.is_err());
+
+        Ok(())
+    })
+    .unwrap();
+}
+
+#[test]
+pub fn jlist_insert_and_remove() {
+    attach_current_thread(|env| {
+        // Create a new ArrayList
+        let list_object = unwrap(env.new_object(c"java/util/ArrayList", c"()V", &[]), env);
+        let list = unwrap(JList::cast_local(list_object, env), env);
+
+        // Add initial elements
+        let first_str = unwrap(env.new_string(c"first"), env);
+        let third_str = unwrap(env.new_string(c"third"), env);
+
+        unwrap(list.add(env, &first_str.into()), env);
+        unwrap(list.add(env, &third_str.into()), env);
+
+        // Insert in the middle
+        let second_str = unwrap(env.new_string(c"second"), env);
+        unwrap(list.insert(env, 1, &second_str.into()), env);
+
+        // Verify the size is now 3
+        let size = unwrap(list.size(env), env);
+        assert_eq!(size, 3);
+
+        // Verify the order
+        let items: Vec<String> = (0..3)
+            .map(|i| {
+                let obj = unwrap(list.get(env, i), env).unwrap();
+                let jstring = unwrap(env.cast_local::<JString>(obj), env);
+                String::from(unwrap(env.get_string(&jstring), env))
+            })
+            .collect();
+
+        assert_eq!(items, vec!["first", "second", "third"]);
+
+        // Remove the middle element
+        let removed_obj = unwrap(list.remove(env, 1), env);
+        let removed_jstring = unwrap(env.cast_local::<JString>(removed_obj), env);
+        let removed_str = unwrap(env.get_string(&removed_jstring), env);
+        assert_eq!(removed_str.to_str().as_ref(), "second");
+
+        // Verify size is now 2
+        let size = unwrap(list.size(env), env);
+        assert_eq!(size, 2);
+
+        // Verify remaining elements
+        let first_remaining = unwrap(list.get(env, 0), env).unwrap();
+        let first_jstring = unwrap(env.cast_local::<JString>(first_remaining), env);
+        let first_str = unwrap(env.get_string(&first_jstring), env);
+        assert_eq!(first_str.to_str().as_ref(), "first");
+
+        let second_remaining = unwrap(list.get(env, 1), env).unwrap();
+        let second_jstring = unwrap(env.cast_local::<JString>(second_remaining), env);
+        let second_str = unwrap(env.get_string(&second_jstring), env);
+        assert_eq!(second_str.to_str().as_ref(), "third");
+
+        Ok(())
+    })
+    .unwrap();
+}
+
+#[test]
+pub fn jlist_size_and_remove() {
+    attach_current_thread(|env| {
+        // Create a new ArrayList
+        let list_object = unwrap(env.new_object(c"java/util/ArrayList", c"()V", &[]), env);
+        let list = unwrap(JList::cast_local(list_object, env), env);
+
+        // Test size on empty list
+        let size = unwrap(list.size(env), env);
+        assert_eq!(size, 0);
+
+        // Add some elements
+        let first_str = unwrap(env.new_string(c"first"), env);
+        let second_str = unwrap(env.new_string(c"second"), env);
+        let third_str = unwrap(env.new_string(c"third"), env);
+
+        unwrap(list.add(env, &first_str), env);
+        unwrap(list.add(env, &second_str), env);
+        unwrap(list.add(env, &third_str), env);
+
+        // Verify size is now 3
+        let size = unwrap(list.size(env), env);
+        assert_eq!(size, 3);
+
+        // Remove the last element
+        let removed_obj = unwrap(list.remove(env, 2), env);
+        let removed_jstring = unwrap(env.cast_local::<JString>(removed_obj), env);
+        let removed_str = unwrap(env.get_string(&removed_jstring), env);
+        assert_eq!(removed_str.to_str().as_ref(), "third");
+
+        // Verify size is now 2
+        let size = unwrap(list.size(env), env);
+        assert_eq!(size, 2);
+
+        // Remove another element
+        let removed_obj = unwrap(list.remove(env, 1), env);
+        let removed_jstring = unwrap(env.cast_local::<JString>(removed_obj), env);
+        let removed_str = unwrap(env.get_string(&removed_jstring), env);
+        assert_eq!(removed_str.to_str().as_ref(), "second");
+
+        // Verify size is now 1
+        let size = unwrap(list.size(env), env);
+        assert_eq!(size, 1);
+
+        // Remove the last element
+        let removed_obj = unwrap(list.remove(env, 0), env);
+        let removed_jstring = unwrap(env.cast_local::<JString>(removed_obj), env);
+        let removed_str = unwrap(env.get_string(&removed_jstring), env);
+        assert_eq!(removed_str.to_str().as_ref(), "first");
+
+        // Verify list is now empty
+        let size = unwrap(list.size(env), env);
+        assert_eq!(size, 0);
+
+        Ok(())
+    })
+    .unwrap();
+}
+
+#[test]
+pub fn jlist_iterator_empty() {
+    attach_current_thread(|env| {
+        // Create an empty ArrayList
+        let list_object = unwrap(env.new_object(c"java/util/ArrayList", c"()V", &[]), env);
+        let list = unwrap(JList::cast_local(list_object, env), env);
+
+        // Test iterator on empty list
+        let mut collected = Vec::new();
+        unwrap(
+            list.iter(env).and_then(|iter| {
+                while let Some(obj) = iter.next(env)? {
+                    let s = env.cast_local::<JString>(obj)?;
+                    let s = env.get_string(&s)?;
+                    collected.push(s.to_owned());
+                }
+                Ok(())
+            }),
+            env,
+        );
+
+        assert!(collected.is_empty());
+        Ok(())
+    })
+    .unwrap();
+}
+
+#[test]
+pub fn jlist_iterator_with_auto_local() {
+    attach_current_thread(|env| {
+        let data = &[
+            JNIStr::from_cstr(c"item1"),
+            JNIStr::from_cstr(c"item2"),
+            JNIStr::from_cstr(c"item3"),
+        ];
+
+        // Create a new ArrayList
+        let list_object = unwrap(env.new_object(c"java/util/ArrayList", c"()V", &[]), env);
+        let list = unwrap(JList::cast_local(list_object, env), env);
+
+        // Add all strings to the list
+        unwrap(
+            data.iter().try_for_each(|s| {
+                let string = env.new_string(s)?;
+                let added = list.add(env, &string)?;
+                assert!(added);
+                Ok(())
+            }),
+            env,
+        );
+
+        // Test iterator with auto_local to prevent memory leaks
+        let mut collected = Vec::new();
+        unwrap(
+            list.iter(env).and_then(|iter| {
+                while let Some(obj) = iter.next(env)? {
+                    let obj = obj.auto(); // Wrap as AutoLocal to avoid leaking while iterating
+                    let s = env.as_cast::<JString>(&obj)?;
+                    let s = env.get_string(&s)?;
+                    collected.push(s.to_owned());
+                }
+                Ok(())
+            }),
+            env,
+        );
+
+        let orig = data.to_vec();
+        assert_eq!(orig, collected);
+        Ok(())
+    })
+    .unwrap();
+}

--- a/tests/jni_api.rs
+++ b/tests/jni_api.rs
@@ -1328,17 +1328,17 @@ fn short_lifetime_list_sub_fn<'local>(
     env: &'_ mut JNIEnv<'local>,
 ) -> Result<JObject<'local>, Error> {
     let list_object = env.new_object(ARRAYLIST_CLASS, c"()V", &[])?;
-    let list = JList::from_env(env, &list_object)?;
+    let list = env.as_cast::<JList>(&list_object)?;
     let element = env.new_object(INTEGER_CLASS, c"(I)V", &[JValue::from(1)])?;
     list.add(env, &element)?;
-    short_lifetime_list_sub_fn_get_first_element(env, &list)
+    short_lifetime_list_sub_fn_get_first_element(&list, env)
 }
 
-fn short_lifetime_list_sub_fn_get_first_element<'local>(
-    env: &'_ mut JNIEnv<'local>,
-    list: &'_ JList<'local, '_, '_>,
-) -> Result<JObject<'local>, Error> {
-    let mut iterator = list.iter(env)?;
+fn short_lifetime_list_sub_fn_get_first_element<'list_local, 'env_local>(
+    list: &'_ JList<'list_local>,
+    env: &'_ mut JNIEnv<'env_local>,
+) -> Result<JObject<'env_local>, Error> {
+    let iterator = list.iter(env)?;
     Ok(iterator.next(env)?.unwrap())
 }
 


### PR DESCRIPTION
JList is now a `#[transparent]` `JObject` wrapper, like `JClass` or `JString` that implements `JObjectRef`

Instead of looking up `JMethodID`s when creating each `JList`, these are now cached via a `JListAPI` singleton, consistent with how other `JObjectRef` types cache their `JClass` and method IDs.

Most of the `JList` API internally casts the list as a `&JCollection` and calls the corresponding method.

This also adds bindings for the `isEmpty()` and `clear()` methods.

This deprecates `JList::pop()` since that's not a standard Java API that can't be implemented based on a single method call.

`JList::iter()` now returns a `JIterator`, so this removes the redundant `JListIter` type.

Notably there's no longer additional state being maintained outside of the Java Iterator. Previously the iterator was based on indexing into a list (which could be an O(N) operation for a linked list) and could potentially hit IndexOutOfBounds exceptions if the list were modified while iterating.

This adds some basic tests to `tests/jlist.rs`

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Change is covered by [automated tests](https://github.com/jni-rs/jni-rs/blob/master/CONTRIBUTING.md#tests)
- [x] The [coding guidelines](https://github.com/jni-rs/jni-rs/blob/master/CONTRIBUTING.md#the-code-style) are followed
- [x] Public API has documentation
- [x] User-visible changes are mentioned in the Changelog
- [x] The continuous integration build passes
