### PR TITLE
make set_static_field safe + mark _unchecked field apis unsafe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,7 +49,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `JValueGen` has been removed. `JValue` and `JValueOwned` are now separate, unrelated, non-generic types. ([#429](https://github.com/jni-rs/jni-rs/pull/429))
 - Make most `from_raw()`, `get_raw()` and `into_raw()` methods `const fn`. ([#453](https://github.com/jni-rs/jni-rs/pull/453))
 - `get_object_class` borrows the `JNIEnv` mutably because it creates a new local reference. ([#456](https://github.com/jni-rs/jni-rs/pull/456))
-- `get/set_field_unchecked` have been marked as unsafe since they can lead to undefined behaviour if the given types don't match the field type ([#457](https://github.com/jni-rs/jni-rs/pull/457))
+- `get/set_*_field_unchecked` have been marked as unsafe since they can lead to undefined behaviour if the given types don't match the field type ([#457](https://github.com/jni-rs/jni-rs/pull/457) + [#629](https://github.com/jni-rs/jni-rs/pull/629))
+- `set_static_field` takes a field name and signature as strings so the ID is looked up internally to ensure it's valid. ([#629](https://github.com/jni-rs/jni-rs/pull/629))
 - `JNIEnv::get/set/take_rust_field` no longer require a mutable `JNIEnv` reference since they don't return any new local references to the caller ([#455](https://github.com/jni-rs/jni-rs/issues/455))
 - `JNIEnv::is_assignable_from` and `is_instance_of` no longer requires a mutable `JNIEnv` reference, since they doesn't return an new local references to the caller
 - `JavaStr` has been renamed `MUTF8Chars` and intended to be got via `JString::mutf8_chars()`

--- a/src/wrapper/objects/jvalue.rs
+++ b/src/wrapper/objects/jvalue.rs
@@ -4,6 +4,7 @@ use std::fmt::Debug;
 
 use log::trace;
 
+use crate::signature::JavaType;
 use crate::{errors::*, objects::JObject, signature::Primitive, sys::*};
 
 #[cfg(doc)]
@@ -219,6 +220,22 @@ impl<'obj_ref> JValue<'obj_ref> {
             Self::Bool(_) => "bool",
             Self::Float(_) => "float",
             Self::Double(_) => "double",
+        }
+    }
+
+    /// Get the corresponding Java type.
+    pub fn java_type(&self) -> JavaType {
+        match *self {
+            Self::Object(_) => JavaType::Object,
+            Self::Void => JavaType::Primitive(Primitive::Void),
+            Self::Byte(_) => JavaType::Primitive(Primitive::Byte),
+            Self::Char(_) => JavaType::Primitive(Primitive::Char),
+            Self::Short(_) => JavaType::Primitive(Primitive::Short),
+            Self::Int(_) => JavaType::Primitive(Primitive::Int),
+            Self::Long(_) => JavaType::Primitive(Primitive::Long),
+            Self::Bool(_) => JavaType::Primitive(Primitive::Boolean),
+            Self::Float(_) => JavaType::Primitive(Primitive::Float),
+            Self::Double(_) => JavaType::Primitive(Primitive::Double),
         }
     }
 


### PR DESCRIPTION
This ensures that `set_static_field` looks up the field ID internally instead of trusting that a given field ID is valid.

The two `get/set_static_field_unchecked` APIs are now marked as `unsafe` because they rely on the caller ensuring that the field IDs are valid for the given class and that given types match the field.

This normalizes some naming and documentation details across the various get/set field APIs and adds more comprehensive unit tests that cover each of these functions.

Fixes: #505
Fixes: #628
