### PR TITLE
Have `new_object_unchecked` accept a `Desc<JMethodID>`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,6 +82,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `JNIEnv::get_array_elements_critical` is deprecated in favor of `JPrimitiveArray::get_elements_critical`
 - `JNIEnv::get_*_array_region` and `JNIEnv::set_*_array_region` are deprecated in favor of `JPrimitiveArray::get/set_region`
 - `JNIEnv::get_array_length` is deprecated in favor of `JPrimitiveArray::len` and `JObjectArray::len`
+- `JNIEnv::new_object_unchecked` now takes a `Desc<JMethodID>` for consistency/flexibility instead of directly taking a `JMethodID`
 
 ### Removed
 - `JavaVM::attach_current_thread_as_daemon` (and general support for 'daemon' threads) has been removed, since their semantics are inherently poorly defined and unsafe (the distinction relates to the poorly defined limbo state after calling `JavaDestroyVM`, where it becomes undefined to touch the JVM) ([#593](https://github.com/jni-rs/jni-rs/pull/593))

--- a/src/wrapper/jnienv.rs
+++ b/src/wrapper/jnienv.rs
@@ -2239,19 +2239,22 @@ impl<'local> JNIEnv<'local> {
     /// The provided JMethodID must be valid, and match the types and number of arguments, as well as return type
     /// (always an Object for a constructor). If these are incorrect, the JVM may crash.  The JMethodID must also match
     /// the passed type.
-    pub unsafe fn new_object_unchecked<'other_local, T>(
+    pub unsafe fn new_object_unchecked<'other_local, C, M>(
         &mut self,
-        class: T,
-        ctor_id: JMethodID,
+        class: C,
+        ctor_id: M,
         ctor_args: &[jvalue],
     ) -> Result<JObject<'local>>
     where
-        T: Desc<'local, JClass<'other_local>>,
+        C: Desc<'local, JClass<'other_local>>,
+        M: Desc<'local, JMethodID>,
     {
         // Runtime check that the 'local reference lifetime will be tied to
         // JNIEnv lifetime for the top JNI stack frame
         assert_eq!(self.level, JavaVM::thread_attach_guard_level());
         let class = class.lookup(self)?;
+
+        let ctor_id: JMethodID = *ctor_id.lookup(self)?.as_ref();
 
         let jni_args = ctor_args.as_ptr();
 


### PR DESCRIPTION
This gives more flexibility with how the `JMethodID` is provided and is consistent with other APIs that need to take a method ID.

Fixes: #532
