### PR TITLE
Simplify AutoElementsCritical + add JPrimitiveArray methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,6 +74,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `JList::pop` is deprecated since this doesn't map to standard Java `List` method.
 - `JList::iter` returns a `JIterator` instead of a `JListIter`
 - `JNIEnv::get_list` has been deprecated, in favor of `JList::cast_local`, or other generic `JNIEnv` `cast_local/cast_global` APIs.
+- `JNIEnv::get_array_elements` is deprecated in favor of `JPrimitiveArray::get_elements`
+- `JNIEnv::get_array_elements_critical` is deprecated in favor of `JPrimitiveArray::get_elements_critical`
+- `JNIEnv::get_*_array_region` and `JNIEnv::set_*_array_region` are deprecated in favor of `JPrimitiveArray::get/set_region`
+- `JNIEnv::get_array_length` is deprecated in favor of `JPrimitiveArray::len` and `JObjectArray::len`
 
 ### Removed
 - `JavaVM::attach_current_thread_as_daemon` (and general support for 'daemon' threads) has been removed, since their semantics are inherently poorly defined and unsafe (the distinction relates to the poorly defined limbo state after calling `JavaDestroyVM`, where it becomes undefined to touch the JVM) ([#593](https://github.com/jni-rs/jni-rs/pull/593))

--- a/src/wrapper/jnienv.rs
+++ b/src/wrapper/jnienv.rs
@@ -11,8 +11,8 @@ use std::{
 use jni_sys::jobject;
 
 use crate::objects::{
-    Cast, JBooleanArray, JByteArray, JCharArray, JDoubleArray, JFloatArray, JIntArray, JLongArray,
-    JObjectArray, JPrimitiveArray, JShortArray, LoaderContext,
+    type_array_sealed::TypeArraySealed, Cast, JBooleanArray, JByteArray, JCharArray, JDoubleArray,
+    JFloatArray, JIntArray, JLongArray, JObjectArray, JPrimitiveArray, JShortArray, LoaderContext,
 };
 use crate::{
     descriptors::Desc,
@@ -2362,6 +2362,10 @@ impl<'local> JNIEnv<'local> {
     }
 
     /// Get the length of a [`JPrimitiveArray`] or [`JObjectArray`].
+    #[deprecated(
+        since = "0.22.0",
+        note = "use JPrimitiveArray::len or JObjectArray::len instead. This method will be removed in a future version"
+    )]
     pub fn get_array_length<'other_local, 'array>(
         &self,
         array: &'array impl AsJArrayRaw<'other_local>,
@@ -2598,25 +2602,19 @@ impl<'local> JNIEnv<'local> {
     /// and `Err` is returned.
     ///
     /// [`array.length`]: struct.JNIEnv.html#method.get_array_length
+    #[deprecated(
+        since = "0.22.0",
+        note = "use JBooleanArray::get_region instead; this method will be removed in a future version"
+    )]
     pub fn get_boolean_array_region<'other_local>(
         &self,
         array: impl AsRef<JBooleanArray<'other_local>>,
         start: jsize,
         buf: &mut [jboolean],
     ) -> Result<()> {
-        let array = null_check!(array.as_ref(), "get_boolean_array_region array argument")?;
         unsafe {
-            jni_call_check_ex!(
-                self,
-                v1_1,
-                GetBooleanArrayRegion,
-                array.as_raw(),
-                start,
-                buf.len() as jsize,
-                buf.as_mut_ptr()
-            )?;
+            <jboolean as TypeArraySealed>::get_region(self, array.as_ref().as_raw(), start, buf)
         }
-        Ok(())
     }
 
     /// Copy elements of the java byte array from the `start` index to the `buf`
@@ -2628,24 +2626,17 @@ impl<'local> JNIEnv<'local> {
     /// and `Err` is returned.
     ///
     /// [`array.length`]: struct.JNIEnv.html#method.get_array_length
+    #[deprecated(
+        since = "0.22.0",
+        note = "use JByteArray::get_region instead; this method will be removed in a future version"
+    )]
     pub fn get_byte_array_region<'other_local>(
         &self,
         array: impl AsRef<JByteArray<'other_local>>,
         start: jsize,
         buf: &mut [jbyte],
     ) -> Result<()> {
-        let array = null_check!(array.as_ref(), "get_byte_array_region array argument")?;
-        unsafe {
-            jni_call_check_ex!(
-                self,
-                v1_1,
-                GetByteArrayRegion,
-                array.as_raw(),
-                start,
-                buf.len() as jsize,
-                buf.as_mut_ptr()
-            )
-        }
+        unsafe { <jbyte as TypeArraySealed>::get_region(self, array.as_ref().as_raw(), start, buf) }
     }
 
     /// Copy elements of the java char array from the `start` index to the
@@ -2657,24 +2648,17 @@ impl<'local> JNIEnv<'local> {
     /// and `Err` is returned.
     ///
     /// [`array.length`]: struct.JNIEnv.html#method.get_array_length
+    #[deprecated(
+        since = "0.22.0",
+        note = "use JCharArray::get_region instead; this method will be removed in a future version"
+    )]
     pub fn get_char_array_region<'other_local>(
         &self,
         array: impl AsRef<JCharArray<'other_local>>,
         start: jsize,
         buf: &mut [jchar],
     ) -> Result<()> {
-        let array = null_check!(array.as_ref(), "get_char_array_region array argument")?;
-        unsafe {
-            jni_call_check_ex!(
-                self,
-                v1_1,
-                GetCharArrayRegion,
-                array.as_raw(),
-                start,
-                buf.len() as jsize,
-                buf.as_mut_ptr()
-            )
-        }
+        unsafe { <jchar as TypeArraySealed>::get_region(self, array.as_ref().as_raw(), start, buf) }
     }
 
     /// Copy elements of the java short array from the `start` index to the
