### PR TITLE
Add JCollection, JSet and JIterator reference types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -109,6 +109,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `JNIEnv::new_cast_local_ref` acts like `new_local_ref` with a type cast ([#612](https://github.com/jni-rs/jni-rs/pull/612))
 - `JNIEnv::cast_local` takes an owned local reference and returns a newly type cast wrapper ([#612](https://github.com/jni-rs/jni-rs/pull/612))
 - `JNIEnv::as_cast` borrows any `From: JObjectRef` (global or local) reference and returns  a `Cast<To>` that will Deref into `&To` ([#612](https://github.com/jni-rs/jni-rs/pull/612))
+- `JCollection`, `JSet` and `JIterator` reference wrappers for `java.util.Collection`, `java.util.Set` and `java.util.Iterator` interfaces.
 
 ### Fixed
 - `JNIEnv::get_string` no longer leaks local references. ([#528](https://github.com/jni-rs/jni-rs/pull/528), [#557](https://github.com/jni-rs/jni-rs/pull/557))

--- a/src/wrapper/objects/jcollection.rs
+++ b/src/wrapper/objects/jcollection.rs
@@ -1,0 +1,303 @@
+use std::ops::Deref;
+
+use once_cell::sync::OnceCell;
+
+use crate::{
+    env::JNIEnv,
+    errors::Result,
+    objects::{GlobalRef, JClass, JIterator, JMethodID, JObject, JValue, LoaderContext},
+    signature::{Primitive, ReturnType},
+    strings::JNIStr,
+    sys::jobject,
+    JavaVM,
+};
+
+use super::JObjectRef;
+
+/// Wrapper for `java.utils.Map.Entry` references. Provides methods to get the key and value.
+#[repr(transparent)]
+#[derive(Default)]
+pub struct JCollection<'local>(JObject<'local>);
+
+impl<'local> AsRef<JCollection<'local>> for JCollection<'local> {
+    fn as_ref(&self) -> &JCollection<'local> {
+        self
+    }
+}
+
+impl<'local> AsRef<JObject<'local>> for JCollection<'local> {
+    fn as_ref(&self) -> &JObject<'local> {
+        self
+    }
+}
+
+impl<'local> ::std::ops::Deref for JCollection<'local> {
+    type Target = JObject<'local>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl<'local> From<JCollection<'local>> for JObject<'local> {
+    fn from(other: JCollection<'local>) -> JObject<'local> {
+        other.0
+    }
+}
+
+struct JCollectionAPI {
+    class: GlobalRef<JClass<'static>>,
+    add_method: JMethodID,
+    remove_method: JMethodID,
+    clear_method: JMethodID,
+    contains_method: JMethodID,
+    size_method: JMethodID,
+    is_empty_method: JMethodID,
+    iterator_method: JMethodID,
+}
+
+impl JCollectionAPI {
+    fn get<'any_local>(
+        vm: &JavaVM,
+        loader_context: &LoaderContext<'any_local, '_>,
+    ) -> Result<&'static Self> {
+        static JCOLLECTION_API: OnceCell<JCollectionAPI> = OnceCell::new();
+        JCOLLECTION_API.get_or_try_init(|| {
+            vm.with_env_current_frame(|env| {
+                let class = loader_context.load_class_for_type::<JCollection>(true, env)?;
+                let class = env.new_global_ref(&class).unwrap();
+
+                let add_method = env.get_method_id(&class, c"add", c"(Ljava/lang/Object;)Z")?;
+                let remove_method =
+                    env.get_method_id(&class, c"remove", c"(Ljava/lang/Object;)Z")?;
+                let clear_method = env.get_method_id(&class, c"clear", c"()V")?;
+                let contains_method =
+                    env.get_method_id(&class, c"contains", c"(Ljava/lang/Object;)Z")?;
+                let size_method = env.get_method_id(&class, c"size", c"()I")?;
+                let is_empty_method = env.get_method_id(&class, c"isEmpty", c"()Z")?;
+                let iterator_method =
+                    env.get_method_id(&class, c"iterator", c"()Ljava/util/Iterator;")?;
+
+                Ok(Self {
+                    class,
+                    add_method,
+                    remove_method,
+                    clear_method,
+                    contains_method,
+                    size_method,
+                    is_empty_method,
+                    iterator_method,
+                })
+            })
+        })
+    }
+}
+
+impl<'local> JCollection<'local> {
+    /// Creates a [`JCollection`] that wraps the given `raw` [`jobject`]
+    ///
+    /// # Safety
+    ///
+    /// `raw` may be a null pointer. If `raw` is not a null pointer, then:
+    ///
+    /// * `raw` must be a valid raw JNI local reference.
+    /// * There must not be any other `JObject` representing the same local reference.
+    /// * The lifetime `'local` must not outlive the local reference frame that the local reference
+    ///   was created in.
+    pub const unsafe fn from_raw(raw: jobject) -> Self {
+        Self(JObject::from_raw(raw))
+    }
+
+    /// Unwrap to the raw jni type.
+    pub const fn into_raw(self) -> jobject {
+        self.0.into_raw()
+    }
+
+    /// Cast a local reference to a `JCollection`
+    ///
+    /// This will do a runtime (`IsInstanceOf`) check that the object is an instance of `java.util.Collection`.
+    ///
+    /// Also see these other options for casting local or global references to a `JCollection`:
+    /// - [JNIEnv::new_cast_local_ref]
+    /// - [JNIEnv::cast_local]
+    /// - [JNIEnv::as_cast_local]
+    /// - [JNIEnv::new_cast_global_ref]
+    /// - [JNIEnv::cast_global]
+    /// - [JNIEnv::as_cast_global]
+    ///
+    /// # Errors
+    ///
+    /// Returns [Error::WrongObjectType] if the `IsInstanceOf` check fails.
+    pub fn cast_local<'any_local>(
+        obj: impl JObjectRef + Into<JObject<'any_local>> + AsRef<JObject<'any_local>>,
+        env: &mut JNIEnv<'_>,
+    ) -> Result<JCollection<'any_local>> {
+        env.cast_local::<JCollection>(obj)
+    }
+
+    /// Adds the given element to this set if it is not already present
+    ///
+    /// Returns `true` if the collection was modified. Returns false if the collection already contains the element and
+    /// the collection doesn't allow duplicates.
+    ///
+    /// # Throws
+    ///
+    /// - `UnsupportedOperationException` - if the add operation is not supported
+    /// - `ClassCastException` - if the element type isn't compatible with the collection
+    /// - `NullPointerException` - if the given element is null and the collection does not allow null values
+    /// - `IllegalArgumentException` - if the element has a property that prevents it from being added to this collection
+    /// - `IllegalStateException` - if the element cannot be added due to the current state of the collection
+    pub fn add<'any_local>(
+        &self,
+        element: impl AsRef<JObject<'any_local>>,
+        env: &mut JNIEnv<'_>,
+    ) -> Result<bool> {
+        let api = JCollectionAPI::get(&env.get_java_vm(), &LoaderContext::default())?;
+        let result = unsafe {
+            env.call_method_unchecked(
+                self,
+                api.add_method,
+                ReturnType::Primitive(Primitive::Boolean),
+                &[JValue::from(element.as_ref()).as_jni()],
+            )?
+        };
+        result.z()
+    }
+
+    /// Removes the given element from this collection if it is present
+    ///
+    /// Returns true if the element was contained in the collection and removed, false otherwise.
+    ///
+    /// # Throws
+    ///
+    /// - `UnsupportedOperationException` - if the remove operation is not supported
+    /// - `ClassCastException` - if the element type isn't compatible with the collection
+    /// - `NullPointerException` - if the given element is null and the collection does not allow null values
+    pub fn remove<'any_local>(
+        &self,
+        element: impl AsRef<JObject<'any_local>>,
+        env: &mut JNIEnv<'_>,
+    ) -> Result<bool> {
+        let api = JCollectionAPI::get(&env.get_java_vm(), &LoaderContext::default())?;
+        let result = unsafe {
+            env.call_method_unchecked(
+                self,
+                api.remove_method,
+                ReturnType::Primitive(Primitive::Boolean),
+                &[JValue::from(element.as_ref()).as_jni()],
+            )?
+        };
+        result.z()
+    }
+
+    /// Removes all of the elements from this collection.
+    ///
+    /// # Throws
+    ///
+    /// - `UnsupportedOperationException` - if the clear operation is not supported
+    pub fn clear(&self, env: &mut JNIEnv<'_>) -> Result<()> {
+        let api = JCollectionAPI::get(&env.get_java_vm(), &LoaderContext::default())?;
+        unsafe {
+            env.call_method_unchecked(
+                self,
+                api.clear_method,
+                ReturnType::Primitive(Primitive::Void),
+                &[],
+            )?;
+        }
+        Ok(())
+    }
+
+    /// Checks if the given element is present in this set.
+    ///
+    /// Returns `true` if the element is present, `false` otherwise.
+    ///
+    /// # Throws
+    ///
+    /// - `ClassCastException` - if the element type isn't compatible with the set
+    /// - `NullPointerException` - if the given element is null and the set does not allow null values
+    pub fn contains(&self, element: &JObject, env: &mut JNIEnv<'_>) -> Result<bool> {
+        let api = JCollectionAPI::get(&env.get_java_vm(), &LoaderContext::default())?;
+        let result = unsafe {
+            env.call_method_unchecked(
+                self,
+                api.contains_method,
+                ReturnType::Primitive(Primitive::Boolean),
+                &[JValue::from(element).as_jni()],
+            )?
+        };
+        result.z()
+    }
+
+    /// Returns the number of elements in this collection.
+    ///
+    /// Returns [i32::MAX] if the collection size is too large to be represented as an i32.
+    pub fn size(&self, env: &mut JNIEnv<'_>) -> Result<i32> {
+        let api = JCollectionAPI::get(&env.get_java_vm(), &LoaderContext::default())?;
+        let result = unsafe {
+            env.call_method_unchecked(
+                self,
+                api.size_method,
+                ReturnType::Primitive(Primitive::Int),
+                &[],
+            )?
+        };
+        result.i()
+    }
+
+    /// Returns `true` if this collection contains no elements.
+    pub fn is_empty(&self, env: &mut JNIEnv<'_>) -> Result<bool> {
+        let api = JCollectionAPI::get(&env.get_java_vm(), &LoaderContext::default())?;
+        let result = unsafe {
+            env.call_method_unchecked(
+                self,
+                api.is_empty_method,
+                ReturnType::Primitive(Primitive::Boolean),
+                &[],
+            )?
+        };
+        result.z()
+    }
+
+    /// Returns an iterator (`java.util.Iterator`) over the elements in this collection.
+    pub fn iterator<'env_local>(
+        &self,
+        env: &mut JNIEnv<'env_local>,
+    ) -> Result<JIterator<'env_local>> {
+        let api = JCollectionAPI::get(&env.get_java_vm(), &LoaderContext::default())?;
+        unsafe {
+            let iterator = env
+                .call_method_unchecked(self, api.iterator_method, ReturnType::Object, &[])?
+                .l()?;
+            Ok(JIterator::from_raw(iterator.into_raw()))
+        }
+    }
+}
+
+// SAFETY: JCollection is a transparent JObject wrapper with no Drop side effects
+unsafe impl JObjectRef for JCollection<'_> {
+    const CLASS_NAME: &'static JNIStr = JNIStr::from_cstr(c"java.util.Collection");
+
+    type Kind<'env> = JCollection<'env>;
+    type GlobalKind = JCollection<'static>;
+
+    fn as_raw(&self) -> jobject {
+        self.0.as_raw()
+    }
+
+    fn lookup_class<'vm>(
+        vm: &'vm JavaVM,
+        loader_context: LoaderContext,
+    ) -> crate::errors::Result<impl Deref<Target = GlobalRef<JClass<'static>>> + 'vm> {
+        let api = JCollectionAPI::get(vm, &loader_context)?;
+        Ok(&api.class)
+    }
+
+    unsafe fn from_raw<'env>(local_ref: jobject) -> Self::Kind<'env> {
+        JCollection::from_raw(local_ref)
+    }
+
+    unsafe fn from_global_raw(global_ref: jobject) -> Self::GlobalKind {
+        JCollection::from_raw(global_ref)
+    }
+}

