### PR TITLE
Keep thread attachment by JNI_CreateJavaVM

### DIFF
--- a/tests/threads_detach.rs
+++ b/tests/threads_detach.rs
@@ -32,7 +32,11 @@ fn thread_detaches_for_tls_attachment_when_finished() {
 rusty_fork_test! {
 #[test]
 fn thread_detaches_for_scoped_attachment() {
+    // A newly created VM will be attached
+    assert_eq!(jvm().threads_attached(), 1);
+    jvm().detach_current_thread().unwrap();
     assert_eq!(jvm().threads_attached(), 0);
+
     attach_current_thread_for_scope(|env| {
         assert_eq!(jvm().threads_attached(), 1);
         let val = call_java_abs(env, -1);
@@ -55,6 +59,9 @@ fn thread_detaches_for_outer_scoped_attachment() {
 rusty_fork_test! {
 #[test]
 fn threads_explicit_detach_error_for_scoped_attachment() {
+    // A newly created VM will be attached
+    assert_eq!(jvm().threads_attached(), 1);
+    jvm().detach_current_thread().unwrap();
     assert_eq!(jvm().threads_attached(), 0);
 
     attach_current_thread_for_scope(|env| {
@@ -83,6 +90,9 @@ fn threads_explicit_detach_error_for_scoped_attachment() {
 rusty_fork_test! {
 #[test]
 fn threads_explicit_detach_tls_attachment() {
+    // A newly created VM will be attached
+    assert_eq!(jvm().threads_attached(), 1);
+    jvm().detach_current_thread().unwrap();
     assert_eq!(jvm().threads_attached(), 0);
 
     attach_current_thread(|env| {
@@ -117,6 +127,9 @@ fn threads_explicit_detach_tls_attachment() {
 rusty_fork_test! {
 #[test]
 fn threads_scoped_attachments_nest() {
+    // A newly created VM will be attached
+    assert_eq!(jvm().threads_attached(), 1);
+    jvm().detach_current_thread().unwrap();
     assert_eq!(jvm().threads_attached(), 0);
     assert!(!util::is_thread_attached());
 
@@ -155,6 +168,9 @@ fn threads_scoped_attachments_nest() {
 rusty_fork_test! {
 #[test]
 fn threads_scope_attachments_block_tls_attachments() {
+    // A newly created VM will be attached
+    assert_eq!(jvm().threads_attached(), 1);
+    jvm().detach_current_thread().unwrap();
     assert_eq!(jvm().threads_attached(), 0);
 
     attach_current_thread_for_scope(|_| {
@@ -191,8 +207,12 @@ fn threads_scope_attachments_block_tls_attachments() {
 rusty_fork_test! {
 #[test]
 fn threads_guard_nesting_blocks_explicit_detachment() {
-    assert_eq!(jvm().threads_attached(), 0);
+    // A newly created VM will be attached
+    assert_eq!(jvm().threads_attached(), 1);
+    // There are initially no AttachGuards in place
     assert_eq!(JavaVM::thread_attach_guard_level(), 0);
+    jvm().detach_current_thread().unwrap();
+    assert_eq!(jvm().threads_attached(), 0);
 
     // While there are no guards and no attachment then `detach_current_thread`
     // is a no-op that shouldn't return an error.

--- a/tests/threads_nested_attach_with_frames.rs
+++ b/tests/threads_nested_attach_with_frames.rs
@@ -11,7 +11,11 @@ use util::jvm;
 /// on exit.
 #[test]
 fn nested_attach() {
+    // A newly created VM will be attached
+    assert_eq!(jvm().threads_attached(), 1);
+    jvm().detach_current_thread().unwrap();
     assert_eq!(jvm().threads_attached(), 0);
+
     let thread = spawn(|| {
         assert_eq!(jvm().threads_attached(), 0);
         check_nested_attach(jvm());


### PR DESCRIPTION
Instead of immediately calling `DetachCurrentThread` after `JNI_CreateJavaVM` returns, we now instead take ownership of the attachment by installing a `TLSAttachGuard`.

This should help preserve any special "main" thread status that the JVM may imbue on this first thread.

The unit tests have been updated accordingly to expect a single thread attachment after creating a new JVM.

Fixes: #590