@@ -2686,23 +2670,18 @@ impl<'local> JNIEnv<'local> {
     /// and `Err` is returned.
     ///
     /// [`array.length`]: struct.JNIEnv.html#method.get_array_length
+    #[deprecated(
+        since = "0.22.0",
+        note = "use JShortArray::get_region instead; this method will be removed in a future version"
+    )]
     pub fn get_short_array_region<'other_local>(
         &self,
         array: impl AsRef<JShortArray<'other_local>>,
         start: jsize,
         buf: &mut [jshort],
     ) -> Result<()> {
-        let array = null_check!(array.as_ref(), "get_short_array_region array argument")?;
         unsafe {
-            jni_call_check_ex!(
-                self,
-                v1_1,
-                GetShortArrayRegion,
-                array.as_raw(),
-                start,
-                buf.len() as jsize,
-                buf.as_mut_ptr()
-            )
+            <jshort as TypeArraySealed>::get_region(self, array.as_ref().as_raw(), start, buf)
         }
     }
 
@@ -2715,24 +2694,17 @@ impl<'local> JNIEnv<'local> {
     /// and `Err` is returned.
     ///
     /// [`array.length`]: struct.JNIEnv.html#method.get_array_length
+    #[deprecated(
+        since = "0.22.0",
+        note = "use JIntArray::get_region instead; this method will be removed in a future version"
+    )]
     pub fn get_int_array_region<'other_local>(
         &self,
         array: impl AsRef<JIntArray<'other_local>>,
         start: jsize,
         buf: &mut [jint],
     ) -> Result<()> {
-        let array = null_check!(array.as_ref(), "get_int_array_region array argument")?;
-        unsafe {
-            jni_call_check_ex!(
-                self,
-                v1_1,
-                GetIntArrayRegion,
-                array.as_raw(),
-                start,
-                buf.len() as jsize,
-                buf.as_mut_ptr()
-            )
-        }
+        unsafe { <jint as TypeArraySealed>::get_region(self, array.as_ref().as_raw(), start, buf) }
     }
 
     /// Copy elements of the java long array from the `start` index to the
@@ -2744,24 +2716,17 @@ impl<'local> JNIEnv<'local> {
     /// and `Err` is returned.
     ///
     /// [`array.length`]: struct.JNIEnv.html#method.get_array_length
+    #[deprecated(
+        since = "0.22.0",
+        note = "use JLongArray::get_region instead; this method will be removed in a future version"
+    )]
     pub fn get_long_array_region<'other_local>(
         &self,
         array: impl AsRef<JLongArray<'other_local>>,
         start: jsize,
         buf: &mut [jlong],
     ) -> Result<()> {
-        let array = null_check!(array.as_ref(), "get_long_array_region array argument")?;
-        unsafe {
-            jni_call_check_ex!(
-                self,
-                v1_1,
-                GetLongArrayRegion,
-                array.as_raw(),
-                start,
-                buf.len() as jsize,
-                buf.as_mut_ptr()
-            )
-        }
+        unsafe { <jlong as TypeArraySealed>::get_region(self, array.as_ref().as_raw(), start, buf) }
     }
 
     /// Copy elements of the java float array from the `start` index to the
@@ -2773,23 +2738,18 @@ impl<'local> JNIEnv<'local> {
     /// and `Err` is returned.
     ///
     /// [`array.length`]: struct.JNIEnv.html#method.get_array_length
+    #[deprecated(
+        since = "0.22.0",
+        note = "use JFloatArray::get_region instead; this method will be removed in a future version"
+    )]
     pub fn get_float_array_region<'other_local>(
         &self,
         array: impl AsRef<JFloatArray<'other_local>>,
         start: jsize,
         buf: &mut [jfloat],
     ) -> Result<()> {
-        let array = null_check!(array.as_ref(), "get_float_array_region array argument")?;
         unsafe {
-            jni_call_check_ex!(
-                self,
-                v1_1,
-                GetFloatArrayRegion,
-                array.as_raw(),
-                start,
-                buf.len() as jsize,
-                buf.as_mut_ptr()
-            )
+            <jfloat as TypeArraySealed>::get_region(self, array.as_ref().as_raw(), start, buf)
         }
     }
 
@@ -2802,199 +2762,146 @@ impl<'local> JNIEnv<'local> {
     /// and `Err` is returned.
     ///
     /// [`array.length`]: struct.JNIEnv.html#method.get_array_length
+    #[deprecated(
+        since = "0.22.0",
+        note = "use JDoubleArray::get_region instead; this method will be removed in a future version"
+    )]
     pub fn get_double_array_region<'other_local>(
         &self,
         array: impl AsRef<JDoubleArray<'other_local>>,
         start: jsize,
         buf: &mut [jdouble],
     ) -> Result<()> {
-        let array = null_check!(array.as_ref(), "get_double_array_region array argument")?;
         unsafe {
-            jni_call_check_ex!(
-                self,
-                v1_1,
-                GetDoubleArrayRegion,
-                array.as_raw(),
-                start,
-                buf.len() as jsize,
-                buf.as_mut_ptr()
-            )
+            <jdouble as TypeArraySealed>::get_region(self, array.as_ref().as_raw(), start, buf)
         }
     }
 
     /// Copy the contents of the `buf` slice to the java boolean array at the
     /// `start` index.
+    #[deprecated(
+        since = "0.22.0",
+        note = "use JBooleanArray::set_region instead; this method will be removed in a future version"
+    )]
     pub fn set_boolean_array_region<'other_local>(
         &self,
         array: impl AsRef<JBooleanArray<'other_local>>,
         start: jsize,
         buf: &[jboolean],
     ) -> Result<()> {
-        let array = null_check!(array.as_ref(), "set_boolean_array_region array argument")?;
         unsafe {
-            jni_call_check_ex!(
-                self,
-                v1_1,
-                SetBooleanArrayRegion,
-                array.as_raw(),
-                start,
-                buf.len() as jsize,
-                buf.as_ptr()
-            )
+            <jboolean as TypeArraySealed>::set_region(self, array.as_ref().as_raw(), start, buf)
         }
     }
 
     /// Copy the contents of the `buf` slice to the java byte array at the
     /// `start` index.
