### PR TITLE
Implement `Display` for `JNIStr`, based on `JNIStr::to_str`

### DIFF
--- a/src/wrapper/strings/ffi_str.rs
+++ b/src/wrapper/strings/ffi_str.rs
@@ -144,6 +144,13 @@ impl From<JNIString> for String {
     }
 }
 
+impl std::fmt::Display for JNIStr {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let s = self.to_str();
+        write!(f, "{}", s)
+    }
+}
+
 impl JNIString {
     /// Converts a Rust string (in standard UTF-8 encoding) into a
     /// Java-compatible string (in Java's [modified UTF-8] encoding).


### PR DESCRIPTION
This makes it more convenient to get a `String` via `JNIStr::to_string`