--- a/src/wrapper/objects/jiterator.rs
+++ b/src/wrapper/objects/jiterator.rs
@@ -1,0 +1,226 @@
+use std::ops::Deref;
+
+use once_cell::sync::OnceCell;
+
+use crate::{
+    env::JNIEnv,
+    errors::{Error, Result},
+    objects::{GlobalRef, JClass, JMethodID, JObject, LoaderContext},
+    signature::{Primitive, ReturnType},
+    strings::JNIStr,
+    sys::jobject,
+    JavaVM,
+};
+
+use super::JObjectRef;
+
+/// Wrapper for `java.utils.Map.Entry` references. Provides methods to get the key and value.
+#[repr(transparent)]
+#[derive(Default)]
+pub struct JIterator<'local>(JObject<'local>);
+
+impl<'local> AsRef<JIterator<'local>> for JIterator<'local> {
+    fn as_ref(&self) -> &JIterator<'local> {
+        self
+    }
+}
+
+impl<'local> AsRef<JObject<'local>> for JIterator<'local> {
+    fn as_ref(&self) -> &JObject<'local> {
+        self
+    }
+}
+
+impl<'local> ::std::ops::Deref for JIterator<'local> {
+    type Target = JObject<'local>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl<'local> From<JIterator<'local>> for JObject<'local> {
+    fn from(other: JIterator<'local>) -> JObject<'local> {
+        other.0
+    }
+}
+
+struct JIteratorAPI {
+    class: GlobalRef<JClass<'static>>,
+    has_next_method: JMethodID,
+    next_method: JMethodID,
+    remove_method: JMethodID,
+}
+
+impl JIteratorAPI {
+    fn get<'any_local>(
+        vm: &JavaVM,
+        loader_context: &LoaderContext<'any_local, '_>,
+    ) -> Result<&'static Self> {
+        static JITERATOR_API: OnceCell<JIteratorAPI> = OnceCell::new();
+        JITERATOR_API.get_or_try_init(|| {
+            vm.with_env_current_frame(|env| {
+                let class = loader_context.load_class_for_type::<JIterator>(true, env)?;
+                let class = env.new_global_ref(&class).unwrap();
+
+                let has_next_method = env.get_method_id(&class, c"hasNext", c"()Z")?;
+                let next_method = env.get_method_id(&class, c"next", c"()Ljava/lang/Object;")?;
+                let remove_method = env.get_method_id(&class, c"remove", c"()V")?;
+
+                Ok(Self {
+                    class,
+                    has_next_method,
+                    next_method,
+                    remove_method,
+                })
+            })
+        })
+    }
+}
+
+impl<'local> JIterator<'local> {
+    /// Creates a [`JIterator`] that wraps the given `raw` [`jobject`]
+    ///
+    /// # Safety
+    ///
+    /// `raw` may be a null pointer. If `raw` is not a null pointer, then:
+    ///
+    /// * `raw` must be a valid raw JNI local reference.
+    /// * There must not be any other `JObject` representing the same local reference.
+    /// * The lifetime `'local` must not outlive the local reference frame that the local reference
+    ///   was created in.
+    pub const unsafe fn from_raw(raw: jobject) -> Self {
+        Self(JObject::from_raw(raw))
+    }
+
+    /// Unwrap to the raw jni type.
+    pub const fn into_raw(self) -> jobject {
+        self.0.into_raw()
+    }
+
+    /// Cast a local reference to a `JIterator`
+    ///
+    /// This will do a runtime (`IsInstanceOf`) check that the object is an instance of `java.util.Iterator`.
+    ///
+    /// Also see these other options for casting local or global references to a `JIterator`:
+    /// - [JNIEnv::new_cast_local_ref]
+    /// - [JNIEnv::cast_local]
+    /// - [JNIEnv::as_cast_local]
+    /// - [JNIEnv::new_cast_global_ref]
+    /// - [JNIEnv::cast_global]
+    /// - [JNIEnv::as_cast_global]
+    ///
+    /// # Errors
+    ///
+    /// Returns [Error::WrongObjectType] if the `IsInstanceOf` check fails.
+    pub fn cast_local<'any_local>(
+        obj: impl JObjectRef + Into<JObject<'any_local>> + AsRef<JObject<'any_local>>,
+        env: &mut JNIEnv<'_>,
+    ) -> Result<JIterator<'any_local>> {
+        env.cast_local::<JIterator>(obj)
+    }
+
+    /// Returns true if the iteration has more elements.
+    pub fn has_next(&self, env: &mut JNIEnv<'_>) -> Result<bool> {
+        let vm = env.get_java_vm();
+        let api = JIteratorAPI::get(&vm, &LoaderContext::None)?;
+        unsafe {
+            env.call_method_unchecked(
+                self,
+                api.has_next_method,
+                ReturnType::Primitive(Primitive::Boolean),
+                &[],
+            )?
+            .z()
+        }
+    }
+
+    /// Returns the next element in the iteration, if it exists.
+    ///
+    /// Returns `Some(element)` if the iteration has more elements, or `None` if
+    /// it has reached the end.
+    ///
+    /// This is like [`std::iter::Iterator::next`], but requires a parameter of
+    /// type `&mut JNIEnv` in order to call into Java.
+    ///
+    /// Any exceptions thrown are assumed to be a `NoSuchElementException` and
+    /// are caught + cleared before returning `None`.
+    ///
+    /// ## Beware of creating excessive local references in the current JNI stack frame
+    ///
+    /// This method creates a new local reference. To prevent excessive memory
+    /// usage or overflow errors (when called repeatedly in a loop), the local
+    /// reference should be deleted using [`JNIEnv::delete_local_ref`] or
+    /// [`JNIEnv::auto_local`] before the next loop iteration. Alternatively, if
+    /// the collection is known to have a small, predictable size, the loop could be
+    /// wrapped in [`JNIEnv::with_local_frame`] to delete all of the local
+    /// references at once.
+    pub fn next<'env_local>(
+        &self,
+        env: &mut JNIEnv<'env_local>,
+    ) -> Result<Option<JObject<'env_local>>> {
+        let vm = env.get_java_vm();
+        let api = JIteratorAPI::get(&vm, &LoaderContext::None)?;
+        unsafe {
+            match env.call_method_unchecked(self, api.next_method, ReturnType::Object, &[]) {
+                Ok(v) => v.l().map(Some),
+                Err(Error::JavaException) => {
+                    // Assume `NoSuchElementException` is thrown
+                    env.exception_clear();
+                    Ok(None)
+                }
+                Err(e) => Err(e),
+            }
+        }
+    }
+
+    /// Removes the current element from the iteration (if supported by the iterator)
+    ///
+    /// This can only be called once after [Self::next] is called.
+    ///
+    /// # Throws
+    ///
+    /// - `UnsupportedOperationException` if the operation is not supported.
+    /// - `IllegalStateException` if the iterator is in an invalid state (i.e [Self::next] has not been called).
+    pub fn remove(&self, env: &mut JNIEnv<'_>) -> Result<()> {
+        let vm = env.get_java_vm();
+        let api = JIteratorAPI::get(&vm, &LoaderContext::None)?;
+        unsafe {
+            env.call_method_unchecked(
+                self,
+                api.remove_method,
+                ReturnType::Primitive(Primitive::Void),
+                &[],
+            )?;
+            Ok(())
+        }
+    }
+}
+
+// SAFETY: JIterator is a transparent JObject wrapper with no Drop side effects
+unsafe impl JObjectRef for JIterator<'_> {
+    const CLASS_NAME: &'static JNIStr = JNIStr::from_cstr(c"java.util.Iterator");
+
+    type Kind<'env> = JIterator<'env>;
+    type GlobalKind = JIterator<'static>;
+
+    fn as_raw(&self) -> jobject {
+        self.0.as_raw()
+    }
+
+    fn lookup_class<'vm>(
+        vm: &'vm JavaVM,
+        loader_context: LoaderContext,
+    ) -> crate::errors::Result<impl Deref<Target = GlobalRef<JClass<'static>>> + 'vm> {
+        let api = JIteratorAPI::get(vm, &loader_context)?;
+        Ok(&api.class)
+    }
+
+    unsafe fn from_raw<'env>(local_ref: jobject) -> Self::Kind<'env> {
+        JIterator::from_raw(local_ref)
+    }
+
+    unsafe fn from_global_raw(global_ref: jobject) -> Self::GlobalKind {
+        JIterator::from_raw(global_ref)
+    }
+}