+    #[deprecated(
+        since = "0.22.0",
+        note = "use JByteArray::set_region instead; this method will be removed in a future version"
+    )]
     pub fn set_byte_array_region<'other_local>(
         &self,
         array: impl AsRef<JByteArray<'other_local>>,
         start: jsize,
         buf: &[jbyte],
     ) -> Result<()> {
-        let array = null_check!(array.as_ref(), "set_byte_array_region array argument")?;
-        unsafe {
-            jni_call_check_ex!(
-                self,
-                v1_1,
-                SetByteArrayRegion,
-                array.as_raw(),
-                start,
-                buf.len() as jsize,
-                buf.as_ptr()
-            )
-        }
+        unsafe { <jbyte as TypeArraySealed>::set_region(self, array.as_ref().as_raw(), start, buf) }
     }
 
     /// Copy the contents of the `buf` slice to the java char array at the
     /// `start` index.
+    #[deprecated(
+        since = "0.22.0",
+        note = "use JCharArray::set_region instead; this method will be removed in a future version"
+    )]
     pub fn set_char_array_region<'other_local>(
         &self,
         array: impl AsRef<JCharArray<'other_local>>,
         start: jsize,
         buf: &[jchar],
     ) -> Result<()> {
-        let array = null_check!(array.as_ref(), "set_char_array_region array argument")?;
-        unsafe {
-            jni_call_check_ex!(
-                self,
-                v1_1,
-                SetCharArrayRegion,
-                array.as_raw(),
-                start,
-                buf.len() as jsize,
-                buf.as_ptr()
-            )
-        }
+        unsafe { <jchar as TypeArraySealed>::set_region(self, array.as_ref().as_raw(), start, buf) }
     }
 
     /// Copy the contents of the `buf` slice to the java short array at the
     /// `start` index.
+    #[deprecated(
+        since = "0.22.0",
+        note = "use JShortArray::set_region instead; this method will be removed in a future version"
+    )]
     pub fn set_short_array_region<'other_local>(
         &self,
         array: impl AsRef<JShortArray<'other_local>>,
         start: jsize,
         buf: &[jshort],
     ) -> Result<()> {
-        let array = null_check!(array.as_ref(), "set_short_array_region array argument")?;
         unsafe {
-            jni_call_check_ex!(
-                self,
-                v1_1,
-                SetShortArrayRegion,
-                array.as_raw(),
-                start,
-                buf.len() as jsize,
-                buf.as_ptr()
-            )
+            <jshort as TypeArraySealed>::set_region(self, array.as_ref().as_raw(), start, buf)
         }
     }
 
     /// Copy the contents of the `buf` slice to the java int array at the
     /// `start` index.
+    #[deprecated(
+        since = "0.22.0",
+        note = "use JIntArray::set_region instead; this method will be removed in a future version"
+    )]
     pub fn set_int_array_region<'other_local>(
         &self,
         array: impl AsRef<JIntArray<'other_local>>,
         start: jsize,
         buf: &[jint],
     ) -> Result<()> {
-        let array = null_check!(array.as_ref(), "set_int_array_region array argument")?;
-        unsafe {
-            jni_call_check_ex!(
-                self,
-                v1_1,
-                SetIntArrayRegion,
-                array.as_raw(),
-                start,
-                buf.len() as jsize,
-                buf.as_ptr()
-            )
-        }
+        unsafe { <jint as TypeArraySealed>::set_region(self, array.as_ref().as_raw(), start, buf) }
     }
 
     /// Copy the contents of the `buf` slice to the java long array at the
     /// `start` index.
+    #[deprecated(
+        since = "0.22.0",
+        note = "use JLongArray::set_region instead; this method will be removed in a future version"
+    )]
     pub fn set_long_array_region<'other_local>(
         &self,
         array: impl AsRef<JLongArray<'other_local>>,
         start: jsize,
         buf: &[jlong],
     ) -> Result<()> {
-        let array = null_check!(array.as_ref(), "set_long_array_region array argument")?;
-        unsafe {
-            jni_call_check_ex!(
-                self,
-                v1_1,
-                SetLongArrayRegion,
-                array.as_raw(),
-                start,
-                buf.len() as jsize,
-                buf.as_ptr()
-            )
-        }
+        unsafe { <jlong as TypeArraySealed>::set_region(self, array.as_ref().as_raw(), start, buf) }
     }
 
     /// Copy the contents of the `buf` slice to the java float array at the
     /// `start` index.
+    #[deprecated(
+        since = "0.22.0",
+        note = "use JFloatArray::set_region instead; this method will be removed in a future version"
+    )]
     pub fn set_float_array_region<'other_local>(
         &self,
         array: impl AsRef<JFloatArray<'other_local>>,
         start: jsize,
         buf: &[jfloat],
     ) -> Result<()> {
-        let array = null_check!(array.as_ref(), "set_float_array_region array argument")?;
         unsafe {
-            jni_call_check_ex!(
-                self,
-                v1_1,
-                SetFloatArrayRegion,
-                array.as_raw(),
-                start,
-                buf.len() as jsize,
-                buf.as_ptr()
-            )
+            <jfloat as TypeArraySealed>::set_region(self, array.as_ref().as_raw(), start, buf)
         }
     }
 
     /// Copy the contents of the `buf` slice to the java double array at the
     /// `start` index.
+    #[deprecated(
+        since = "0.22.0",
+        note = "use JDoubleArray::set_region instead; this method will be removed in a future version"
+    )]
     pub fn set_double_array_region<'other_local>(
         &self,
         array: impl AsRef<JDoubleArray<'other_local>>,
         start: jsize,
         buf: &[jdouble],
     ) -> Result<()> {
-        let array = null_check!(array.as_ref(), "set_double_array_region array argument")?;
         unsafe {
-            jni_call_check_ex!(
-                self,
-                v1_1,
-                SetDoubleArrayRegion,
-                array.as_raw(),
-                start,
-                buf.len() as jsize,
-                buf.as_ptr()
-            )
+            <jdouble as TypeArraySealed>::set_region(self, array.as_ref().as_raw(), start, buf)
         }
     }
 
