### PR TITLE
Renames JNIEnv -> Env and JNIEnvUnowned -> EnvUnowned

### DIFF
--- a/benches/api_calls.rs
+++ b/benches/api_calls.rs
@@ -8,11 +8,10 @@ use criterion::{black_box, criterion_group, criterion_main, Criterion};
 use jni::objects::{GlobalRef, IntoAutoLocal as _};
 use jni::{
     descriptors::Desc,
-    env::JNIEnv,
     objects::{JClass, JMethodID, JObject, JStaticMethodID, JValue},
     signature::{Primitive, ReturnType},
     sys::jint,
-    InitArgsBuilder, JNIVersion, JavaVM,
+    Env, InitArgsBuilder, JNIVersion, JavaVM,
 };
 use std::rc::Rc;
 use std::sync::Arc;
@@ -37,7 +36,7 @@ fn native_abs(x: i32) -> i32 {
     x.abs()
 }
 
-fn jni_abs_safe(env: &mut JNIEnv, x: jint) -> jint {
+fn jni_abs_safe(env: &mut Env, x: jint) -> jint {
     let x = JValue::from(x);
     let v = env
         .call_static_method(CLASS_MATH, METHOD_MATH_ABS, SIG_MATH_ABS, &[x])
@@ -45,7 +44,7 @@ fn jni_abs_safe(env: &mut JNIEnv, x: jint) -> jint {
     v.i().unwrap()
 }
 
-fn jni_hash_safe(env: &mut JNIEnv, obj: &JObject) -> jint {
+fn jni_hash_safe(env: &mut Env, obj: &JObject) -> jint {
     let v = env
         .call_method(obj, METHOD_OBJECT_HASH_CODE, SIG_OBJECT_HASH_CODE, &[])
         .unwrap();
@@ -54,7 +53,7 @@ fn jni_hash_safe(env: &mut JNIEnv, obj: &JObject) -> jint {
 
 #[allow(clippy::too_many_arguments)]
 fn jni_local_date_time_of_safe<'local>(
-    env: &mut JNIEnv<'local>,
+    env: &mut Env<'local>,
     year: jint,
     month: jint,
     day_of_month: jint,
@@ -83,7 +82,7 @@ fn jni_local_date_time_of_safe<'local>(
 }
 
 fn jni_int_call_static_unchecked<'local, C>(
-    env: &mut JNIEnv<'local>,
+    env: &mut Env<'local>,
     class: C,
     method_id: JStaticMethodID,
     x: jint,
@@ -99,7 +98,7 @@ where
 }
 
 fn jni_int_call_unchecked<'local, M>(
-    env: &mut JNIEnv<'local>,
+    env: &mut Env<'local>,
     obj: &JObject<'local>,
     method_id: M,
 ) -> jint
@@ -113,7 +112,7 @@ where
 }
 
 fn jni_object_call_static_unchecked<'local, C>(
-    env: &mut JNIEnv<'local>,
+    env: &mut Env<'local>,
     class: C,
     method_id: JStaticMethodID,
     args: &[jvalue],

--- a/src/wrapper/descriptors/class_desc.rs
+++ b/src/wrapper/descriptors/class_desc.rs
@@ -1,6 +1,6 @@
 use crate::{
     descriptors::Desc,
-    env::JNIEnv,
+    env::Env,
     errors::*,
     objects::{AutoLocal, IntoAutoLocal as _, JClass},
     strings::JNIStr,
@@ -12,7 +12,7 @@ where
 {
     type Output = AutoLocal<'local, JClass<'local>>;
 
-    fn lookup(self, env: &mut JNIEnv<'local>) -> Result<Self::Output> {
+    fn lookup(self, env: &mut Env<'local>) -> Result<Self::Output> {
         Ok(env.find_class(self.as_ref())?.auto())
     }
 }

--- a/src/wrapper/descriptors/desc.rs
+++ b/src/wrapper/descriptors/desc.rs
@@ -1,7 +1,7 @@
 use crate::{
-    env::JNIEnv,
     errors::*,
     objects::{AutoLocal, GlobalRef, JObject, JObjectRef},
+    Env,
 };
 
 #[cfg(doc)]
@@ -31,9 +31,9 @@ pub unsafe trait Desc<'local, T> {
     /// necessary to use turbofish syntax when calling this method:
     ///
     /// ```rust,no_run
-    /// # use jni::{descriptors::Desc, errors::Result, env::JNIEnv, objects::JClass};
+    /// # use jni::{descriptors::Desc, errors::Result, Env, objects::JClass};
     /// #
-    /// # fn example(env: &mut JNIEnv) -> Result<()> {
+    /// # fn example(env: &mut Env) -> Result<()> {
     /// // The value returned by `lookup` is not exactly `JClass`.
     /// let class/*: impl AsRef<JClass> */ =
     ///     Desc::<JClass>::lookup(c"java/lang/Object", env)?;
@@ -47,17 +47,17 @@ pub unsafe trait Desc<'local, T> {
     /// **Warning:** Many built-in implementations of this trait return
     /// [`AutoLocal`] from this method. If you then call [`JObject::as_raw`] on
     /// the returned object reference, this may result in the reference being
-    /// [deleted][JNIEnv::delete_local_ref] before it is used, causing
+    /// [deleted][Env::delete_local_ref] before it is used, causing
     /// undefined behavior.
     ///
     /// For example, don't do this:
     ///
     /// ```rust,no_run
-    /// # use jni::{descriptors::Desc, errors::Result, env::JNIEnv, objects::JClass};
+    /// # use jni::{descriptors::Desc, errors::Result, Env, objects::JClass};
     /// #
     /// # fn some_function<T>(ptr: *mut T) {}
     /// #
-    /// # fn example(env: &mut JNIEnv) -> Result<()> {
+    /// # fn example(env: &mut Env) -> Result<()> {
     /// // Undefined behavior: the `JClass` is dropped before the raw pointer
     /// // is passed to `some_function`!
     /// some_function(Desc::<JClass>::lookup(c"java/lang/Object", env)?.as_raw());
@@ -68,11 +68,11 @@ pub unsafe trait Desc<'local, T> {
     /// Instead, do this:
     ///
     /// ```rust,no_run
-    /// # use jni::{descriptors::Desc, errors::Result, env::JNIEnv, objects::JClass};
+    /// # use jni::{descriptors::Desc, errors::Result, Env, objects::JClass};
     /// #
     /// # fn some_function<T>(ptr: *mut T) {}
     /// #
-    /// # fn example(env: &mut JNIEnv) -> Result<()> {
+    /// # fn example(env: &mut Env) -> Result<()> {
     /// let class = Desc::<JClass>::lookup(c"java/lang/Object", env)?;
     ///
     /// some_function(class.as_raw());
@@ -85,7 +85,7 @@ pub unsafe trait Desc<'local, T> {
     /// This will still work without the call to `drop` at the end, but calling
     /// `drop` ensures that the reference is not accidentally dropped earlier
     /// than it should be.
-    fn lookup(self, _: &mut JNIEnv<'local>) -> Result<Self::Output>;
+    fn lookup(self, _: &mut Env<'local>) -> Result<Self::Output>;
 }
 
 unsafe impl<'local, T> Desc<'local, T> for T
@@ -94,7 +94,7 @@ where
 {
     type Output = Self;
 
-    fn lookup(self, _: &mut JNIEnv<'local>) -> Result<T> {
+    fn lookup(self, _: &mut Env<'local>) -> Result<T> {
         Ok(self)
     }
 }
@@ -105,7 +105,7 @@ where
 {
     type Output = Self;
 
-    fn lookup(self, _: &mut JNIEnv<'local>) -> Result<Self::Output> {
+    fn lookup(self, _: &mut Env<'local>) -> Result<Self::Output> {
         Ok(self)
     }
 }
@@ -116,7 +116,7 @@ where
 {
     type Output = Self;
 
-    fn lookup(self, _: &mut JNIEnv<'local>) -> Result<Self::Output> {
+    fn lookup(self, _: &mut Env<'local>) -> Result<Self::Output> {
         Ok(self)
     }
 }
@@ -127,7 +127,7 @@ where
 {
     type Output = Self;
 
-    fn lookup(self, _: &mut JNIEnv<'local>) -> Result<Self::Output> {
+    fn lookup(self, _: &mut Env<'local>) -> Result<Self::Output> {
         Ok(self)
     }
 }
@@ -145,7 +145,7 @@ where
 {
     type Output = &'obj_ref T;
 
-    fn lookup(self, _: &mut JNIEnv<'local>) -> Result<Self::Output> {
+    fn lookup(self, _: &mut Env<'local>) -> Result<Self::Output> {
         Ok(self.as_ref())
     }
 }

--- a/src/wrapper/descriptors/exception_desc.rs
+++ b/src/wrapper/descriptors/exception_desc.rs
@@ -1,6 +1,6 @@
 use crate::{
     descriptors::Desc,
-    env::JNIEnv,
+    env::Env,
     errors::*,
     objects::{AutoLocal, IntoAutoLocal as _, JClass, JObject, JThrowable, JValue},
     strings::{JNIStr, JNIString},
@@ -15,7 +15,7 @@ where
 {
     type Output = AutoLocal<'local, JThrowable<'local>>;
 
-    fn lookup(self, env: &mut JNIEnv<'local>) -> Result<Self::Output> {
+    fn lookup(self, env: &mut Env<'local>) -> Result<Self::Output> {
         let jmsg = env.new_string(self.1.as_ref())?.auto();
         let obj: JObject =
             env.new_object(self.0, c"(Ljava/lang/String;)V", &[JValue::from(&jmsg)])?;
@@ -27,7 +27,7 @@ where
 unsafe impl<'local> Desc<'local, JThrowable<'local>> for Exception {
     type Output = AutoLocal<'local, JThrowable<'local>>;
 
-    fn lookup(self, env: &mut JNIEnv<'local>) -> Result<Self::Output> {
+    fn lookup(self, env: &mut Env<'local>) -> Result<Self::Output> {
         let jni_class: JNIString = self.class.into();
         let jni_msg: JNIString = self.msg.into();
         Desc::<JThrowable>::lookup((jni_class, jni_msg), env)
@@ -37,7 +37,7 @@ unsafe impl<'local> Desc<'local, JThrowable<'local>> for Exception {
 unsafe impl<'local> Desc<'local, JThrowable<'local>> for &str {
     type Output = AutoLocal<'local, JThrowable<'local>>;
 
-    fn lookup(self, env: &mut JNIEnv<'local>) -> Result<Self::Output> {
+    fn lookup(self, env: &mut Env<'local>) -> Result<Self::Output> {
         let jni_msg: JNIString = self.into();
         Desc::<JThrowable>::lookup((DEFAULT_EXCEPTION_CLASS, jni_msg), env)
     }
@@ -46,7 +46,7 @@ unsafe impl<'local> Desc<'local, JThrowable<'local>> for &str {
 unsafe impl<'local> Desc<'local, JThrowable<'local>> for String {
     type Output = AutoLocal<'local, JThrowable<'local>>;
 
-    fn lookup(self, env: &mut JNIEnv<'local>) -> Result<Self::Output> {
+    fn lookup(self, env: &mut Env<'local>) -> Result<Self::Output> {
         let jni_msg: JNIString = self.into();
         Desc::<JThrowable>::lookup((DEFAULT_EXCEPTION_CLASS, jni_msg), env)
     }
@@ -58,7 +58,7 @@ where
 {
     type Output = AutoLocal<'local, JThrowable<'local>>;
 
-    fn lookup(self, env: &mut JNIEnv<'local>) -> Result<Self::Output> {
+    fn lookup(self, env: &mut Env<'local>) -> Result<Self::Output> {
         Desc::<JThrowable>::lookup((DEFAULT_EXCEPTION_CLASS, self.as_ref()), env)
     }
 }

--- a/src/wrapper/descriptors/field_desc.rs
+++ b/src/wrapper/descriptors/field_desc.rs
@@ -1,6 +1,6 @@
 use crate::{
     descriptors::Desc,
-    env::JNIEnv,
+    env::Env,
     errors::*,
     objects::{JClass, JFieldID, JStaticFieldID},
     strings::JNIStr,
@@ -14,7 +14,7 @@ where
 {
     type Output = JFieldID;
 
-    fn lookup(self, env: &mut JNIEnv<'local>) -> Result<Self::Output> {
+    fn lookup(self, env: &mut Env<'local>) -> Result<Self::Output> {
         env.get_field_id(self.0, self.1, self.2)
     }
 }
@@ -27,7 +27,7 @@ where
 {
     type Output = JStaticFieldID;
 
-    fn lookup(self, env: &mut JNIEnv<'local>) -> Result<Self::Output> {
+    fn lookup(self, env: &mut Env<'local>) -> Result<Self::Output> {
         env.get_static_field_id(self.0, self.1, self.2)
     }
 }

--- a/src/wrapper/descriptors/method_desc.rs
+++ b/src/wrapper/descriptors/method_desc.rs
@@ -1,6 +1,6 @@
 use crate::{
     descriptors::Desc,
-    env::JNIEnv,
+    env::Env,
     errors::*,
     objects::{JClass, JMethodID, JStaticMethodID},
     strings::JNIStr,
@@ -14,7 +14,7 @@ where
 {
     type Output = JMethodID;
 
-    fn lookup(self, env: &mut JNIEnv<'local>) -> Result<Self::Output> {
+    fn lookup(self, env: &mut Env<'local>) -> Result<Self::Output> {
         env.get_method_id(self.0, self.1, self.2)
     }
 }
@@ -26,7 +26,7 @@ where
 {
     type Output = JMethodID;
 
-    fn lookup(self, env: &mut JNIEnv<'local>) -> Result<Self::Output> {
+    fn lookup(self, env: &mut Env<'local>) -> Result<Self::Output> {
         Desc::<JMethodID>::lookup((self.0, c"<init>", self.1.as_ref()), env)
     }
 }
@@ -39,7 +39,7 @@ where
 {
     type Output = JStaticMethodID;
 
-    fn lookup(self, env: &mut JNIEnv<'local>) -> Result<Self::Output> {
+    fn lookup(self, env: &mut Env<'local>) -> Result<Self::Output> {
         env.get_static_method_id(self.0, self.1, self.2)
     }
 }

--- a/src/wrapper/errors.rs
+++ b/src/wrapper/errors.rs
@@ -35,8 +35,8 @@ pub enum Error {
     FieldNotFound { name: String, sig: String },
     #[error("Java exception was thrown")]
     JavaException,
-    #[error("JNIEnv null method pointer for {0}")]
-    JNIEnvMethodNotFound(&'static str),
+    #[error("Env null method pointer for {0}")]
+    EnvMethodNotFound(&'static str),
     #[error("Null pointer in {0}")]
     NullPtr(&'static str),
     #[error("Mutex already locked")]

--- a/src/wrapper/macros.rs
+++ b/src/wrapper/macros.rs
@@ -1,4 +1,4 @@
-/// Directly calls a JNIEnv FFI function, nothing else
+/// Directly calls a Env FFI function, nothing else
 ///
 /// # Safety
 ///
@@ -6,7 +6,7 @@
 /// for the current JNI version.
 macro_rules! jni_call_unchecked {
     ( $jnienv:expr, $version:tt, $name:tt $(, $args:expr )*) => {{
-        // Safety: we know that the JNIEnv pointer can't be null, since that's
+        // Safety: we know that the Env pointer can't be null, since that's
         // checked in `from_raw()`
         let env: *mut jni_sys::JNIEnv = $jnienv.get_raw();
         let interface: *const jni_sys::JNINativeInterface_ = *env;
@@ -14,7 +14,7 @@ macro_rules! jni_call_unchecked {
     }};
 }
 
-/// Calls a JNIEnv function, then checks for a pending exception
+/// Calls a Env function, then checks for a pending exception
 ///
 /// This only checks for an exception, it doesn't clear the exception and so the
 /// exception will be thrown if the native code returns to the JVM.
@@ -31,7 +31,7 @@ macro_rules! jni_call_check_ex {
     })
 }
 
-/// Calls a JNIEnv function, then checks for a pending exception, then checks for a `null` return value
+/// Calls a Env function, then checks for a pending exception, then checks for a `null` return value
 ///
 /// Returns `Err` if there is a pending exception after the call.
 /// Returns `Err(Error::NullPtr)` if the JNI function returns `null`
@@ -47,7 +47,7 @@ macro_rules! jni_call_check_ex_and_null_ret {
     })
 }
 
-/// Calls a JNIEnv function, with no check for exceptions, then checks for a `null` return value
+/// Calls a Env function, with no check for exceptions, then checks for a `null` return value
 ///
 /// Returns `Err(Error::NullPtr)` if the JNI function returns `null`
 macro_rules! jni_call_only_check_null_ret {

--- a/src/wrapper/objects/auto_elements_critical.rs
+++ b/src/wrapper/objects/auto_elements_critical.rs
@@ -5,7 +5,7 @@ use std::ptr::NonNull;
 use crate::sys::jboolean;
 use crate::wrapper::objects::ReleaseMode;
 use crate::JavaVM;
-use crate::{env::JNIEnv, errors::*, sys};
+use crate::{env::Env, errors::*, sys};
 
 use super::{JPrimitiveArray, TypeArray};
 
@@ -37,7 +37,7 @@ where
     ///
     /// `len` must be the correct length (number of elements) of the given `array`
     pub(crate) unsafe fn new_with_len(
-        env: &JNIEnv<'_>,
+        env: &Env<'_>,
         array: TArrayRef,
         len: usize,
         mode: ReleaseMode,
@@ -63,7 +63,7 @@ where
         })
     }
 
-    pub(crate) fn new(env: &JNIEnv<'_>, array: TArrayRef, mode: ReleaseMode) -> Result<Self> {
+    pub(crate) fn new(env: &Env<'_>, array: TArrayRef, mode: ReleaseMode) -> Result<Self> {
         let len = array.as_ref().len(env)?;
         unsafe { Self::new_with_len(env, array, len, mode) }
     }
@@ -83,7 +83,7 @@ where
     /// If `mode` is not [`sys::JNI_COMMIT`], then `self.ptr` must not have already been released.
     unsafe fn release_primitive_array_critical(&mut self, mode: i32) -> Result<()> {
         // Panic: Since we can't construct `AutoElementsCritical` without a
-        // valid `JNIEnv` reference we know we can call `JavaVM::singleton()`
+        // valid `Env` reference we know we can call `JavaVM::singleton()`
         // without a panic.
         JavaVM::singleton()?.with_env_current_frame(|env| {
             jni_call_unchecked!(

--- a/src/wrapper/objects/auto_local.rs
+++ b/src/wrapper/objects/auto_local.rs
@@ -43,7 +43,7 @@ use super::JObjectRef;
 ///
 /// If you aren't sure whether it's OK to create new local references in the
 /// current JNI frame (perhaps because you don't know when it will unwind)
-/// you can also consider using APIs like `JNIEnv::with_local_frame()` which
+/// you can also consider using APIs like `Env::with_local_frame()` which
 /// can run your code in a temporary stack frame that will release all local
 /// references in bulk, without needing to use `AutoLocal`.
 ///
@@ -96,7 +96,7 @@ where
     /// the Java VM then the local JNI stack frame will unwind and delete all
     /// local references.
     ///
-    /// Another option can be to use `JNIEnv::with_local_frame` or similar APIs
+    /// Another option can be to use `Env::with_local_frame` or similar APIs
     /// that create a temporary JNI local frame where you can assume that all
     /// local references will be deleted when that local frame is unwound, after
     /// the given closure is called.
@@ -155,11 +155,11 @@ where
             let Ok(vm) = JavaVM::singleton() else {
                 // Since we wrap a non-null reference with a lifetime associated with a JNI stack
                 // frame we can (mostly) assume that JavaVM::singleton() must have been initialized
-                // in order to get a JNIEnv reference.
+                // in order to get a Env reference.
                 //
                 // The only (remote) exception to this is that the reference came from a native
                 // method argument and for some reason an AutoLocal wrapper was created before an
-                // AttachGuard was created to access a JNIEnv reference (which would initialize the
+                // AttachGuard was created to access a Env reference (which would initialize the
                 // JavaVM singleton).
                 //
                 // This would be a redundant thing to try, but just to err on the side of caution we

--- a/src/wrapper/objects/cast.rs
+++ b/src/wrapper/objects/cast.rs
@@ -3,7 +3,7 @@ use std::{marker::PhantomData, ops::Deref};
 use jni_sys::jobject;
 
 use crate::{
-    env::JNIEnv,
+    env::Env,
     errors::{Error, Result},
     objects::{GlobalRef, JClass, JObject, JObjectRef, LoaderContext},
     strings::JNIStr,
@@ -16,7 +16,7 @@ use crate::{
 ///
 /// This can be used to cast global or local references.
 ///
-/// See: [JNIEnv::as_cast]
+/// See: [Env::as_cast]
 ///
 #[repr(transparent)]
 pub struct Cast<'any, 'from, To: JObjectRef> {
@@ -35,7 +35,7 @@ impl<'any, 'from, To: JObjectRef> Cast<'any, 'from, To> {
     /// Returns [Error::WrongObjectType] if the object is not of the expected type.
     pub(crate) fn new<'env_local, From: JObjectRef + AsRef<JObject<'any>>>(
         from: &'from From,
-        env: &JNIEnv<'env_local>,
+        env: &Env<'env_local>,
     ) -> Result<Self>
     where
         'any: 'from,

--- a/src/wrapper/objects/jclass.rs
+++ b/src/wrapper/objects/jclass.rs
@@ -3,7 +3,7 @@ use std::ops::Deref;
 use once_cell::sync::OnceCell;
 
 use crate::{
-    env::JNIEnv,
+    env::Env,
     errors::Result,
     objects::{
         GlobalRef, JClassLoader, JMethodID, JObject, JStaticMethodID, JValue, LoaderContext,
@@ -119,10 +119,7 @@ impl JClass<'_> {
     /// # Throws
     ///
     /// `SecurityException` if the class loader cannot be accessed.
-    pub fn get_class_loader<'local>(
-        &self,
-        env: &mut JNIEnv<'local>,
-    ) -> Result<JClassLoader<'local>> {
+    pub fn get_class_loader<'local>(&self, env: &mut Env<'local>) -> Result<JClassLoader<'local>> {
         let vm = env.get_java_vm();
         let api = JClassAPI::get(&vm)?;
 
@@ -149,7 +146,7 @@ impl JClass<'_> {
     /// # Throws
     ///
     /// This method may throw a `ClassNotFoundException` if the class cannot be found.
-    pub fn for_name<'local, C>(class_name: C, env: &mut JNIEnv<'local>) -> Result<JClass<'local>>
+    pub fn for_name<'local, C>(class_name: C, env: &mut Env<'local>) -> Result<JClass<'local>>
     where
         C: AsRef<JNIStr>,
     {
@@ -193,7 +190,7 @@ impl JClass<'_> {
         class_name: C,
         initialize: bool,
         loader: L,
-        env: &mut JNIEnv<'env_local>,
+        env: &mut Env<'env_local>,
     ) -> Result<JClass<'env_local>>
     where
         C: AsRef<JNIStr>,

--- a/src/wrapper/objects/jclass_loader.rs
+++ b/src/wrapper/objects/jclass_loader.rs
@@ -3,7 +3,7 @@ use std::ops::Deref;
 use once_cell::sync::OnceCell;
 
 use crate::{
-    env::JNIEnv,
+    env::Env,
     errors::Result,
     objects::{GlobalRef, JClass, JMethodID, JObject, JValue, LoaderContext},
     signature::JavaType,
@@ -107,7 +107,7 @@ impl JClassLoader<'_> {
     pub fn load_class<'local>(
         &self,
         name: &JNIStr,
-        env: &mut JNIEnv<'local>,
+        env: &mut Env<'local>,
     ) -> Result<JClass<'local>> {
         let vm = env.get_java_vm();
         let api = JClassLoaderAPI::get(&vm)?;

--- a/src/wrapper/objects/jcollection.rs
+++ b/src/wrapper/objects/jcollection.rs
@@ -3,7 +3,7 @@ use std::ops::Deref;
 use once_cell::sync::OnceCell;
 
 use crate::{
-    env::JNIEnv,
+    env::Env,
     errors::Result,
     objects::{GlobalRef, JClass, JIterator, JMethodID, JObject, JValue, LoaderContext},
     signature::{Primitive, ReturnType},
@@ -118,19 +118,19 @@ impl<'local> JCollection<'local> {
     /// This will do a runtime (`IsInstanceOf`) check that the object is an instance of `java.util.Collection`.
     ///
     /// Also see these other options for casting local or global references to a `JCollection`:
-    /// - [JNIEnv::new_cast_local_ref]
-    /// - [JNIEnv::cast_local]
-    /// - [JNIEnv::as_cast_local]
-    /// - [JNIEnv::new_cast_global_ref]
-    /// - [JNIEnv::cast_global]
-    /// - [JNIEnv::as_cast_global]
+    /// - [Env::new_cast_local_ref]
+    /// - [Env::cast_local]
+    /// - [Env::as_cast_local]
+    /// - [Env::new_cast_global_ref]
+    /// - [Env::cast_global]
+    /// - [Env::as_cast_global]
     ///
     /// # Errors
     ///
     /// Returns [Error::WrongObjectType] if the `IsInstanceOf` check fails.
     pub fn cast_local<'any_local>(
         obj: impl JObjectRef + Into<JObject<'any_local>> + AsRef<JObject<'any_local>>,
-        env: &mut JNIEnv<'_>,
+        env: &mut Env<'_>,
     ) -> Result<JCollection<'any_local>> {
         env.cast_local::<JCollection>(obj)
     }
@@ -150,7 +150,7 @@ impl<'local> JCollection<'local> {
     pub fn add<'any_local>(
         &self,
         element: impl AsRef<JObject<'any_local>>,
-        env: &mut JNIEnv<'_>,
+        env: &mut Env<'_>,
     ) -> Result<bool> {
         let api = JCollectionAPI::get(&env.get_java_vm(), &LoaderContext::default())?;
         let result = unsafe {
@@ -176,7 +176,7 @@ impl<'local> JCollection<'local> {
     pub fn remove<'any_local>(
         &self,
         element: impl AsRef<JObject<'any_local>>,
-        env: &mut JNIEnv<'_>,
+        env: &mut Env<'_>,
     ) -> Result<bool> {
         let api = JCollectionAPI::get(&env.get_java_vm(), &LoaderContext::default())?;
         let result = unsafe {
@@ -195,7 +195,7 @@ impl<'local> JCollection<'local> {
     /// # Throws
     ///
     /// - `UnsupportedOperationException` - if the clear operation is not supported
-    pub fn clear(&self, env: &mut JNIEnv<'_>) -> Result<()> {
+    pub fn clear(&self, env: &mut Env<'_>) -> Result<()> {
         let api = JCollectionAPI::get(&env.get_java_vm(), &LoaderContext::default())?;
         unsafe {
             env.call_method_unchecked(
@@ -216,7 +216,7 @@ impl<'local> JCollection<'local> {
     ///
     /// - `ClassCastException` - if the element type isn't compatible with the set
     /// - `NullPointerException` - if the given element is null and the set does not allow null values
-    pub fn contains(&self, element: &JObject, env: &mut JNIEnv<'_>) -> Result<bool> {
+    pub fn contains(&self, element: &JObject, env: &mut Env<'_>) -> Result<bool> {
         let api = JCollectionAPI::get(&env.get_java_vm(), &LoaderContext::default())?;
         let result = unsafe {
             env.call_method_unchecked(
@@ -232,7 +232,7 @@ impl<'local> JCollection<'local> {
     /// Returns the number of elements in this collection.
     ///
     /// Returns [i32::MAX] if the collection size is too large to be represented as an i32.
-    pub fn size(&self, env: &mut JNIEnv<'_>) -> Result<i32> {
+    pub fn size(&self, env: &mut Env<'_>) -> Result<i32> {
         let api = JCollectionAPI::get(&env.get_java_vm(), &LoaderContext::default())?;
         let result = unsafe {
             env.call_method_unchecked(
@@ -246,7 +246,7 @@ impl<'local> JCollection<'local> {
     }
 
     /// Returns `true` if this collection contains no elements.
-    pub fn is_empty(&self, env: &mut JNIEnv<'_>) -> Result<bool> {
+    pub fn is_empty(&self, env: &mut Env<'_>) -> Result<bool> {
         let api = JCollectionAPI::get(&env.get_java_vm(), &LoaderContext::default())?;
         let result = unsafe {
             env.call_method_unchecked(
@@ -260,10 +260,7 @@ impl<'local> JCollection<'local> {
     }
 
     /// Returns an iterator (`java.util.Iterator`) over the elements in this collection.
-    pub fn iterator<'env_local>(
-        &self,
-        env: &mut JNIEnv<'env_local>,
-    ) -> Result<JIterator<'env_local>> {
+    pub fn iterator<'env_local>(&self, env: &mut Env<'env_local>) -> Result<JIterator<'env_local>> {
         let api = JCollectionAPI::get(&env.get_java_vm(), &LoaderContext::default())?;
         unsafe {
             let iterator = env

--- a/src/wrapper/objects/jfieldid.rs
+++ b/src/wrapper/objects/jfieldid.rs
@@ -1,7 +1,7 @@
 use crate::sys::jfieldID;
 
 /// Wrapper around [`jfieldID`] that implements `Send` + `Sync` since method IDs
-/// are valid across threads (not tied to a `JNIEnv`).
+/// are valid across threads (not tied to a `Env`).
 ///
 /// There is no lifetime associated with these since they aren't garbage
 /// collected like objects and their lifetime is not implicitly connected with
@@ -26,7 +26,7 @@ pub struct JFieldID {
     internal: jfieldID,
 }
 
-// Field IDs are valid across threads (not tied to a JNIEnv)
+// Field IDs are valid across threads (not tied to a Env)
 unsafe impl Send for JFieldID {}
 unsafe impl Sync for JFieldID {}
 

--- a/src/wrapper/objects/jiterator.rs
+++ b/src/wrapper/objects/jiterator.rs
@@ -3,7 +3,7 @@ use std::ops::Deref;
 use once_cell::sync::OnceCell;
 
 use crate::{
-    env::JNIEnv,
+    env::Env,
     errors::{Error, Result},
     objects::{GlobalRef, JClass, JMethodID, JObject, LoaderContext},
     signature::{Primitive, ReturnType},
@@ -103,25 +103,25 @@ impl<'local> JIterator<'local> {
     /// This will do a runtime (`IsInstanceOf`) check that the object is an instance of `java.util.Iterator`.
     ///
     /// Also see these other options for casting local or global references to a `JIterator`:
-    /// - [JNIEnv::new_cast_local_ref]
-    /// - [JNIEnv::cast_local]
-    /// - [JNIEnv::as_cast_local]
-    /// - [JNIEnv::new_cast_global_ref]
-    /// - [JNIEnv::cast_global]
-    /// - [JNIEnv::as_cast_global]
+    /// - [Env::new_cast_local_ref]
+    /// - [Env::cast_local]
+    /// - [Env::as_cast_local]
+    /// - [Env::new_cast_global_ref]
+    /// - [Env::cast_global]
+    /// - [Env::as_cast_global]
     ///
     /// # Errors
     ///
     /// Returns [Error::WrongObjectType] if the `IsInstanceOf` check fails.
     pub fn cast_local<'any_local>(
         obj: impl JObjectRef + Into<JObject<'any_local>> + AsRef<JObject<'any_local>>,
-        env: &mut JNIEnv<'_>,
+        env: &mut Env<'_>,
     ) -> Result<JIterator<'any_local>> {
         env.cast_local::<JIterator>(obj)
     }
 
     /// Returns true if the iteration has more elements.
-    pub fn has_next(&self, env: &mut JNIEnv<'_>) -> Result<bool> {
+    pub fn has_next(&self, env: &mut Env<'_>) -> Result<bool> {
         let vm = env.get_java_vm();
         let api = JIteratorAPI::get(&vm, &LoaderContext::None)?;
         unsafe {
@@ -141,7 +141,7 @@ impl<'local> JIterator<'local> {
     /// it has reached the end.
     ///
     /// This is like [`std::iter::Iterator::next`], but requires a parameter of
-    /// type `&mut JNIEnv` in order to call into Java.
+    /// type `&mut Env` in order to call into Java.
     ///
     /// Any exceptions thrown are assumed to be a `NoSuchElementException` and
     /// are caught + cleared before returning `None`.
@@ -150,14 +150,14 @@ impl<'local> JIterator<'local> {
     ///
     /// This method creates a new local reference. To prevent excessive memory
     /// usage or overflow errors (when called repeatedly in a loop), the local
-    /// reference should be deleted using [`JNIEnv::delete_local_ref`] or
-    /// [`JNIEnv::auto_local`] before the next loop iteration. Alternatively, if
+    /// reference should be deleted using [`Env::delete_local_ref`] or
+    /// [`Env::auto_local`] before the next loop iteration. Alternatively, if
     /// the collection is known to have a small, predictable size, the loop could be
-    /// wrapped in [`JNIEnv::with_local_frame`] to delete all of the local
+    /// wrapped in [`Env::with_local_frame`] to delete all of the local
     /// references at once.
     pub fn next<'env_local>(
         &self,
-        env: &mut JNIEnv<'env_local>,
+        env: &mut Env<'env_local>,
     ) -> Result<Option<JObject<'env_local>>> {
         let vm = env.get_java_vm();
         let api = JIteratorAPI::get(&vm, &LoaderContext::None)?;
@@ -182,7 +182,7 @@ impl<'local> JIterator<'local> {
     ///
     /// - `UnsupportedOperationException` if the operation is not supported.
     /// - `IllegalStateException` if the iterator is in an invalid state (i.e [Self::next] has not been called).
-    pub fn remove(&self, env: &mut JNIEnv<'_>) -> Result<()> {
+    pub fn remove(&self, env: &mut Env<'_>) -> Result<()> {
         let vm = env.get_java_vm();
         let api = JIteratorAPI::get(&vm, &LoaderContext::None)?;
         unsafe {

--- a/src/wrapper/objects/jmethodid.rs
+++ b/src/wrapper/objects/jmethodid.rs
@@ -1,7 +1,7 @@
 use crate::sys::jmethodID;
 
 /// Wrapper around [`jmethodID`] that implements `Send` + `Sync` since method IDs
-/// are valid across threads (not tied to a `JNIEnv`).
+/// are valid across threads (not tied to a `Env`).
 ///
 /// There is no lifetime associated with these since they aren't garbage
 /// collected like objects and their lifetime is not implicitly connected with
@@ -26,7 +26,7 @@ pub struct JMethodID {
     internal: jmethodID,
 }
 
-// Method IDs are valid across threads (not tied to a JNIEnv)
+// Method IDs are valid across threads (not tied to a Env)
 unsafe impl Send for JMethodID {}
 unsafe impl Sync for JMethodID {}
 

--- a/src/wrapper/objects/jobject.rs
+++ b/src/wrapper/objects/jobject.rs
@@ -23,7 +23,7 @@ use super::JObjectRef;
 /// representation.
 ///
 /// The lifetime `'local` represents the local reference frame that this
-/// reference belongs to. See the [`JNIEnv`] documentation for more information
+/// reference belongs to. See the [`Env`] documentation for more information
 /// about local reference frames. If `'local` is `'static`, then this reference
 /// does not belong to a local reference frame, that is, it is either null or a
 /// [global reference][GlobalRef].

--- a/src/wrapper/objects/jobject_array.rs
+++ b/src/wrapper/objects/jobject_array.rs
@@ -3,7 +3,7 @@ use std::ops::Deref;
 use once_cell::sync::OnceCell;
 
 use crate::{
-    env::JNIEnv,
+    env::Env,
     errors::Result,
     objects::{GlobalRef, JClass, JObject, JObjectRef, LoaderContext},
     strings::JNIStr,
@@ -92,7 +92,7 @@ impl JObjectArray<'_> {
     }
 
     /// Returns the length of the array.
-    pub fn len(&self, env: &JNIEnv) -> Result<usize> {
+    pub fn len(&self, env: &Env) -> Result<usize> {
         let array = null_check!(self.as_raw(), "JObjectArray::len self argument")?;
         let len = unsafe { jni_call_unchecked!(env, v1_1, GetArrayLength, array) } as usize;
         Ok(len)

--- a/src/wrapper/objects/jset.rs
+++ b/src/wrapper/objects/jset.rs
@@ -3,7 +3,7 @@ use std::ops::Deref;
 use once_cell::sync::OnceCell;
 
 use crate::{
-    env::JNIEnv,
+    env::Env,
     errors::Result,
     objects::{Cast, GlobalRef, JClass, JCollection, JIterator, JObject, LoaderContext},
     strings::JNIStr,
@@ -97,19 +97,19 @@ impl<'local> JSet<'local> {
     /// This will do a runtime (`IsInstanceOf`) check that the object is an instance of `java.util.Set`.
     ///
     /// Also see these other options for casting local or global references to a `JSet`:
-    /// - [JNIEnv::new_cast_local_ref]
-    /// - [JNIEnv::cast_local]
-    /// - [JNIEnv::as_cast_local]
-    /// - [JNIEnv::new_cast_global_ref]
-    /// - [JNIEnv::cast_global]
-    /// - [JNIEnv::as_cast_global]
+    /// - [Env::new_cast_local_ref]
+    /// - [Env::cast_local]
+    /// - [Env::as_cast_local]
+    /// - [Env::new_cast_global_ref]
+    /// - [Env::cast_global]
+    /// - [Env::as_cast_global]
     ///
     /// # Errors
     ///
     /// Returns [Error::WrongObjectType] if the `IsInstanceOf` check fails.
     pub fn cast_local<'any_local>(
         obj: impl JObjectRef + Into<JObject<'any_local>> + AsRef<JObject<'any_local>>,
-        env: &mut JNIEnv<'_>,
+        env: &mut Env<'_>,
     ) -> Result<JSet<'any_local>> {
         env.cast_local::<JSet>(obj)
     }
@@ -135,7 +135,7 @@ impl<'local> JSet<'local> {
     pub fn add<'any_local>(
         &self,
         element: impl AsRef<JObject<'any_local>>,
-        env: &mut JNIEnv<'_>,
+        env: &mut Env<'_>,
     ) -> Result<bool> {
         self.as_collection().add(element, env)
     }
@@ -152,7 +152,7 @@ impl<'local> JSet<'local> {
     pub fn remove<'any_local>(
         &self,
         element: impl AsRef<JObject<'any_local>>,
-        env: &mut JNIEnv<'_>,
+        env: &mut Env<'_>,
     ) -> Result<bool> {
         self.as_collection().remove(element, env)
     }
@@ -162,7 +162,7 @@ impl<'local> JSet<'local> {
     /// # Throws
     ///
     /// - `UnsupportedOperationException` - if the clear operation is not supported
-    pub fn clear(&self, env: &mut JNIEnv<'_>) -> Result<()> {
+    pub fn clear(&self, env: &mut Env<'_>) -> Result<()> {
         self.as_collection().clear(env)
     }
 
@@ -174,25 +174,22 @@ impl<'local> JSet<'local> {
     ///
     /// - `ClassCastException` - if the element type isn't compatible with the set
     /// - `NullPointerException` - if the given element is null and the set does not allow null values
-    pub fn contains(&self, element: &JObject, env: &mut JNIEnv<'_>) -> Result<bool> {
+    pub fn contains(&self, element: &JObject, env: &mut Env<'_>) -> Result<bool> {
         self.as_collection().contains(element, env)
     }
 
     /// Returns the number of elements in this set.
-    pub fn size(&self, env: &mut JNIEnv<'_>) -> Result<i32> {
+    pub fn size(&self, env: &mut Env<'_>) -> Result<i32> {
         self.as_collection().size(env)
     }
 
     /// Returns `true` if this set contains no elements.
-    pub fn is_empty(&self, env: &mut JNIEnv<'_>) -> Result<bool> {
+    pub fn is_empty(&self, env: &mut Env<'_>) -> Result<bool> {
         self.as_collection().is_empty(env)
     }
 
     /// Returns an iterator (`java.util.Iterator`) over the elements in this set.
-    pub fn iterator<'env_local>(
-        &self,
-        env: &mut JNIEnv<'env_local>,
-    ) -> Result<JIterator<'env_local>> {
+    pub fn iterator<'env_local>(&self, env: &mut Env<'env_local>) -> Result<JIterator<'env_local>> {
         self.as_collection().iterator(env)
     }
 }

--- a/src/wrapper/objects/jstaticfieldid.rs
+++ b/src/wrapper/objects/jstaticfieldid.rs
@@ -1,7 +1,7 @@
 use crate::sys::jfieldID;
 
 /// Wrapper around [`jfieldID`] that implements `Send` + `Sync` since field IDs
-/// are valid across threads (not tied to a `JNIEnv`).
+/// are valid across threads (not tied to a `Env`).
 ///
 /// There is no lifetime associated with these since they aren't garbage
 /// collected like objects and their lifetime is not implicitly connected with
@@ -26,7 +26,7 @@ pub struct JStaticFieldID {
     internal: jfieldID,
 }
 
-// Static Field IDs are valid across threads (not tied to a JNIEnv)
+// Static Field IDs are valid across threads (not tied to a Env)
 unsafe impl Send for JStaticFieldID {}
 unsafe impl Sync for JStaticFieldID {}
 

--- a/src/wrapper/objects/jstaticmethodid.rs
+++ b/src/wrapper/objects/jstaticmethodid.rs
@@ -1,7 +1,7 @@
 use crate::sys::jmethodID;
 
 /// Wrapper around [`jmethodID`] that implements `Send` + `Sync` since method IDs
-/// are valid across threads (not tied to a `JNIEnv`).
+/// are valid across threads (not tied to a `Env`).
 ///
 /// There is no lifetime associated with these since they aren't garbage
 /// collected like objects and their lifetime is not implicitly connected with
@@ -26,7 +26,7 @@ pub struct JStaticMethodID {
     internal: jmethodID,
 }
 
-// Method IDs are valid across threads (not tied to a JNIEnv)
+// Method IDs are valid across threads (not tied to a Env)
 unsafe impl Send for JStaticMethodID {}
 unsafe impl Sync for JStaticMethodID {}
 

--- a/src/wrapper/objects/jthread.rs
+++ b/src/wrapper/objects/jthread.rs
@@ -3,7 +3,7 @@ use std::ops::Deref;
 use once_cell::sync::OnceCell;
 
 use crate::{
-    env::JNIEnv,
+    env::Env,
     errors::Result,
     objects::{
         GlobalRef, JClass, JClassLoader, JMethodID, JObject, JStaticMethodID, JValue, LoaderContext,
@@ -110,7 +110,7 @@ impl JThread<'_> {
     }
 
     /// Get the message of the throwable by calling the `getMessage` method.
-    pub fn current_thread<'local>(env: &mut JNIEnv<'_>) -> Result<JThread<'local>> {
+    pub fn current_thread<'local>(env: &mut Env<'_>) -> Result<JThread<'local>> {
         let vm = env.get_java_vm();
         let api = JThreadAPI::get(&vm)?;
 
@@ -138,7 +138,7 @@ impl JThread<'_> {
     /// Throws `SecurityException` if the current thread can't access its context class loader.
     pub fn get_context_class_loader<'local>(
         &self,
-        env: &mut JNIEnv<'local>,
+        env: &mut Env<'local>,
     ) -> Result<JClassLoader<'local>> {
         let vm = env.get_java_vm();
         let api = JThreadAPI::get(&vm)?;
@@ -170,7 +170,7 @@ impl JThread<'_> {
     pub fn set_context_class_loader<'loader_local, 'env_local>(
         &self,
         loader: &JClassLoader<'loader_local>,
-        env: &mut JNIEnv<'env_local>,
+        env: &mut Env<'env_local>,
     ) -> Result<JClassLoader<'env_local>> {
         let vm = env.get_java_vm();
         let api = JThreadAPI::get(&vm)?;

--- a/src/wrapper/objects/jthrowable.rs
+++ b/src/wrapper/objects/jthrowable.rs
@@ -3,7 +3,7 @@ use std::ops::Deref;
 use once_cell::sync::OnceCell;
 
 use crate::{
-    env::JNIEnv,
+    env::Env,
     errors::Result,
     objects::{GlobalRef, JClass, JMethodID, JObject, JString, LoaderContext},
     strings::JNIStr,
@@ -97,7 +97,7 @@ impl JThrowable<'_> {
     }
 
     /// Get the message of the throwable by calling the `getMessage` method.
-    pub fn get_message(&self, env: &mut JNIEnv<'_>) -> Result<JString<'_>> {
+    pub fn get_message(&self, env: &mut Env<'_>) -> Result<JString<'_>> {
         let vm = env.get_java_vm();
         let api = JThrowableAPI::get(&vm, &LoaderContext::None)?;
 
@@ -117,7 +117,7 @@ impl JThrowable<'_> {
     }
 
     /// Get the cause of the throwable by calling the `getCause` method.
-    pub fn get_cause(&self, env: &mut JNIEnv<'_>) -> Result<JThrowable<'_>> {
+    pub fn get_cause(&self, env: &mut Env<'_>) -> Result<JThrowable<'_>> {
         let vm = env.get_java_vm();
         let api = JThrowableAPI::get(&vm, &LoaderContext::None)?;
 

--- a/src/wrapper/objects/jvalue.rs
+++ b/src/wrapper/objects/jvalue.rs
@@ -8,7 +8,7 @@ use crate::signature::JavaType;
 use crate::{errors::*, objects::JObject, signature::Primitive, sys::*};
 
 #[cfg(doc)]
-use crate::JNIEnv;
+use crate::env::Env;
 
 /// A Java owned local reference or primitive value.
 ///
@@ -486,7 +486,7 @@ impl TryFrom<char> for JValue<'_> {
 ///
 /// * Use Java `int`s containing UTF-32. You can encode a Java `String` as a sequence of UTF-32 `int`s using its [`codePoints`] method, then use [`char_from_java_int`] to convert each one to a Rust `char`.
 ///
-/// * Convert a Java `String` using [`JNIEnv::get_string`].
+/// * Convert a Java `String` using [`Env::get_string`].
 ///
 /// * Convert multiple Java `char`s at a time (such as in a Java `char[]` array) using [`char::decode_utf16`] (which this function is a simple wrapper around). That will properly convert any surrogate pairs among the Java `char`s.
 ///
@@ -512,7 +512,7 @@ pub fn char_from_java(char: jchar) -> std::result::Result<char, DecodeUtf16Error
 ///
 /// * Use Java `int`s containing UTF-32. You can convert a Rust `char` to a Java `int` containing UTF-32 using [`char_to_java_int`], which never fails.
 ///
-/// * Convert a Rust [`str`] to a Java `String` using [`JNIEnv::new_string`].
+/// * Convert a Rust [`str`] to a Java `String` using [`Env::new_string`].
 ///
 /// * Convert a Rust `char` to multiple Java `char`s at a time using [`char::encode_utf16`] (which this function is a wrapper around). That will properly generate surrogate pairs as needed.
 ///

--- a/src/wrapper/objects/type_array.rs
+++ b/src/wrapper/objects/type_array.rs
@@ -4,7 +4,7 @@ pub(crate) mod type_array_sealed {
     use jni_sys::jsize;
 
     use crate::sys::{jarray, jboolean, jbyte, jchar, jdouble, jfloat, jint, jlong, jshort};
-    use crate::{env::JNIEnv, errors::*};
+    use crate::{env::Env, errors::*};
     use paste::paste;
     use std::ptr::NonNull;
 
@@ -12,8 +12,8 @@ pub(crate) mod type_array_sealed {
     ///
     /// # Safety
     ///
-    /// The methods of this trait must uphold the invariants described in [`JNIEnv::unsafe_clone`] when
-    /// using the provided [`JNIEnv`].
+    /// The methods of this trait must uphold the invariants described in [`Env::unsafe_clone`] when
+    /// using the provided [`Env`].
     ///
     /// The `get` method must return a valid pointer to the beginning of the JNI array.
     ///
@@ -28,7 +28,7 @@ pub(crate) mod type_array_sealed {
         /// The caller is responsible for passing the returned pointer to [`release`], along
         /// with the same `env` and `array` reference (which needs to still be valid)
         unsafe fn get_elements(
-            env: &JNIEnv,
+            env: &Env,
             array: jarray,
             is_copy: &mut jboolean,
         ) -> Result<*mut Self>;
@@ -44,7 +44,7 @@ pub(crate) mod type_array_sealed {
         /// If `mode` is not [`sys::JNI_COMMIT`], `ptr` must not be used again after calling this
         /// function.
         unsafe fn release_elements(
-            env: &JNIEnv,
+            env: &Env,
             array: jarray,
             ptr: NonNull<Self>,
             mode: i32,
@@ -64,7 +64,7 @@ pub(crate) mod type_array_sealed {
         /// `array` must be a valid pointer to a primitive JNI array object, matching the type of
         /// `Self`, or `null`.
         unsafe fn get_region(
-            env: &JNIEnv,
+            env: &Env,
             array: jarray,
             start: jsize,
             buf: &mut [Self],
@@ -77,8 +77,7 @@ pub(crate) mod type_array_sealed {
         ///
         /// `array` must be a valid pointer to a primitive JNI array object, matching the type of
         /// `Self`, or `null`.
-        unsafe fn set_region(env: &JNIEnv, array: jarray, start: jsize, buf: &[Self])
-            -> Result<()>;
+        unsafe fn set_region(env: &Env, array: jarray, start: jsize, buf: &[Self]) -> Result<()>;
     }
 
     // TypeArray builder
@@ -89,7 +88,7 @@ pub(crate) mod type_array_sealed {
                 unsafe impl TypeArraySealed for $jni_type {
                     /// Get Java $jni_type array
                     unsafe fn get_elements(
-                        env: &JNIEnv,
+                        env: &Env,
                         array: jarray,
                         is_copy: &mut jboolean,
                     ) -> Result<*mut Self> {
@@ -101,7 +100,7 @@ pub(crate) mod type_array_sealed {
 
                     /// Release Java $jni_type array
                     unsafe fn release_elements(
-                        env: &JNIEnv,
+                        env: &Env,
                         array: jarray,
                         ptr: NonNull<Self>,
                         mode: i32,
@@ -112,7 +111,7 @@ pub(crate) mod type_array_sealed {
                     }
 
                     unsafe fn get_region(
-                        env: &JNIEnv,
+                        env: &Env,
                         array: jarray,
                         start: jsize,
                         buf: &mut [Self],
@@ -133,7 +132,7 @@ pub(crate) mod type_array_sealed {
                     }
 
                     unsafe fn set_region(
-                        env: &JNIEnv,
+                        env: &Env,
                         array: jarray,
                         start: jsize,
                         buf: &[Self],

--- a/tests/jni_weak_refs.rs
+++ b/tests/jni_weak_refs.rs
@@ -6,9 +6,9 @@ use std::{
 };
 
 use jni::{
-    env::JNIEnv,
     objects::{IntoAutoLocal as _, JObject, JValue, WeakRef},
     sys::jint,
+    Env,
 };
 
 mod util;
@@ -104,7 +104,7 @@ fn weak_ref_is_actually_weak() {
     attach_current_thread(|env| {
         // This test uses `with_local_frame` to work around issue #109.
 
-        fn run_gc(env: &mut JNIEnv) {
+        fn run_gc(env: &mut Env) {
             unwrap(
                 env.with_local_frame(1, |env| {
                     env.call_static_method(c"java/lang/System", c"gc", c"()V", &[])?;

--- a/tests/threads_atomic_int_proxy.rs
+++ b/tests/threads_atomic_int_proxy.rs
@@ -105,7 +105,7 @@ fn test_destroy() {
         let jvm = jvm.clone();
         let atomic = atomic.clone();
         let jh = spawn(move || {
-            // Safety: there is no other mutable `JNIEnv` in scope, so we aren't
+            // Safety: there is no other mutable `Env` in scope, so we aren't
             // creating an opportunity for local references to be created
             // in association with the wrong stack frame.
             jvm.attach_current_thread(|env| -> jni::errors::Result<()> {
@@ -154,7 +154,7 @@ fn test_destroy() {
             // JavaVM before it gets destroyed, including dropping the AutoLocal
             // for the `MATH_CLASS`
             {
-                // Safety: there is no other mutable `JNIEnv` in scope, so we aren't
+                // Safety: there is no other mutable `Env` in scope, so we aren't
                 // creating an opportunity for local references to be created
                 // in association with the wrong stack frame.
                 let mut guard = unsafe { attach_current_thread_as_daemon(&jvm).unwrap() };
@@ -178,7 +178,7 @@ fn test_destroy() {
             // threads exit and they try to automatically detach from the `JavaVM`
             //
             // # Safety
-            // We won't be accessing any (invalid) `JNIEnv` once we have detached this
+            // We won't be accessing any (invalid) `Env` once we have detached this
             // thread
             unsafe {
                 // Note: jni-rs doesn't directly support 'daemon' threads so we're

--- a/tests/threads_nested_attach_with_frames.rs
+++ b/tests/threads_nested_attach_with_frames.rs
@@ -33,7 +33,7 @@ fn check_nested_attach(vm: &Arc<JavaVM>) {
     vm.attach_current_thread(|_env| -> jni::errors::Result<()> {
         check_attached(vm);
 
-        // Alias the outer _env so we avoid having more than one mutable JNIEnv in scope
+        // Alias the outer _env so we avoid having more than one mutable Env in scope
         vm.attach_current_thread(|_env| -> jni::errors::Result<()> {
             check_attached(vm);
             Ok(())

--- a/tests/ui/fail/auto-elements-lifetime.rs
+++ b/tests/ui/fail/auto-elements-lifetime.rs
@@ -10,7 +10,7 @@ pub fn main() {
             .with_local_frame(10, |env1| -> jni::errors::Result<_> {
                 let java_array = env1
                     .new_int_array(3)
-                    .expect("JNIEnv#new_int_array must create a java array with given size");
+                    .expect("Env#new_int_array must create a java array with given size");
 
                 // It should be OK to get AutoElements from a new `env2` frame because
                 // it is only constrained by the `env1` lifetime of it's array reference

--- a/tests/ui/fail/auto-elements-lifetime.stderr
+++ b/tests/ui/fail/auto-elements-lifetime.stderr
@@ -1,4 +1,4 @@
-warning: use of deprecated method `jni::env::JNIEnv::<'local>::get_array_elements`: use JPrimitiveArray::get_elements instead. This API will be removed in a future version
+warning: use of deprecated method `jni::Env::<'local>::get_array_elements`: use JPrimitiveArray::get_elements instead. This API will be removed in a future version
   --> tests/ui/fail/auto-elements-lifetime.rs:19:30
    |
 19 |                         env2.get_array_elements(java_array, ReleaseMode::CopyBack)
@@ -12,7 +12,7 @@ error: lifetime may not live long enough
 10 |             .with_local_frame(10, |env1| -> jni::errors::Result<_> {
    |                                    ----     ---------------------- return type of closure is std::result::Result<AutoElements<'2, i32, JPrimitiveArray<'_, i32>>, jni::errors::Error>
    |                                    |
-   |                                    has type `&mut JNIEnv<'1>`
+   |                                    has type `&mut Env<'1>`
 ...
 26 |                 Ok(elems1)
    |                 ^^^^^^^^^^ returning this value requires that `'1` must outlive `'2`

--- a/tests/util/mod.rs
+++ b/tests/util/mod.rs
@@ -1,8 +1,6 @@
 use std::sync::{Arc, Once};
 
-use jni::{
-    env::JNIEnv, errors::Result, objects::JValue, sys::jint, InitArgsBuilder, JNIVersion, JavaVM,
-};
+use jni::{errors::Result, objects::JValue, sys::jint, Env, InitArgsBuilder, JNIVersion, JavaVM};
 
 mod example_proxy;
 
@@ -34,7 +32,7 @@ pub fn jvm() -> &'static Arc<JavaVM> {
 }
 
 #[allow(dead_code)]
-pub fn call_java_abs(env: &mut JNIEnv, value: i32) -> i32 {
+pub fn call_java_abs(env: &mut Env, value: i32) -> i32 {
     env.call_static_method(
         c"java/lang/Math",
         c"abs",
@@ -49,7 +47,7 @@ pub fn call_java_abs(env: &mut JNIEnv, value: i32) -> i32 {
 #[allow(dead_code)]
 pub fn attach_current_thread<F, T>(callback: F) -> jni::errors::Result<T>
 where
-    F: FnOnce(&mut JNIEnv) -> jni::errors::Result<T>,
+    F: FnOnce(&mut Env) -> jni::errors::Result<T>,
 {
     jvm().attach_current_thread(|env| callback(env))
 }
@@ -57,7 +55,7 @@ where
 #[allow(dead_code)]
 pub fn attach_current_thread_for_scope<F, T>(callback: F) -> jni::errors::Result<T>
 where
-    F: FnOnce(&mut JNIEnv) -> jni::errors::Result<T>,
+    F: FnOnce(&mut Env) -> jni::errors::Result<T>,
 {
     jvm().attach_current_thread_for_scope(|env| callback(env))
 }
@@ -74,7 +72,7 @@ pub fn detach_current_thread() -> Result<()> {
     jvm().detach_current_thread()
 }
 
-pub fn print_exception(env: &JNIEnv) {
+pub fn print_exception(env: &Env) {
     let exception_occurred = env.exception_check();
     if exception_occurred {
         env.exception_describe();
@@ -82,7 +80,7 @@ pub fn print_exception(env: &JNIEnv) {
 }
 
 #[allow(dead_code)]
-pub fn unwrap<T>(res: Result<T>, env: &JNIEnv) -> T {
+pub fn unwrap<T>(res: Result<T>, env: &Env) -> T {
     res.unwrap_or_else(|e| {
         print_exception(env);
         panic!("{:#?}", e);


### PR DESCRIPTION
One of the important changes made in #570 was that `JNIEnv` is no longer a transparent `jni_sys::JNIEnv` pointer wrapper.

One of the difficulties with that change though was that we have to consider that existing code may be using `JNIEnv` to capture raw pointers passed to native methods and Rust has no way of explicitly stopping a type from being used unsafely in an FFI interface.

The previous solution was to move the "real" `JNIEnv` to `env::JNIEnv` and make the original `JNIEnv` a type alias for the FFI-safe `JNIEnvUnowned` that has a very loud deprecation warning.

We have also added a `Drop` implementation to help trigger a compiler warning when the type is used in FFI.

Although this solution would certainly mean that everyone updating to 0.22 would see the deprecation message there was still some risk that after simply updating some `use` statements to `use jni::env::JNIEnv` then it would still be possible to accidentally not update native methods to use `JNIEnvUnowned`.

By renaming `JNIEnv` to `Env` then, not only do we remove a redundant `JNI` prefix, we also further reduce the risk that someone will not update native methods to use `JNIEnvUnowned`.

This keeps the `JNIEnv` -> `EnvUnowned` type alias plus the loud deprecation warning so we get FFI safety by default and a clear explanation of what has changed.

For code that needs to refer to non-ffi `JNIEnv` type they will need to explicitly refer to the new `Env` type and there's less risk that that migration will affect native method implementations.

Of course, it's still possible that a blind find/replace could have the original problem but that's at least more involved than swapping a single `use` statement and it should hopefully be more likely that someone can do an interactive find/replace if they know they have a mixture of FFI/non-FFI `JNIEnv` usages.

Even if someone does a blind find and replace then so long as they choose to replace `JNIEnv` with `JNIEnvUnowned` then the compiler can complain and help you migrate any non-FFI usages since `JNIEnvUnowned` has none of the APIs that would be expected.

Addresses: #633