--- a/src/wrapper/objects/jset.rs
+++ b/src/wrapper/objects/jset.rs
@@ -1,0 +1,226 @@
+use std::ops::Deref;
+
+use once_cell::sync::OnceCell;
+
+use crate::{
+    env::JNIEnv,
+    errors::Result,
+    objects::{Cast, GlobalRef, JClass, JCollection, JIterator, JObject, LoaderContext},
+    strings::JNIStr,
+    sys::jobject,
+    JavaVM,
+};
+
+use super::JObjectRef;
+
+/// Wrapper for `java.utils.Map.Entry` references. Provides methods to get the key and value.
+#[repr(transparent)]
+#[derive(Default)]
+pub struct JSet<'local>(JObject<'local>);
+
+impl<'local> AsRef<JSet<'local>> for JSet<'local> {
+    fn as_ref(&self) -> &JSet<'local> {
+        self
+    }
+}
+
+impl<'local> AsRef<JObject<'local>> for JSet<'local> {
+    fn as_ref(&self) -> &JObject<'local> {
+        self
+    }
+}
+
+impl<'local> ::std::ops::Deref for JSet<'local> {
+    type Target = JObject<'local>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl<'local> From<JSet<'local>> for JObject<'local> {
+    fn from(other: JSet<'local>) -> JObject<'local> {
+        other.0
+    }
+}
+
+impl<'local> From<JSet<'local>> for JCollection<'local> {
+    fn from(other: JSet<'local>) -> JCollection<'local> {
+        // SAFETY: Any `java.lang.Set` is also a `java.util.Collection`
+        unsafe { JCollection::from_raw(other.into_raw()) }
+    }
+}
+
+struct JSetAPI {
+    class: GlobalRef<JClass<'static>>,
+}
+
+impl JSetAPI {
+    fn get<'any_local>(
+        vm: &JavaVM,
+        loader_context: &LoaderContext<'any_local, '_>,
+    ) -> Result<&'static Self> {
+        static JSET_API: OnceCell<JSetAPI> = OnceCell::new();
+        JSET_API.get_or_try_init(|| {
+            vm.with_env_current_frame(|env| {
+                let class = loader_context.load_class_for_type::<JSet>(true, env)?;
+                let class = env.new_global_ref(&class).unwrap();
+
+                Ok(Self { class })
+            })
+        })
+    }
+}
+
+impl<'local> JSet<'local> {
+    /// Creates a [`JSet`] that wraps the given `raw` [`jobject`]
+    ///
+    /// # Safety
+    ///
+    /// `raw` may be a null pointer. If `raw` is not a null pointer, then:
+    ///
+    /// * `raw` must be a valid raw JNI local reference.
+    /// * There must not be any other `JObject` representing the same local reference.
+    /// * The lifetime `'local` must not outlive the local reference frame that the local reference
+    ///   was created in.
+    pub const unsafe fn from_raw(raw: jobject) -> Self {
+        Self(JObject::from_raw(raw))
+    }
+
+    /// Unwrap to the raw jni type.
+    pub const fn into_raw(self) -> jobject {
+        self.0.into_raw()
+    }
+
+    /// Cast a local reference to a `JSet`
+    ///
+    /// This will do a runtime (`IsInstanceOf`) check that the object is an instance of `java.util.Set`.
+    ///
+    /// Also see these other options for casting local or global references to a `JSet`:
+    /// - [JNIEnv::new_cast_local_ref]
+    /// - [JNIEnv::cast_local]
+    /// - [JNIEnv::as_cast_local]
+    /// - [JNIEnv::new_cast_global_ref]
+    /// - [JNIEnv::cast_global]
+    /// - [JNIEnv::as_cast_global]
+    ///
+    /// # Errors
+    ///
+    /// Returns [Error::WrongObjectType] if the `IsInstanceOf` check fails.
+    pub fn cast_local<'any_local>(
+        obj: impl JObjectRef + Into<JObject<'any_local>> + AsRef<JObject<'any_local>>,
+        env: &mut JNIEnv<'_>,
+    ) -> Result<JSet<'any_local>> {
+        env.cast_local::<JSet>(obj)
+    }
+
+    /// Casts this `JSet` to a `JCollection`
+    ///
+    /// This does not require a runtime type check since any `java.lang.Set` is also a `java.util.Collection`
+    pub fn as_collection(&self) -> Cast<'local, '_, JCollection<'local>> {
+        // SAFETY: we know that any `java.lang.Set` is also a `java.util.Collection`
+        unsafe { Cast::<JCollection>::new_unchecked(self) }
+    }
+
+    /// Adds the given element to this set if it is not already present
+    ///
+    /// Returns `true` if the element was added, `false` if it was already present.
+    ///
+    /// # Throws
+    ///
+    /// - `UnsupportedOperationException` - if the add operation is not supported
+    /// - `ClassCastException` - if the element type isn't compatible with the set
+    /// - `NullPointerException` - if the given element is null and the set does not allow null values
+    /// - `IllegalArgumentException` - if the element has a property that prevents it from being added to this set
+    pub fn add<'any_local>(
+        &self,
+        element: impl AsRef<JObject<'any_local>>,
+        env: &mut JNIEnv<'_>,
+    ) -> Result<bool> {
+        self.as_collection().add(element, env)
+    }
+
+    /// Removes the given element from this set if it is present
+    ///
+    /// Returns `true` if the element was removed.
+    ///
+    /// # Throws
+    ///
+    /// - `UnsupportedOperationException` - if the remove operation is not supported
+    /// - `ClassCastException` - if the element type isn't compatible with the set
+    /// - `NullPointerException` - if the given element is null and the set does not allow null values
+    pub fn remove<'any_local>(
+        &self,
+        element: impl AsRef<JObject<'any_local>>,
+        env: &mut JNIEnv<'_>,
+    ) -> Result<bool> {
+        self.as_collection().remove(element, env)
+    }
+
+    /// Removes all of the elements from this set.
+    ///
+    /// # Throws
+    ///
+    /// - `UnsupportedOperationException` - if the clear operation is not supported
+    pub fn clear(&self, env: &mut JNIEnv<'_>) -> Result<()> {
+        self.as_collection().clear(env)
+    }
+
+    /// Checks if the given element is present in this set.
+    ///
+    /// Returns `true` if the element is present, `false` otherwise.
+    ///
+    /// # Throws
+    ///
+    /// - `ClassCastException` - if the element type isn't compatible with the set
+    /// - `NullPointerException` - if the given element is null and the set does not allow null values
+    pub fn contains(&self, element: &JObject, env: &mut JNIEnv<'_>) -> Result<bool> {
+        self.as_collection().contains(element, env)
+    }
+
+    /// Returns the number of elements in this set.
+    pub fn size(&self, env: &mut JNIEnv<'_>) -> Result<i32> {
+        self.as_collection().size(env)
+    }
+
+    /// Returns `true` if this set contains no elements.
+    pub fn is_empty(&self, env: &mut JNIEnv<'_>) -> Result<bool> {
+        self.as_collection().is_empty(env)
+    }
+
+    /// Returns an iterator (`java.util.Iterator`) over the elements in this set.
+    pub fn iterator<'env_local>(
+        &self,
+        env: &mut JNIEnv<'env_local>,
+    ) -> Result<JIterator<'env_local>> {
+        self.as_collection().iterator(env)
+    }
+}
+
+// SAFETY: JSet is a transparent JObject wrapper with no Drop side effects
+unsafe impl JObjectRef for JSet<'_> {
+    const CLASS_NAME: &'static JNIStr = JNIStr::from_cstr(c"java.util.Set");
+
+    type Kind<'env> = JSet<'env>;
+    type GlobalKind = JSet<'static>;
+
+    fn as_raw(&self) -> jobject {
+        self.0.as_raw()
+    }
+
+    fn lookup_class<'vm>(
+        vm: &'vm JavaVM,
+        loader_context: LoaderContext,
+    ) -> crate::errors::Result<impl Deref<Target = GlobalRef<JClass<'static>>> + 'vm> {
+        let api = JSetAPI::get(vm, &loader_context)?;
+        Ok(&api.class)
+    }
+
+    unsafe fn from_raw<'env>(local_ref: jobject) -> Self::Kind<'env> {
+        JSet::from_raw(local_ref)
+    }
+
+    unsafe fn from_global_raw(global_ref: jobject) -> Self::GlobalKind {
+        JSet::from_raw(global_ref)
+    }
+}

--- a/src/wrapper/objects/mod.rs
+++ b/src/wrapper/objects/mod.rs
@@ -35,6 +35,15 @@ pub use self::jclass_loader::*;
 mod jstring;
 pub use self::jstring::*;
 
+mod jcollection;
+pub use self::jcollection::*;
+
+mod jset;
+pub use self::jset::*;
+
+mod jiterator;
+pub use self::jiterator::*;
+
 mod jmap;
 pub use self::jmap::*;
 


### PR DESCRIPTION
This adds wrapper APIs for the `java.util.Collection`, `java.util.Set` and `java.util.Iterator` interfaces that are used by `JList` and `JMap`.

These implement `JObjectRef` like other reference types.

The plan is to rework `JList` and `JMap` to be based on these.

### Definition of Done

- [x] There are no TODOs left in the code
- [ ] Change is covered by [automated tests](https://github.com/jni-rs/jni-rs/blob/master/CONTRIBUTING.md#tests)
- [x] The [coding guidelines](https://github.com/jni-rs/jni-rs/blob/master/CONTRIBUTING.md#the-code-style) are followed
- [x] Public API has documentation
- [x] User-visible changes are mentioned in the Changelog
- [x] The continuous integration build passes