@@ -3704,60 +3611,13 @@ impl<'local> JNIEnv<'local> {
 
     /// Returns an [`AutoElements`] to access the elements of the given Java `array`.
     ///
-    /// The elements are accessible until the returned auto-release guard is dropped.
-    ///
-    /// The returned array may be a copy of the Java array and changes made to
-    /// the returned array will not necessarily be reflected in the original
-    /// array until the [`AutoElements`] guard is dropped.
-    ///
-    /// If you know in advance that you will only be reading from the array then
-    /// pass [`ReleaseMode::NoCopyBack`] so that the JNI implementation knows
-    /// that it's not necessary to copy any data back to the original Java array
-    /// when the [`AutoElements`] guard is dropped.
-    ///
-    /// Since the returned array may be a copy of the Java array, changes made to the
-    /// returned array will not necessarily be reflected in the original array until
-    /// the corresponding `Release*ArrayElements` JNI method is called.
-    /// [`AutoElements`] has a commit() method, to force a copy back of pending
-    /// array changes if needed (and without releasing it).
-    ///
     /// # Safety
     ///
-    /// ## No data races
-    ///
-    /// This API has no built-in synchronization that ensures there won't be any data
-    /// races while accessing the array elements.
-    ///
-    /// To avoid undefined behaviour it is the caller's responsibility to ensure there
-    /// will be no data races between other Rust or Java threads trying to access the
-    /// same array.
-    ///
-    /// Acquiring a [`MonitorGuard`] lock for the `array` could be one way of ensuring
-    /// mutual exclusion between Rust and Java threads, so long as the Java threads
-    /// also acquire the same lock via `synchronized(array) {}`.
-    ///
-    /// ## No aliasing
-    ///
-    /// Callers must not create more than one [`AutoElements`] or
-    /// [`AutoElementsCritical`] per Java array at the same time - even if
-    /// there is no risk of a data race.
-    ///
-    /// The reason for this restriction is that [`AutoElements`] and
-    /// [`AutoElementsCritical`] implement `DerefMut` which can provide a
-    /// mutable `&mut [T]` slice reference for the elements and it would
-    /// constitute undefined behaviour to allow there to be more than one
-    /// mutable reference that points to the same memory.
-    ///
-    /// # jboolean elements
-    ///
-    /// Keep in mind that arrays of `jboolean` values should only ever hold
-    /// values of `0` or `1` because any other value could lead to undefined
-    /// behaviour within the JVM.
-    ///
-    /// Also see
-    /// [`get_array_elements_critical`](Self::get_array_elements_critical) which
-    /// imposes additional restrictions that make it less likely to incur the
-    /// cost of copying the array elements.
+    /// See: [JPrimitiveArray::get_array_elements] for more details
+    #[deprecated(
+        since = "0.22.0",
+        note = "use JPrimitiveArray::get_elements instead. This API will be removed in a future version"
+    )]
     pub unsafe fn get_array_elements<'array_local, T, TArrayRef>(
         &self,
         array: TArrayRef,
@@ -3772,104 +3632,22 @@ impl<'local> JNIEnv<'local> {
 
     /// Returns an [`AutoElementsCritical`] to access the elements of the given Java `array`.
     ///
-    /// The elements are accessible during the critical section that exists until the
-    /// returned auto-release guard is dropped.
-    ///
-    /// This API imposes some strict restrictions that help the JNI implementation
-    /// avoid any need to copy the underlying array elements before making them
-    /// accessible to native code:
-    ///
-    /// 1. No other use of JNI calls are allowed (on the same thread) within the critical
-    ///    section that exists while holding the [`AutoElementsCritical`] guard.
-    /// 2. No system calls can be made (Such as `read`) that may depend on a result
-    ///    from another Java thread.
-    ///
-    /// The JNI spec does not specify what will happen if these rules aren't adhered to
-    /// but it should be assumed it will lead to undefined behaviour, likely deadlock
-    /// and possible program termination.
-    ///
-    /// Even with these restrictions the returned array may still be a copy of
-    /// the Java array and changes made to the returned array will not
-    /// necessarily be reflected in the original array until the [`AutoElementsCritical`]
-    /// guard is dropped.
-    ///
-    /// If you know in advance that you will only be reading from the array then
-    /// pass [`ReleaseMode::NoCopyBack`] so that the JNI implementation knows
-    /// that it's not necessary to copy any data back to the original Java array
-    /// when the [`AutoElementsCritical`] guard is dropped.
-    ///
-    /// A nested scope or explicit use of `std::mem::drop` can be used to
-    /// control when the returned [`AutoElementsCritical`] is dropped to
-    /// minimize the length of the critical section.
-    ///
-    /// If the given array is `null`, an `Error::NullPtr` is returned.
-    ///
     /// # Safety
     ///
-    /// ## Critical Section Restrictions
-    ///
-    /// Although this API takes a mutable reference to a [`JNIEnv`] which should
-    /// ensure that it's not possible to call JNI, this API is still marked as
-    /// `unsafe` due to the complex, far-reaching nature of the critical-section
-    /// restrictions imposed here that can't be guaranteed simply through Rust's
-    /// borrow checker rules.
-    ///
-    /// The rules above about JNI usage and system calls _must_ be adhered to.
-    ///
-    /// Using this API implies:
-    ///
-    /// 1. All garbage collection will likely be paused during the critical section
-    /// 2. Any use of JNI in other threads may block if they need to allocate memory
-    ///    (due to the garbage collector being paused)
-    /// 3. Any use of system calls that will wait for a result from another Java thread
-    ///    could deadlock if that other thread is blocked by a paused garbage collector.
-    ///
-    /// A failure to adhere to the critical section rules could lead to any
-    /// undefined behaviour, including aborting the program.
-    ///
-    /// ## No data races
-    ///
-    /// This API has no built-in synchronization that ensures there won't be any data
-    /// races while accessing the array elements.
-    ///
-    /// To avoid undefined behaviour it is the caller's responsibility to ensure there
-    /// will be no data races between other Rust or Java threads trying to access the
-    /// same array.
-    ///
-    /// Acquiring a [`MonitorGuard`] lock for the `array` could be one way of ensuring
-    /// mutual exclusion between Rust and Java threads, so long as the Java threads
-    /// also acquire the same lock via `synchronized(array) {}`.
-    ///
-    /// ## No aliasing
-    ///
-    /// Callers must not create more than one [`AutoElements`] or
-    /// [`AutoElementsCritical`] per Java array at the same time - even if
-    /// there is no risk of a data race.
-    ///
-    /// The reason for this restriction is that [`AutoElements`] and
-    /// [`AutoElementsCritical`] implement `DerefMut` which can provide a
-    /// mutable `&mut [T]` slice reference for the elements and it would
-    /// constitute undefined behaviour to allow there to be more than one
-    /// mutable reference that points to the same memory.
-    ///
-    /// ## jboolean elements
-    ///
-    /// Keep in mind that arrays of `jboolean` values should only ever hold
-    /// values of `0` or `1` because any other value could lead to undefined
-    /// behaviour within the JVM.
-    ///
-    /// Also see [`get_array_elements`](Self::get_array_elements) which has fewer
-    /// restrictions, but is is more likely to incur a cost from copying the
-    /// array elements.
-    pub unsafe fn get_array_elements_critical<'other_local, 'array, 'env, T: TypeArray>(
-        &'env mut self,
-        array: &'array JPrimitiveArray<'other_local, T>,
+    /// See: [JPrimitiveArray::get_array_elements_critical] for more details
+    #[deprecated(
+        since = "0.22.0",
+        note = "use JPrimitiveArray::get_elements_critical instead. This API will be removed in a future version"
+    )]
+    pub unsafe fn get_array_elements_critical<'array_local, T, TArrayRef>(
+        &self,
+        array: TArrayRef,
         mode: ReleaseMode,
