### PR TITLE
specify get_static_field_unchecked ty with ReturnType

### DIFF
--- a/src/wrapper/jnienv.rs
+++ b/src/wrapper/jnienv.rs
@@ -3155,7 +3155,7 @@ impl<'local> JNIEnv<'local> {
         &mut self,
         class: C,
         field: F,
-        ty: JavaType,
+        ty: ReturnType,
     ) -> Result<JValueOwned<'local>>
     where
         C: Desc<'local, JClass<'other_local>>,


### PR DESCRIPTION
This addresses an inconsistency between get_field_unchecked and get_static_field_unchecked so they both use `ReturnType` to represent the field type.

Since #607 this change has essentially become redundant (`ReturnType` has become an alias for `JavaType`) but it's still nice to be consistent.

Fixes: #504
