### PR TITLE
Rework JMap as a JObjectRef based on JSet + JIterator + JMapEntry

### DIFF
--- a/src/wrapper/jnienv.rs
+++ b/src/wrapper/jnienv.rs
@@ -2287,21 +2287,18 @@ impl<'local> JNIEnv<'local> {
         JList::cast_local(obj, self)
     }
 
-    /// Cast a JObject to a JMap. This won't throw exceptions or return errors
-    /// in the event that the object isn't actually a map, but the methods on
-    /// the resulting map object will.
-    pub fn get_map<'other_local_1, 'obj_ref>(
+    /// Cast a [JObject] to a [JMap].
+    ///
+    /// Returns `Error::WrongObjectType` if the object is not a `java.util.Map`.
+    #[deprecated(
+        since = "0.22.0",
+        note = "use JMap::cast_local instead or JNIEnv::new_cast_local_ref/cast_local/as_cast_local or JNIEnv::new_cast_global_ref/cast_global/as_cast_global"
+    )]
+    pub fn get_map<'any_local>(
         &mut self,
-        obj: &'obj_ref JObject<'other_local_1>,
-    ) -> Result<JMap<'local, 'other_local_1, 'obj_ref>>
-    where
-        'other_local_1: 'obj_ref,
-    {
-        // Runtime check that the 'local reference lifetime will be tied to
-        // JNIEnv lifetime for the top JNI stack frame
-        assert_eq!(self.level, JavaVM::thread_attach_guard_level());
-        let obj = null_check!(obj, "get_map obj argument")?;
-        JMap::from_env(self, obj)
+        obj: impl JObjectRef + Into<JObject<'any_local>> + AsRef<JObject<'any_local>>,
+    ) -> Result<JMap<'any_local>> {
+        JMap::cast_local(obj, self)
     }
 
     /// Gets the bytes of a Java string, in [modified UTF-8] encoding.

--- a/tests/jmap.rs
+++ b/tests/jmap.rs
@@ -20,7 +20,7 @@ pub fn jmap_push_and_iterate() {
 
         // Create a new map. Use LinkedHashMap to have predictable iteration order
         let map_object = unwrap(env.new_object(c"java/util/LinkedHashMap", c"()V", &[]), env);
-        let map = unwrap(JMap::from_env(env, &map_object), env);
+        let map = unwrap(JMap::cast_local(map_object, env), env);
 
         // Push all strings
         unwrap(
@@ -37,7 +37,8 @@ pub fn jmap_push_and_iterate() {
         unwrap(
             map.iter(env).and_then(|mut iter| {
                 while let Some(e) = iter.next(env)? {
-                    let s = env.cast_local::<JString>(e.0)?;
+                    let value = e.value(env)?;
+                    let s = env.cast_local::<JString>(value)?;
                     let s = env.get_string(&s)?;
 
                     collected.push(s.to_owned());


### PR DESCRIPTION
`JMap` is now a transparent `JObject` wrapper that implements `JObjectRef`, like other reference types.

This also implements `JObjectRef` for the `JMapEntry` type that is yielded by the `entrySet()` iterator that's used to iterate the key/values of a map.

A `JMapIter` (got via `JMap::iter()`) will now yield `JMapEntry` references and the key/value can then be got via `entry.key(env)` or `entry.value(env)` respectively. This avoids assuming that the application needs both and also makes it possible to replace values with `entry.set_value()` where supported.

`JMap::entry_set()` now directly exposes the `JSet` that is iterated by `JMapIter`. In turn `JSet::iterator()` exposes the `JIterator` interface which exposes the underlying `hasNext()` and `remove()` APIs, in addition to `next()`.

`JMapIter` derefs to `JIterator`