-    ) -> Result<AutoElementsCritical<'local, 'other_local, 'array, 'env, T>> {
-        // Runtime check that the 'local reference lifetime will be tied to
-        // JNIEnv lifetime for the top JNI stack frame
-        assert_eq!(self.level, JavaVM::thread_attach_guard_level());
-        let array = null_check!(array, "get_primitive_array_critical array argument")?;
+    ) -> Result<AutoElementsCritical<'array_local, T, TArrayRef>>
+    where
+        T: TypeArray,
+        TArrayRef: AsRef<JPrimitiveArray<'array_local, T>> + JObjectRef,
+    {
         AutoElementsCritical::new(self, array, mode)
     }
 }

--- a/src/wrapper/objects/jobject_array.rs
+++ b/src/wrapper/objects/jobject_array.rs
@@ -3,6 +3,7 @@ use std::ops::Deref;
 use once_cell::sync::OnceCell;
 
 use crate::{
+    env::JNIEnv,
     errors::Result,
     objects::{GlobalRef, JClass, JObject, JObjectRef, LoaderContext},
     strings::JNIStr,
@@ -80,9 +81,21 @@ impl JObjectArray<'_> {
         Self(JObject::from_raw(raw as jobject))
     }
 
+    /// Returns the raw JNI pointer.
+    pub const fn as_raw(&self) -> jobjectArray {
+        self.0.as_raw() as jobjectArray
+    }
+
     /// Unwrap to the raw jni type.
     pub const fn into_raw(self) -> jobjectArray {
         self.0.into_raw() as jobjectArray
+    }
+
+    /// Returns the length of the array.
+    pub fn len(&self, env: &JNIEnv) -> Result<usize> {
+        let array = null_check!(self.as_raw(), "JObjectArray::len self argument")?;
+        let len = unsafe { jni_call_unchecked!(env, v1_1, GetArrayLength, array) } as usize;
+        Ok(len)
     }
 }
 

--- a/src/wrapper/objects/jprimitive_array.rs
+++ b/src/wrapper/objects/jprimitive_array.rs
@@ -4,17 +4,18 @@ use std::ops::Deref;
 use once_cell::sync::OnceCell;
 
 use crate::{
+    env::JNIEnv,
     errors::Result,
-    objects::{GlobalRef, JClass, JObject, JObjectRef, LoaderContext},
+    objects::{
+        AutoElements, AutoElementsCritical, GlobalRef, JClass, JObject, JObjectRef, LoaderContext,
+        ReleaseMode,
+    },
     strings::JNIStr,
     sys::{jarray, jobject},
     JavaVM,
 };
 
 use super::TypeArray;
-
-#[cfg(doc)]
-use crate::JNIEnv;
 
 /// Lifetime'd representation of a [`jarray`] which wraps a [`JObject`] reference
 ///
@@ -24,7 +25,7 @@ use crate::JNIEnv;
 #[derive(Debug)]
 pub struct JPrimitiveArray<'local, T: TypeArray> {
     obj: JObject<'local>,
-    lifetime: PhantomData<(&'local (), T)>,
+    _marker: PhantomData<T>,
 }
 
 impl<'local, T: TypeArray> AsRef<JPrimitiveArray<'local, T>> for JPrimitiveArray<'local, T> {
@@ -63,12 +64,12 @@ impl<T: TypeArray> std::default::Default for JPrimitiveArray<'_, T> {
     fn default() -> Self {
         Self {
             obj: JObject::null(),
-            lifetime: PhantomData,
+            _marker: PhantomData,
         }
     }
 }
 
