### PR TITLE
Implement Display for MUTF8Chars and JString

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,14 +53,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `set_static_field` takes a field name and signature as strings so the ID is looked up internally to ensure it's valid. ([#629](https://github.com/jni-rs/jni-rs/pull/629))
 - `JNIEnv::get/set/take_rust_field` no longer require a mutable `JNIEnv` reference since they don't return any new local references to the caller ([#455](https://github.com/jni-rs/jni-rs/issues/455))
 - `JNIEnv::is_assignable_from` and `is_instance_of` no longer requires a mutable `JNIEnv` reference, since they doesn't return an new local references to the caller
-- `JavaStr` has been renamed `MUTF8Chars` and intended to be got via `JString::mutf8_chars()`
+- `JavaStr` has been renamed `MUTF8Chars` (with a deprecated `JavaStr` alias) and intended to be got via `JString::mutf8_chars()`
 - `JavaStr/MUTF8Chars::from_env` has been removed because it was unsound (it could cause undefined behavior and was not marked `unsafe`). Use `JString::mutf8_chars` instead. ([#510](https://github.com/jni-rs/jni-rs/issues/510) / [#512](https://github.com/jni-rs/jni-rs/pull/512))
 - `JavaStr/MUTF8Chars::get_raw` has been renamed to `as_ptr`. ([#510](https://github.com/jni-rs/jni-rs/issues/510) / [#512](https://github.com/jni-rs/jni-rs/pull/512))
 - `JavaStr/MUTF8Chars`, `JNIStr`, and `JNIString` no longer coerce to `CStr`, because using `CStr::to_str` will often have incorrect results. You can still get a `CStr`, but must use the new `as_cstr` method to do so. ([#510](https://github.com/jni-rs/jni-rs/issues/510) / [#512](https://github.com/jni-rs/jni-rs/pull/512))
 - All APIs that were accepting modified-utf8 string args via `Into<JNIString>`, now take `AsRef<JNIStr>` to avoid string copies every call. Considering that these strings are often literals for signatures or class names, most code can rely on `AsRef<JNIStr>` for `CStr` and pass `CStr` literals like `env.find_class(c"java/lang/Foo")`. ([#617](https://github.com/jni-rs/jni-rs/pull/617))
+- `JavaStr/MUTF8Chars` and `JString` both implement `Display` and therefore `ToString`, making it even easier to get a Rust `String`.
 - `JNIEnv::get_string` performance was optimized by caching an expensive class lookup, and using a faster instanceof check. ([#531](https://github.com/jni-rs/jni-rs/pull/531))
 - `JNIEnv::get_string` performance was later further optimized to avoid the need for runtime type checking ([#612](https://github.com/jni-rs/jni-rs/pull/612))
-- `JNIEnv::get_string` has been deprecated in favor of `JString::mutf8_chars` and `JString::to_string`
+- `JNIEnv::get_string` has been deprecated in favor of `JString::mutf8_chars` and `JString::to_string()` or `JString::try_to_string(env)`
 - `GlobalRef` and `WeakRef` are parameterized, transparent wrappers over `'static` reference types like `GlobalRef<JClass<'static>>` (no longer an `Arc` holding a reference and VM pointer) ([#596](https://github.com/jni-rs/jni-rs/pull/596))
   - `GlobalRef` and `WeakRef` no longer implement `Clone`, since JNI is required to create new reference (you'll need to explicitly use `env.new_global_ref`)
   - `GlobalRef` and `WeakRef` both implement `Default`, which will represent `::null()` references (equivalent to `JObject::null()`)

--- a/benches/api_calls.rs
+++ b/benches/api_calls.rs
@@ -374,7 +374,7 @@ fn jni_get_string(c: &mut Criterion) {
 
         c.bench_function("jni_get_string", |b| {
             b.iter(|| {
-                let s: String = string.to_string(env).unwrap();
+                let s: String = string.try_to_string(env).unwrap();
                 assert_eq!(s, TEST_STRING_UNICODE);
             })
         });
@@ -391,7 +391,7 @@ fn jni_get_string_unchecked(c: &mut Criterion) {
 
         c.bench_function("jni_get_string_unchecked", |b| {
             b.iter(|| {
-                let s: String = string.to_string(env).unwrap();
+                let s: String = string.try_to_string(env).unwrap();
                 assert_eq!(s, TEST_STRING_UNICODE);
             })
         });

--- a/src/wrapper/strings/mutf8_chars.rs
+++ b/src/wrapper/strings/mutf8_chars.rs
@@ -187,6 +187,16 @@ where
     }
 }
 
+impl<'local, StringRef> std::fmt::Display for MUTF8Chars<'local, StringRef>
+where
+    StringRef: AsRef<JString<'local>> + JObjectRef,
+{
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let jni_str: &JNIStr = self;
+        jni_str.fmt(f)
+    }
+}
+
 impl<'local, StringRef> ::std::ops::Deref for MUTF8Chars<'local, StringRef>
 where
     StringRef: AsRef<JString<'local>> + JObjectRef,


### PR DESCRIPTION
This makes it even easier to get a Rust `String`, from a borrowed `MUTF8Chars` guard or directly from a `JString`.

The implementation is based on `JavaVM::singleton()` and `vm.attach_current_thread_scoped()`.

The general expectation is that having a `JString` almost certainly implies that `JavaVM::singleton()` is initialized and generally expects that `vm.attach_current_thread_scoped` will probably be a NOOP.

If a `JString` reference is `null` then it will format as "<NULl>

In the (unlikely) case that you capture a `JString` as a native method argument and try to format it before anything else has initialized `JavaVM::singleton` then the string will be formatted as "<JNI Not Initialied>".

In the (unlikely) case of any other JNI error then it will format as "<JNI Error>".

In these latter two conditions the implementation will also log an error as they most likely imply some bug or misuse of the API.

The previous `JString::to_string(env)` method has now been renamed to `try_to_string`.