-impl<T: TypeArray> JPrimitiveArray<'_, T> {
+impl<'local, T: TypeArray> JPrimitiveArray<'local, T> {
     /// Creates a [`JPrimitiveArray`] that wraps the given `raw` [`jarray`]
     ///
     /// # Safety
@@ -82,13 +83,209 @@ impl<T: TypeArray> JPrimitiveArray<'_, T> {
     pub const unsafe fn from_raw(raw: jarray) -> Self {
         Self {
             obj: JObject::from_raw(raw as jobject),
-            lifetime: PhantomData,
+            _marker: PhantomData,
         }
+    }
+
+    /// Returns the raw JNI pointer.
+    pub const fn as_raw(&self) -> jarray {
+        self.obj.as_raw() as jarray
     }
 
     /// Unwrap to the raw jni type.
     pub const fn into_raw(self) -> jarray {
         self.obj.into_raw() as jarray
+    }
+
+    /// Returns the length of the array.
+    pub fn len(&self, env: &JNIEnv) -> Result<usize> {
+        let array = null_check!(self.as_raw(), "JPrimitiveArray::len self argument")?;
+        let len = unsafe { jni_call_unchecked!(env, v1_1, GetArrayLength, array) } as usize;
+        Ok(len)
+    }
+
+    /// Returns an [`AutoElements`] to access the elements of the given Java `array`.
+    ///
+    /// The elements are accessible until the returned auto-release guard is dropped.
+    ///
+    /// The returned array may be a copy of the Java array and changes made to
+    /// the returned array will not necessarily be reflected in the original
+    /// array until the [`AutoElements`] guard is dropped.
+    ///
+    /// If you know in advance that you will only be reading from the array then
+    /// pass [`ReleaseMode::NoCopyBack`] so that the JNI implementation knows
+    /// that it's not necessary to copy any data back to the original Java array
+    /// when the [`AutoElements`] guard is dropped.
+    ///
+    /// Since the returned array may be a copy of the Java array, changes made to the
+    /// returned array will not necessarily be reflected in the original array until
+    /// the corresponding `Release*ArrayElements` JNI method is called.
+    /// [`AutoElements`] has a commit() method, to force a copy back of pending
+    /// array changes if needed (and without releasing it).
+    ///
+    /// # Safety
+    ///
+    /// ## No data races
+    ///
+    /// This API has no built-in synchronization that ensures there won't be any data
+    /// races while accessing the array elements.
+    ///
+    /// To avoid undefined behaviour it is the caller's responsibility to ensure there
+    /// will be no data races between other Rust or Java threads trying to access the
+    /// same array.
+    ///
+    /// Acquiring a [`MonitorGuard`] lock for the `array` could be one way of ensuring
+    /// mutual exclusion between Rust and Java threads, so long as the Java threads
+    /// also acquire the same lock via `synchronized(array) {}`.
+    ///
+    /// ## No aliasing
+    ///
+    /// Callers must not create more than one [`AutoElements`] or
+    /// [`AutoElementsCritical`] per Java array at the same time - even if
+    /// there is no risk of a data race.
+    ///
+    /// The reason for this restriction is that [`AutoElements`] and
+    /// [`AutoElementsCritical`] implement `DerefMut` which can provide a
+    /// mutable `&mut [T]` slice reference for the elements and it would
+    /// constitute undefined behaviour to allow there to be more than one
+    /// mutable reference that points to the same memory.
+    ///
+    /// # jboolean elements
+    ///
+    /// Keep in mind that arrays of `jboolean` values should only ever hold
+    /// values of `0` or `1` because any other value could lead to undefined
+    /// behaviour within the JVM.
+    ///
+    /// Also see
+    /// [`JNIEnv::get_array_elements_critical`] which
+    /// imposes additional restrictions that make it less likely to incur the
+    /// cost of copying the array elements.
+    pub unsafe fn get_elements(
+        &self,
+        env: &JNIEnv,
+        mode: ReleaseMode,
+    ) -> Result<AutoElements<'local, T, &Self>> {
+        AutoElements::new(env, self, mode)
+    }
+
+    /// Returns an [`AutoElementsCritical`] to access the elements of this
+    /// array.
+    ///
+    /// The elements are accessible during the critical section that exists
+    /// until the returned auto-release guard is dropped.
+    ///
+    /// This API imposes some strict restrictions that help the JNI
+    /// implementation avoid any need to copy the underlying array elements
+    /// before making them accessible to native code:
+    ///
+    /// 1. No other use of JNI calls are allowed (on the same thread) within the
+    ///    critical section that exists while holding the
+    ///    [`AutoElementsCritical`] guard.
+    /// 2. No system calls can be made (Such as `read`) that may depend on a
+    ///    result from another Java thread.
+    ///
+    /// The JNI spec does not specify what will happen if these rules aren't
+    /// adhered to but it should be assumed it will lead to undefined behaviour,
+    /// likely deadlock and possible program termination.
+    ///
+    /// Even with these restrictions the returned array may still be a copy of
+    /// the Java array and changes made to the returned array will not
+    /// necessarily be reflected in the original array until the
+    /// [`AutoElementsCritical`] guard is dropped.
+    ///
+    /// If you know in advance that you will only be reading from the array then
+    /// pass [`ReleaseMode::NoCopyBack`] so that the JNI implementation knows
+    /// that it's not necessary to copy any data back to the original Java array
+    /// when the [`AutoElementsCritical`] guard is dropped.
+    ///
+    /// A nested scope or explicit use of `std::mem::drop` can be used to
+    /// control when the returned [`AutoElementsCritical`] is dropped to
+    /// minimize the length of the critical section.
+    ///
+    /// If this array is `null`, an [`Error::NullPtr`] is returned.
+    ///
+    /// # Safety
+    ///
+    /// ## Critical Section Restrictions
+    ///
+    /// This API is marked as `unsafe` due to the complex, far-reaching nature
+    /// of the critical-section restrictions imposed here that can't be enforced
+    /// through Rust's borrow checker rules.
+    ///
+    /// The rules above about JNI usage and system calls _must_ be adhered to.
+    ///
+    /// Using this API implies:
+    ///
+    /// 1. All garbage collection will likely be paused during the critical
+    ///    section
+    /// 2. Any use of JNI in other threads may block if they need to allocate
+    ///    memory (due to the garbage collector being paused)
+    /// 3. Any use of system calls that will wait for a result from another Java
+    ///    thread could deadlock if that other thread is blocked by a paused
+    ///    garbage collector.
+    ///
+    /// A failure to adhere to the critical section rules could lead to any
+    /// undefined behaviour, including aborting the program.
+    ///
+    /// ## No data races
+    ///
+    /// This API has no built-in synchronization that ensures there won't be any
+    /// data races while accessing the array elements.
+    ///
+    /// To avoid undefined behaviour it is the caller's responsibility to ensure
+    /// there will be no data races between other Rust or Java threads trying to
+    /// access the same array.
+    ///
+    /// Acquiring a [`MonitorGuard`] lock for this array could be one way of
+    /// ensuring mutual exclusion between Rust and Java threads, so long as the
+    /// Java threads also acquire the same lock via `synchronized(array) {}`.
+    ///
+    /// ## No aliasing
+    ///
+    /// Callers must not create more than one [`AutoElements`] or
+    /// [`AutoElementsCritical`] per Java array at the same time - even if there
+    /// is no risk of a data race.
+    ///
+    /// The reason for this restriction is that [`AutoElements`] and
+    /// [`AutoElementsCritical`] implement `DerefMut` which can provide a
+    /// mutable `&mut [T]` slice reference for the elements and it would
+    /// constitute undefined behaviour to allow there to be more than one
+    /// mutable reference that points to the same memory.
+    ///
+    /// ## jboolean elements
+    ///
+    /// Keep in mind that arrays of `jboolean` values should only ever hold
+    /// values of `0` or `1` because any other value could lead to undefined
+    /// behaviour within the JVM.
+    ///
+    /// Also see [`get_array_elements`](Self::get_array_elements) which has
+    /// fewer restrictions, but is more likely to incur a cost from copying
+    /// the array elements.
+    pub unsafe fn get_elements_critical(
+        &self,
+        env: &JNIEnv<'_>,
+        mode: ReleaseMode,
+    ) -> Result<AutoElementsCritical<'local, T, &Self>> {
+        AutoElementsCritical::new(env, self, mode)
+    }
+
+    /// Copy elements of the array from the `start` index to the
+    /// `buf` slice. The number of copied elements is equal to the `buf` length.
+    ///
+    /// # Errors
+    /// If `start` is negative _or_ `start + buf.len()` is greater than [`array.length`]
+    /// then no elements are copied, an `ArrayIndexOutOfBoundsException` is thrown,
+    /// and `Err` is returned.
+    ///
+    /// [`array.length`]: struct.JNIEnv.html#method.get_array_length
+    pub fn get_region(&self, env: &JNIEnv, start: crate::sys::jsize, buf: &mut [T]) -> Result<()> {
+        unsafe { T::get_region(env, self.as_raw() as jarray, start, buf) }
+    }
+
+    /// Copy the contents of the `buf` slice to the java byte array at the
+    /// `start` index.
+    pub fn set_region(&self, env: &JNIEnv, start: crate::sys::jsize, buf: &[T]) -> Result<()> {
+        unsafe { T::set_region(env, self.as_raw() as jarray, start, buf) }
     }
 }
 

--- a/src/wrapper/objects/mod.rs
+++ b/src/wrapper/objects/mod.rs
@@ -74,6 +74,9 @@ pub use self::release_mode::*;
 mod jobject_array;
 pub use self::jobject_array::*;
 
+mod type_array;
+pub use self::type_array::*;
+
 /// Primitive Array types
 mod jprimitive_array;
 pub use self::jprimitive_array::*;

--- a/src/wrapper/objects/type_array.rs
+++ b/src/wrapper/objects/type_array.rs
@@ -1,0 +1,179 @@
+use crate::sys::{jboolean, jbyte, jchar, jdouble, jfloat, jint, jlong, jshort};
+
+pub(crate) mod type_array_sealed {
+    use jni_sys::jsize;
+
+    use crate::sys::{jarray, jboolean, jbyte, jchar, jdouble, jfloat, jint, jlong, jshort};
+    use crate::{env::JNIEnv, errors::*};
+    use paste::paste;
+    use std::ptr::NonNull;
+
+    /// Trait to define type array access/release
+    ///
+    /// # Safety
+    ///
+    /// The methods of this trait must uphold the invariants described in [`JNIEnv::unsafe_clone`] when
+    /// using the provided [`JNIEnv`].
+    ///
+    /// The `get` method must return a valid pointer to the beginning of the JNI array.
+    ///
+    /// The `release` method must not invalidate the `ptr` if the `mode` is [`sys::JNI_COMMIT`].
+    pub unsafe trait TypeArraySealed: Copy + Send + Sync {
+        /// getter
+        ///
+        /// # Safety
+        ///
+        /// `array` must be a valid pointer to an `Array` object, or `null`
+        ///
+        /// The caller is responsible for passing the returned pointer to [`release`], along
+        /// with the same `env` and `array` reference (which needs to still be valid)
+        unsafe fn get_elements(
+            env: &JNIEnv,
+            array: jarray,
+            is_copy: &mut jboolean,
+        ) -> Result<*mut Self>;
+
+        /// releaser
+        ///
+        /// # Safety
+        ///
+        /// `array` must be a valid pointer to an `Array` object, or `null`
+        ///
+        /// `ptr` must have been previously returned by the `get` function.
+        ///
+        /// If `mode` is not [`sys::JNI_COMMIT`], `ptr` must not be used again after calling this
+        /// function.
+        unsafe fn release_elements(
+            env: &JNIEnv,
+            array: jarray,
+            ptr: NonNull<Self>,
+            mode: i32,
+        ) -> Result<()>;
+
+        /// Copy elements of the array from the `start` index to the `buf` slice. The number of
+        /// copied elements is equal to the `buf` length.
+        ///
+        /// # Errors
+        ///
+        /// If `start` is negative _or_ `start + buf.len()` is greater than [`JPrimitiveArray::len`]
+        /// then no elements are copied, an `ArrayIndexOutOfBoundsException` is thrown, and `Err` is
+        /// returned.
+        ///
+        /// # Safety
+        ///
+        /// `array` must be a valid pointer to a primitive JNI array object, matching the type of
+        /// `Self`, or `null`.
+        unsafe fn get_region(
+            env: &JNIEnv,
+            array: jarray,
+            start: jsize,
+            buf: &mut [Self],
+        ) -> Result<()>;
+
+        /// Copy the contents of the `buf` slice to the java byte array at the
+        /// `start` index.
+        ///
+        /// # Safety
+        ///
+        /// `array` must be a valid pointer to a primitive JNI array object, matching the type of
+        /// `Self`, or `null`.
+        unsafe fn set_region(env: &JNIEnv, array: jarray, start: jsize, buf: &[Self])
+            -> Result<()>;
+    }
+
+    // TypeArray builder
+    macro_rules! type_array {
+        ( $jni_type:ty, $jni_type_name:ident) => {
+            paste! {
+                /// $jni_type array access/release impl
+                unsafe impl TypeArraySealed for $jni_type {
+                    /// Get Java $jni_type array
+                    unsafe fn get_elements(
+                        env: &JNIEnv,
+                        array: jarray,
+                        is_copy: &mut jboolean,
+                    ) -> Result<*mut Self> {
+                        // There are no documented exceptions for Get<Primitive>ArrayElements() but
+                        // they may return `NULL`.
+                        let ptr = jni_call_only_check_null_ret!(env, v1_1, [< Get $jni_type_name ArrayElements>], array, is_copy)?;
+                        Ok(ptr as _)
+                    }
+
+                    /// Release Java $jni_type array
+                    unsafe fn release_elements(
+                        env: &JNIEnv,
+                        array: jarray,
+                        ptr: NonNull<Self>,
+                        mode: i32,
+                    ) -> Result<()> {
+                        // There are no documented exceptions for Release<Primitive>ArrayElements()
+                        jni_call_unchecked!(env, v1_1, [< Release $jni_type_name ArrayElements>], array, ptr.as_ptr(), mode as i32);
+                        Ok(())
+                    }
+
+                    unsafe fn get_region(
+                        env: &JNIEnv,
+                        array: jarray,
+                        start: jsize,
+                        buf: &mut [Self],
+                    ) -> Result<()> {
+                        let array =
+                            null_check!(array, "get_*_array_region array argument")?;
+                        unsafe {
+                            jni_call_check_ex!(
+                                env,
+                                v1_1,
+                                [< Get $jni_type_name ArrayRegion>],
+                                array,
+                                start,
+                                buf.len() as jsize,
+                                buf.as_mut_ptr()
+                            )
+                        }
+                    }
+
+                    unsafe fn set_region(
+                        env: &JNIEnv,
+                        array: jarray,
+                        start: jsize,
+                        buf: &[Self],
+                    ) -> Result<()> {
+                        let array = null_check!(array, "set_*_array_region array argument")?;
+                        unsafe {
+                            jni_call_check_ex!(
+                                env,
+                                v1_1,
+                                [< Set $jni_type_name ArrayRegion>],
+                                array,
+                                start,
+                                buf.len() as jsize,
+                                buf.as_ptr()
+                            )
+                        }
+                    }
+                }
+            }
+        };
+    }
+
+    type_array!(jint, Int);
+    type_array!(jlong, Long);
+    type_array!(jbyte, Byte);
+    type_array!(jboolean, Boolean);
+    type_array!(jchar, Char);
+    type_array!(jshort, Short);
+    type_array!(jfloat, Float);
+    type_array!(jdouble, Double);
+}
+
+/// A sealed trait to define type array access/release for primitive JNI types
+pub trait TypeArray: type_array_sealed::TypeArraySealed {}
+
+impl TypeArray for jint {}
+impl TypeArray for jlong {}
+impl TypeArray for jbyte {}
+impl TypeArray for jboolean {}
+impl TypeArray for jchar {}
+impl TypeArray for jshort {}
+impl TypeArray for jfloat {}
+impl TypeArray for jdouble {}

--- a/tests/ui/fail/auto-elements-lifetime.stderr
+++ b/tests/ui/fail/auto-elements-lifetime.stderr
@@ -1,3 +1,11 @@
+warning: use of deprecated method `jni::env::JNIEnv::<'local>::get_array_elements`: use JPrimitiveArray::get_elements instead. This API will be removed in a future version
+  --> tests/ui/fail/auto-elements-lifetime.rs:19:30
+   |
+19 |                         env2.get_array_elements(java_array, ReleaseMode::CopyBack)
+   |                              ^^^^^^^^^^^^^^^^^^
+   |
+   = note: `#[warn(deprecated)]` on by default
+
 error: lifetime may not live long enough
   --> tests/ui/fail/auto-elements-lifetime.rs:26:17
    |


### PR DESCRIPTION
Firstly, this is a follow up to #508 that applies the same simplifications to `AutoElementsCritical` that were made to `AutoElements`.

This also moves more of the `JPrimitiveArray` implementation details into the `TypeArray` trait so we don't have an inconsistency in how we access array elements vs array regions.

All of the `JNIEnv::get_*_array_region` and `JNIEnv::set_*_array_region` methods are now implemented in terms of `TypeArray::get_array_region` and `TypeArray::set_array_region` respectively.

`JPrimitiveArray` now has `get/set_array_region` methods and all of the separate `JNIEnv::get_*_array_region` and `JNIEnv::set_*_array_region` have been marked as deprecated, with a pointer to the `JPrimitiveArray` methods.
