### PR TITLE
Rename GlobalRef + WeakRef to Global and Weak

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,11 +63,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `Env::get_string` performance was optimized by caching an expensive class lookup, and using a faster instanceof check. ([#531](https://github.com/jni-rs/jni-rs/pull/531))
 - `Env::get_string` performance was later further optimized to avoid the need for runtime type checking ([#612](https://github.com/jni-rs/jni-rs/pull/612))
 - `Env::get_string` has been deprecated in favor of `JString::mutf8_chars` and `JString::to_string()` or `JString::try_to_string(env)`
-- `GlobalRef` and `WeakRef` are parameterized, transparent wrappers over `'static` reference types like `GlobalRef<JClass<'static>>` (no longer an `Arc` holding a reference and VM pointer) ([#596](https://github.com/jni-rs/jni-rs/pull/596))
-  - `GlobalRef` and `WeakRef` no longer implement `Clone`, since JNI is required to create new reference (you'll need to explicitly use `env.new_global_ref`)
-  - `GlobalRef` and `WeakRef` both implement `Default`, which will represent `::null()` references (equivalent to `JObject::null()`)
-- `GlobalRef::into_raw` replaces `GlobalRef::try_into_raw` and is infallible ([#596](https://github.com/jni-rs/jni-rs/pull/596))
-- `Env::new_weak_ref` returns a `Result<WeakRef>` and `Error::ObjectFreed` if the reference is null or has already been freed (instead of `Result<Option<WeakRef>>`) ([#596](https://github.com/jni-rs/jni-rs/pull/596))
+
+- `GlobalRef` and `WeakRef` have been renamed to `Global` and `Weak` and are now generic, parameterized, transparent wrappers over `'static` reference types like `Global<JClass<'static>>` (no longer an `Arc` holding a reference and VM pointer) ([#596](https://github.com/jni-rs/jni-rs/pull/596))
+  - `Global` and `Weak` no longer implement `Clone`, since JNI is required to create new reference (you'll need to explicitly use `env.new_global_ref`)
+  - `Global` and `Weak` both implement `Default`, which will represent `::null()` references (equivalent to `JObject::null()`)
+- `Global::into_raw` replaces `Global::try_into_raw` and is infallible ([#596](https://github.com/jni-rs/jni-rs/pull/596))
+- `Env::new_weak_ref` returns a `Result<Weak>` and `Error::ObjectFreed` if the reference is null or has already been freed (instead of `Result<Option<Weak>>`) ([#596](https://github.com/jni-rs/jni-rs/pull/596))
 - `Env::new_global_ref` and `::new_local_ref` may return `Error::ObjectFreed` in case a weak reference was given and the object has been freed. ([#596](https://github.com/jni-rs/jni-rs/pull/596))
 - `Env::define_class` takes a `name: Option<>` instead of having a separate `define_unnamed_class` API.
 - `Env::define_class_bytearray` was renamed to `Env::define_class_jbyte` and is identical to `define_class` except for taking a `&[jbyte]` slice instead of `&[u8]`, which is a convenience if you have a `JByteArray` or `AutoElements<JByteArray>`.
@@ -100,7 +101,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `JavaStr/MUTF8Chars`, `JNIStr`, and `JNIString` have several new methods and traits, most notably a `to_str` method that converts to a regular Rust string. ([#510](https://github.com/jni-rs/jni-rs/issues/510) / [#512](https://github.com/jni-rs/jni-rs/pull/512))
 - Added dependency on `once_cell` version `1.19.0` for lazy initialization of various global statics.
 - `JavaVM::singleton()` lets you acquire the `JavaVM` for the process when you know that the `JavaVM` singleton has been initialized ([#595](https://github.com/jni-rs/jni-rs/pull/595))
-- `GlobalRef::null()` and `WeakRef::null()` construct null references (equivalent to `Default::default()`). ([#596](https://github.com/jni-rs/jni-rs/pull/596))
+- `Global::null()` and `Weak::null()` construct null references (equivalent to `Default::default()`). ([#596](https://github.com/jni-rs/jni-rs/pull/596))
 - `JavaVM::is_thread_attached` can query whether the current thread is attached to the Java VM ([#570](https://github.com/jni-rs/jni-rs/pull/570))
 - `EnvUnowned` is an FFI-safe type that can be used to capture a `jni_sys::Env` pointer given to native methods and give it a named lifetime (this can then be temporarily upgraded to a `&mut Env` reference via `EnvUnowned::with_env`) ([#570](https://github.com/jni-rs/jni-rs/pull/570))
 - `AttachGuard::from_unowned` added as a low-level (unsafe) way to represent a thread attachment with a raw `jni_sys::Env` pointer ([#570](https://github.com/jni-rs/jni-rs/pull/570))
@@ -120,9 +121,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `JThread` as a `JObjectRef` wrapper for `java.lang.Thread` references ([#612](https://github.com/jni-rs/jni-rs/pull/612))
 - `JClassLoader` as a `JObjectRef` wrapper for `java.lang.ClassLoader` references ([#612](https://github.com/jni-rs/jni-rs/pull/612))
 - `LoaderContext` + `LoaderContext::load_class` for loading classes, depending on available context ([#612](https://github.com/jni-rs/jni-rs/pull/612))
-- `JObjectRef::load_class` exposes a cached `GlobalRef<JClass>` for all `JObjectRef` implementations ([#612](https://github.com/jni-rs/jni-rs/pull/612))
+- `JObjectRef::load_class` exposes a cached `Global<JClass>` for all `JObjectRef` implementations ([#612](https://github.com/jni-rs/jni-rs/pull/612))
 - `Env::new_cast_global_ref` acts like `new_global_ref` with a type cast ([#612](https://github.com/jni-rs/jni-rs/pull/612))
-- `Env::cast_global` takes an owned `GlobalRef<From>` and returns a `GlobalRef<To>` ([#612](https://github.com/jni-rs/jni-rs/pull/612))
+- `Env::cast_global` takes an owned `Global<From>` and returns a `Global<To>` ([#612](https://github.com/jni-rs/jni-rs/pull/612))
 - `Env::new_cast_local_ref` acts like `new_local_ref` with a type cast ([#612](https://github.com/jni-rs/jni-rs/pull/612))
 - `Env::cast_local` takes an owned local reference and returns a newly type cast wrapper ([#612](https://github.com/jni-rs/jni-rs/pull/612))
 - `Env::as_cast` borrows any `From: JObjectRef` (global or local) reference and returns  a `Cast<To>` that will Deref into `&To` ([#612](https://github.com/jni-rs/jni-rs/pull/612))

--- a/benches/api_calls.rs
+++ b/benches/api_calls.rs
@@ -5,7 +5,7 @@ use jni_sys::jvalue;
 use lazy_static::lazy_static;
 
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
-use jni::objects::{GlobalRef, IntoAutoLocal as _};
+use jni::objects::{Global, IntoAutoLocal as _};
 use jni::{
     descriptors::Desc,
     objects::{JClass, JMethodID, JObject, JStaticMethodID, JValue},
@@ -450,7 +450,7 @@ fn jni_with_local_frame_returning_global_to_local(c: &mut Criterion) {
         c.bench_function("jni_with_local_frame_returning_global_to_local", |b| {
             b.iter(|| {
                 let global = env
-                    .with_local_frame::<_, GlobalRef<JObject<'static>>, jni::errors::Error>(
+                    .with_local_frame::<_, Global<JObject<'static>>, jni::errors::Error>(
                         LOCAL_FRAME_SIZE,
                         |env| {
                             let local = env.new_object(&class, SIG_OBJECT_CTOR, &[])?;

--- a/example/mylib/src/lib.rs
+++ b/example/mylib/src/lib.rs
@@ -6,7 +6,7 @@ use jni::EnvUnowned;
 // They carry extra lifetime information to prevent them escaping from the
 // current local frame (which is the scope within which local (temporary)
 // references to Java objects remain valid)
-use jni::objects::{GlobalRef, JClass, JObject, JString};
+use jni::objects::{Global, JClass, JObject, JString};
 
 use jni::objects::JByteArray;
 
@@ -118,11 +118,11 @@ pub extern "system" fn Java_HelloWorld_factAndCallMeBack(
 
 struct Counter {
     count: i32,
-    callback: GlobalRef<JObject<'static>>,
+    callback: Global<JObject<'static>>,
 }
 
 impl Counter {
-    pub fn new(callback: GlobalRef<JObject<'static>>) -> Counter {
+    pub fn new(callback: Global<JObject<'static>>) -> Counter {
         Counter {
             count: 0,
             callback: callback,

--- a/src/wrapper/descriptors/desc.rs
+++ b/src/wrapper/descriptors/desc.rs
@@ -1,6 +1,6 @@
 use crate::{
     errors::*,
-    objects::{AutoLocal, GlobalRef, JObject, JObjectRef},
+    objects::{AutoLocal, Global, JObject, JObjectRef},
     Env,
 };
 
@@ -132,7 +132,7 @@ where
     }
 }
 
-unsafe impl<'local, 'obj_ref, T> Desc<'local, T> for &'obj_ref GlobalRef<T>
+unsafe impl<'local, 'obj_ref, T> Desc<'local, T> for &'obj_ref Global<T>
 where
     T: JObjectRef
         + AsRef<T>

--- a/src/wrapper/java_vm/vm.rs
+++ b/src/wrapper/java_vm/vm.rs
@@ -11,7 +11,7 @@ use log::{debug, error};
 use crate::{
     env::Env,
     errors::*,
-    objects::{GlobalRef, JObject, JObjectRef},
+    objects::{Global, JObject, JObjectRef},
     strings::JNIString,
     sys, JNIVersion,
 };
@@ -915,10 +915,10 @@ impl JavaVM {
     /// - `AutoElements`
     /// - `AutoElementsCritical`
     /// - `AutoLocal`
-    /// - `GlobalRef`
+    /// - `Global`
     /// - `MUTF8Chars`
     /// - `JMap`
-    /// - `WeakRef`
+    /// - `Weak`
     ///
     /// ## Invalid `JavaVM` on return
     ///
@@ -950,7 +950,7 @@ impl JavaVM {
 pub struct AttachConfig<'a> {
     scoped: bool,
     name: Option<JNIString>,
-    group: Option<&'a GlobalRef<JObject<'static>>>,
+    group: Option<&'a Global<JObject<'static>>>,
 }
 
 impl<'a> AttachConfig<'a> {
@@ -980,7 +980,7 @@ impl<'a> AttachConfig<'a> {
 
     /// Specifies a global reference to a `ThreadGroup` that the thread should
     /// be associated with.
-    pub fn group(mut self, group: &'a GlobalRef<JObject<'static>>) -> Self {
+    pub fn group(mut self, group: &'a Global<JObject<'static>>) -> Self {
         self.group = Some(group);
         self
     }
@@ -1100,7 +1100,7 @@ thread_local! {
 ///
 /// If you know that at least one [`AttachGuard`] has ever existed (which is
 /// implied if you have a `Env` reference or any non-null reference type
-/// (like `JObject` or `GlobalRef`) you can assume that [`JavaVM::singleton()`]
+/// (like `JObject` or `Global`) you can assume that [`JavaVM::singleton()`]
 /// will return `Some(JavaVM)`.
 ///
 /// You can use this to avoid redundantly copying JavaVM pointers that can

--- a/src/wrapper/objects/auto_local.rs
+++ b/src/wrapper/objects/auto_local.rs
@@ -4,7 +4,7 @@ use jni_sys::jobject;
 
 use crate::{
     errors,
-    objects::{GlobalRef, JClass, JObject, LoaderContext},
+    objects::{Global, JClass, JObject, LoaderContext},
     strings::JNIStr,
     JavaVM,
 };
@@ -62,7 +62,7 @@ where
 
 impl<'local, T> AutoLocal<'local, T>
 where
-    // Note that this bound prevents `AutoLocal` from wrapping a `GlobalRef`, which implements
+    // Note that this bound prevents `AutoLocal` from wrapping a `Global`, which implements
     // `AsRef<JObject<'static>>` but *not* `Into<JObject<'static>>`. This is good, because trying
     // to delete a global reference as though it were local would cause undefined behavior.
     T: Into<JObject<'local>>,
@@ -242,7 +242,7 @@ where
     fn lookup_class<'vm>(
         vm: &'vm JavaVM,
         loader_context: LoaderContext,
-    ) -> crate::errors::Result<impl Deref<Target = GlobalRef<JClass<'static>>> + 'vm> {
+    ) -> crate::errors::Result<impl Deref<Target = Global<JClass<'static>>> + 'vm> {
         T::lookup_class(vm, loader_context)
     }
 

--- a/src/wrapper/objects/cast.rs
+++ b/src/wrapper/objects/cast.rs
@@ -5,7 +5,7 @@ use jni_sys::jobject;
 use crate::{
     env::Env,
     errors::{Error, Result},
-    objects::{GlobalRef, JClass, JObject, JObjectRef, LoaderContext},
+    objects::{Global, JClass, JObject, JObjectRef, LoaderContext},
     strings::JNIStr,
     JavaVM,
 };
@@ -129,7 +129,7 @@ unsafe impl<'any, 'from, To: JObjectRef> JObjectRef for Cast<'any, 'from, To> {
     fn lookup_class<'vm>(
         vm: &'vm JavaVM,
         loader_context: LoaderContext,
-    ) -> crate::errors::Result<impl Deref<Target = GlobalRef<JClass<'static>>> + 'vm> {
+    ) -> crate::errors::Result<impl Deref<Target = Global<JClass<'static>>> + 'vm> {
         To::lookup_class(vm, loader_context)
     }
 

--- a/src/wrapper/objects/jbytebuffer.rs
+++ b/src/wrapper/objects/jbytebuffer.rs
@@ -4,7 +4,7 @@ use once_cell::sync::OnceCell;
 
 use crate::{
     errors::Result,
-    objects::{GlobalRef, JClass, JObject, JObjectRef, LoaderContext},
+    objects::{Global, JClass, JObject, JObjectRef, LoaderContext},
     strings::JNIStr,
     sys::jobject,
     JavaVM,
@@ -43,7 +43,7 @@ impl<'local> From<JByteBuffer<'local>> for JObject<'local> {
 }
 
 struct JByteBufferAPI {
-    class: GlobalRef<JClass<'static>>,
+    class: Global<JClass<'static>>,
 }
 
 impl JByteBufferAPI {
@@ -92,7 +92,7 @@ unsafe impl JObjectRef for JByteBuffer<'_> {
     fn lookup_class<'vm>(
         vm: &'vm JavaVM,
         loader_context: LoaderContext,
-    ) -> crate::errors::Result<impl Deref<Target = GlobalRef<JClass<'static>>> + 'vm> {
+    ) -> crate::errors::Result<impl Deref<Target = Global<JClass<'static>>> + 'vm> {
         let api = JByteBufferAPI::get(vm, &loader_context)?;
         Ok(&api.class)
     }

--- a/src/wrapper/objects/jclass.rs
+++ b/src/wrapper/objects/jclass.rs
@@ -5,9 +5,7 @@ use once_cell::sync::OnceCell;
 use crate::{
     env::Env,
     errors::Result,
-    objects::{
-        GlobalRef, JClassLoader, JMethodID, JObject, JStaticMethodID, JValue, LoaderContext,
-    },
+    objects::{Global, JClassLoader, JMethodID, JObject, JStaticMethodID, JValue, LoaderContext},
     signature::JavaType,
     strings::JNIStr,
     sys::{jclass, jobject},
@@ -48,7 +46,7 @@ impl<'local> From<JClass<'local>> for JObject<'local> {
     }
 }
 struct JClassAPI {
-    class: GlobalRef<JClass<'static>>,
+    class: Global<JClass<'static>>,
     get_class_loader_method: JMethodID,
     for_name_method: JStaticMethodID,
     for_name_with_loader_method: JStaticMethodID,
@@ -236,7 +234,7 @@ unsafe impl JObjectRef for JClass<'_> {
     fn lookup_class<'vm>(
         vm: &'vm JavaVM,
         _loader_context: LoaderContext,
-    ) -> crate::errors::Result<impl Deref<Target = GlobalRef<JClass<'static>>> + 'vm> {
+    ) -> crate::errors::Result<impl Deref<Target = Global<JClass<'static>>> + 'vm> {
         // As a special-case; we ignore loader_context just to be clear that there's no risk of
         // recursion. (`LoaderContext::load_class` depends on the `JClassAPI`)
         let api = JClassAPI::get(vm)?;

--- a/src/wrapper/objects/jclass_loader.rs
+++ b/src/wrapper/objects/jclass_loader.rs
@@ -5,7 +5,7 @@ use once_cell::sync::OnceCell;
 use crate::{
     env::Env,
     errors::Result,
-    objects::{GlobalRef, JClass, JMethodID, JObject, JValue, LoaderContext},
+    objects::{Global, JClass, JMethodID, JObject, JValue, LoaderContext},
     signature::JavaType,
     strings::JNIStr,
     sys::{jclass, jobject},
@@ -46,7 +46,7 @@ impl<'local> From<JClassLoader<'local>> for JObject<'local> {
 }
 
 struct JClassLoaderAPI {
-    class: GlobalRef<JClass<'static>>,
+    class: Global<JClass<'static>>,
     load_class_method: JMethodID,
 }
 
@@ -146,7 +146,7 @@ unsafe impl JObjectRef for JClassLoader<'_> {
     fn lookup_class<'vm>(
         vm: &'vm JavaVM,
         _loader_context: LoaderContext,
-    ) -> crate::errors::Result<impl Deref<Target = GlobalRef<JClass<'static>>> + 'vm> {
+    ) -> crate::errors::Result<impl Deref<Target = Global<JClass<'static>>> + 'vm> {
         // As a special-case; we ignore loader_context just to be clear that there's no risk of
         // recursion. (`LoaderContext::load_class` depends on the `JClassLoaderAPI`)
         let api = JClassLoaderAPI::get(vm)?;

--- a/src/wrapper/objects/jcollection.rs
+++ b/src/wrapper/objects/jcollection.rs
@@ -5,7 +5,7 @@ use once_cell::sync::OnceCell;
 use crate::{
     env::Env,
     errors::Result,
-    objects::{GlobalRef, JClass, JIterator, JMethodID, JObject, JValue, LoaderContext},
+    objects::{Global, JClass, JIterator, JMethodID, JObject, JValue, LoaderContext},
     signature::{Primitive, ReturnType},
     strings::JNIStr,
     sys::jobject,
@@ -46,7 +46,7 @@ impl<'local> From<JCollection<'local>> for JObject<'local> {
 }
 
 struct JCollectionAPI {
-    class: GlobalRef<JClass<'static>>,
+    class: Global<JClass<'static>>,
     add_method: JMethodID,
     remove_method: JMethodID,
     clear_method: JMethodID,
@@ -285,7 +285,7 @@ unsafe impl JObjectRef for JCollection<'_> {
     fn lookup_class<'vm>(
         vm: &'vm JavaVM,
         loader_context: LoaderContext,
-    ) -> crate::errors::Result<impl Deref<Target = GlobalRef<JClass<'static>>> + 'vm> {
+    ) -> crate::errors::Result<impl Deref<Target = Global<JClass<'static>>> + 'vm> {
         let api = JCollectionAPI::get(vm, &loader_context)?;
         Ok(&api.class)
     }

--- a/src/wrapper/objects/jiterator.rs
+++ b/src/wrapper/objects/jiterator.rs
@@ -5,7 +5,7 @@ use once_cell::sync::OnceCell;
 use crate::{
     env::Env,
     errors::{Error, Result},
-    objects::{GlobalRef, JClass, JMethodID, JObject, LoaderContext},
+    objects::{Global, JClass, JMethodID, JObject, LoaderContext},
     signature::{Primitive, ReturnType},
     strings::JNIStr,
     sys::jobject,
@@ -46,7 +46,7 @@ impl<'local> From<JIterator<'local>> for JObject<'local> {
 }
 
 struct JIteratorAPI {
-    class: GlobalRef<JClass<'static>>,
+    class: Global<JClass<'static>>,
     has_next_method: JMethodID,
     next_method: JMethodID,
     remove_method: JMethodID,
@@ -211,7 +211,7 @@ unsafe impl JObjectRef for JIterator<'_> {
     fn lookup_class<'vm>(
         vm: &'vm JavaVM,
         loader_context: LoaderContext,
-    ) -> crate::errors::Result<impl Deref<Target = GlobalRef<JClass<'static>>> + 'vm> {
+    ) -> crate::errors::Result<impl Deref<Target = Global<JClass<'static>>> + 'vm> {
         let api = JIteratorAPI::get(vm, &loader_context)?;
         Ok(&api.class)
     }

--- a/src/wrapper/objects/jlist.rs
+++ b/src/wrapper/objects/jlist.rs
@@ -4,7 +4,7 @@ use once_cell::sync::OnceCell;
 use crate::{
     errors::*,
     objects::{
-        Cast, GlobalRef, JClass, JCollection, JIterator, JMethodID, JObject, JObjectRef, JValue,
+        Cast, Global, JClass, JCollection, JIterator, JMethodID, JObject, JObjectRef, JValue,
         LoaderContext,
     },
     signature::{Primitive, ReturnType},
@@ -55,7 +55,7 @@ impl<'local> From<JList<'local>> for JCollection<'local> {
 }
 
 struct JListAPI {
-    class: GlobalRef<JClass<'static>>,
+    class: Global<JClass<'static>>,
     get_method: JMethodID,
     add_idx_method: JMethodID,
     remove_method: JMethodID,
@@ -336,7 +336,7 @@ unsafe impl JObjectRef for JList<'_> {
     fn lookup_class<'vm>(
         vm: &'vm JavaVM,
         loader_context: LoaderContext,
-    ) -> crate::errors::Result<impl Deref<Target = GlobalRef<JClass<'static>>> + 'vm> {
+    ) -> crate::errors::Result<impl Deref<Target = Global<JClass<'static>>> + 'vm> {
         let api = JListAPI::get(vm, &loader_context)?;
         Ok(&api.class)
     }

--- a/src/wrapper/objects/jmap.rs
+++ b/src/wrapper/objects/jmap.rs
@@ -4,7 +4,7 @@ use once_cell::sync::OnceCell;
 use crate::{
     errors::*,
     objects::{
-        GlobalRef, JClass, JIterator, JMethodID, JObject, JObjectRef, JSet, JValue, LoaderContext,
+        Global, JClass, JIterator, JMethodID, JObject, JObjectRef, JSet, JValue, LoaderContext,
     },
     signature::{Primitive, ReturnType},
     strings::JNIStr,
@@ -46,7 +46,7 @@ impl<'local> From<JMap<'local>> for JObject<'local> {
 }
 
 struct JMapAPI {
-    class: GlobalRef<JClass<'static>>,
+    class: Global<JClass<'static>>,
     get_method: JMethodID,
     put_method: JMethodID,
     remove_method: JMethodID,
@@ -306,7 +306,7 @@ unsafe impl JObjectRef for JMap<'_> {
     fn lookup_class<'vm>(
         vm: &'vm JavaVM,
         loader_context: LoaderContext,
-    ) -> crate::errors::Result<impl Deref<Target = GlobalRef<JClass<'static>>> + 'vm> {
+    ) -> crate::errors::Result<impl Deref<Target = Global<JClass<'static>>> + 'vm> {
         let api = JMapAPI::get(vm, &loader_context)?;
         Ok(&api.class)
     }
@@ -352,7 +352,7 @@ impl<'local> From<JMapEntry<'local>> for JObject<'local> {
 }
 
 struct JMapEntryAPI {
-    class: GlobalRef<JClass<'static>>,
+    class: Global<JClass<'static>>,
     get_key_method: JMethodID,
     get_value_method: JMethodID,
     set_value_method: JMethodID,
@@ -501,7 +501,7 @@ unsafe impl JObjectRef for JMapEntry<'_> {
     fn lookup_class<'vm>(
         vm: &'vm JavaVM,
         loader_context: LoaderContext,
-    ) -> crate::errors::Result<impl Deref<Target = GlobalRef<JClass<'static>>> + 'vm> {
+    ) -> crate::errors::Result<impl Deref<Target = Global<JClass<'static>>> + 'vm> {
         let api = JMapEntryAPI::get(vm, &loader_context)?;
         Ok(&api.class)
     }

--- a/src/wrapper/objects/jobject.rs
+++ b/src/wrapper/objects/jobject.rs
@@ -4,7 +4,7 @@ use once_cell::sync::OnceCell;
 
 use crate::{
     errors::Result,
-    objects::{GlobalRef, JClass, LoaderContext},
+    objects::{Global, JClass, LoaderContext},
     strings::JNIStr,
     sys::jobject,
     JavaVM,
@@ -26,10 +26,10 @@ use super::JObjectRef;
 /// reference belongs to. See the [`Env`] documentation for more information
 /// about local reference frames. If `'local` is `'static`, then this reference
 /// does not belong to a local reference frame, that is, it is either null or a
-/// [global reference][GlobalRef].
+/// [global reference][Global].
 ///
 /// Note that an *owned* `JObject` is always a local reference and will never
-/// have the `'static` lifetime. [`GlobalRef`] does implement
+/// have the `'static` lifetime. [`Global`] does implement
 /// <code>[AsRef]&lt;JObject&lt;'static>></code>, but this only yields a
 /// *borrowed* `&JObject<'static>`, never an owned `JObject<'static>`.
 ///
@@ -67,7 +67,7 @@ impl ::std::ops::Deref for JObject<'_> {
 }
 
 struct JObjectAPI {
-    class: GlobalRef<JClass<'static>>,
+    class: Global<JClass<'static>>,
     // no methods cached for now
 }
 impl JObjectAPI {
@@ -140,7 +140,7 @@ unsafe impl JObjectRef for JObject<'_> {
     fn lookup_class<'vm>(
         vm: &'vm JavaVM,
         _loader_context: LoaderContext,
-    ) -> crate::errors::Result<impl Deref<Target = GlobalRef<JClass<'static>>> + 'vm> {
+    ) -> crate::errors::Result<impl Deref<Target = Global<JClass<'static>>> + 'vm> {
         // As a special-case; we ignore loader_context just to be clear that there's no risk of
         // recursion. (`LoaderContext::load_class` depends on the `JObjectAPI`)
         let api = JObjectAPI::get(vm)?;

--- a/src/wrapper/objects/jobject_array.rs
+++ b/src/wrapper/objects/jobject_array.rs
@@ -5,7 +5,7 @@ use once_cell::sync::OnceCell;
 use crate::{
     env::Env,
     errors::Result,
-    objects::{GlobalRef, JClass, JObject, JObjectRef, LoaderContext},
+    objects::{Global, JClass, JObject, JObjectRef, LoaderContext},
     strings::JNIStr,
     sys::{jobject, jobjectArray},
     JavaVM,
@@ -47,7 +47,7 @@ impl<'local> From<JObjectArray<'local>> for JObject<'local> {
 unsafe impl<'local> AsJArrayRaw<'local> for JObjectArray<'local> {}
 
 struct JObjectArrayAPI {
-    class: GlobalRef<JClass<'static>>,
+    class: Global<JClass<'static>>,
 }
 
 impl JObjectArrayAPI {
@@ -113,7 +113,7 @@ unsafe impl JObjectRef for JObjectArray<'_> {
     fn lookup_class<'vm>(
         vm: &'vm JavaVM,
         loader_context: LoaderContext,
-    ) -> crate::errors::Result<impl Deref<Target = GlobalRef<JClass<'static>>> + 'vm> {
+    ) -> crate::errors::Result<impl Deref<Target = Global<JClass<'static>>> + 'vm> {
         let api = JObjectArrayAPI::get(vm, &loader_context)?;
         Ok(&api.class)
     }

--- a/src/wrapper/objects/jobject_ref.rs
+++ b/src/wrapper/objects/jobject_ref.rs
@@ -4,7 +4,7 @@ use jni_sys::jobject;
 
 use crate::{
     errors::Error,
-    objects::{GlobalRef, JClass, JClassLoader, JObject, JThread},
+    objects::{Global, JClass, JClassLoader, JObject, JThread},
     strings::{JNIStr, JNIString},
     JavaVM,
 };
@@ -13,12 +13,12 @@ use crate::{
 use crate::objects::{AutoLocal, JString};
 
 /// A trait for types that represents a JNI reference (could be local, global or
-/// weak global as well as wrapper types like [`AutoLocal`] and [`GlobalRef`])
+/// weak global as well as wrapper types like [`AutoLocal`] and [`Global`])
 ///
 ///
 /// This makes it possible for APIs like [`Env::new_global_ref`] to be given
 /// a non-static local reference type like [`JString<'local>`] (or an
-/// [`AutoLocal`] wrapper) and return a [`GlobalRef`] that is instead
+/// [`AutoLocal`] wrapper) and return a [`Global`] that is instead
 /// parameterized by [`JString<'static>`].
 ///
 /// # Safety
@@ -94,7 +94,7 @@ pub unsafe trait JObjectRef: Sized {
     /// references - avoiding the cost of repeated FindClass or loadClass calls.
     ///
     /// The implementation is expected to use [`JavaVM::get_cached_or_insert_with`] to lookup cached
-    /// API state, including a `GlobalRef<JClass>`.
+    /// API state, including a `Global<JClass>`.
     ///
     /// In case no class reference is already cached then use `loader_source.lookup_class()` to
     /// lookup a class reference.
@@ -102,7 +102,7 @@ pub unsafe trait JObjectRef: Sized {
     fn lookup_class<'vm>(
         vm: &'vm JavaVM,
         loader_context: LoaderContext,
-    ) -> crate::errors::Result<impl Deref<Target = GlobalRef<JClass<'static>>> + 'vm>;
+    ) -> crate::errors::Result<impl Deref<Target = Global<JClass<'static>>> + 'vm>;
 
     /// Returns a new reference type based on [`Self::Kind`] for the given `reference` that is tied
     /// to the specified lifetime.
@@ -330,7 +330,7 @@ where
     fn lookup_class<'vm>(
         vm: &'vm JavaVM,
         loader_context: LoaderContext,
-    ) -> crate::errors::Result<impl Deref<Target = GlobalRef<JClass<'static>>> + 'vm> {
+    ) -> crate::errors::Result<impl Deref<Target = Global<JClass<'static>>> + 'vm> {
         T::lookup_class(vm, loader_context)
     }
 

--- a/src/wrapper/objects/jprimitive_array.rs
+++ b/src/wrapper/objects/jprimitive_array.rs
@@ -7,7 +7,7 @@ use crate::{
     env::Env,
     errors::Result,
     objects::{
-        AutoElements, AutoElementsCritical, GlobalRef, JClass, JObject, JObjectRef, LoaderContext,
+        AutoElements, AutoElementsCritical, Global, JClass, JObject, JObjectRef, LoaderContext,
         ReleaseMode,
     },
     strings::JNIStr,
@@ -336,7 +336,7 @@ macro_rules! impl_ref_for_jprimitive_array {
         paste! {
             #[allow(non_camel_case_types)]
             struct [<JPrimitiveArrayAPI _ $type>] {
-                class: GlobalRef<JClass<'static>>,
+                class: Global<JClass<'static>>,
             }
 
             impl [<JPrimitiveArrayAPI _ $type>] {
@@ -372,7 +372,7 @@ macro_rules! impl_ref_for_jprimitive_array {
                 fn lookup_class<'vm>(
                     vm: &'vm JavaVM,
                     loader_context: LoaderContext,
-                ) -> crate::errors::Result<impl Deref<Target = GlobalRef<JClass<'static>>> + 'vm> {
+                ) -> crate::errors::Result<impl Deref<Target = Global<JClass<'static>>> + 'vm> {
                     let api = [<JPrimitiveArrayAPI _ $type>]::get(vm, &loader_context)?;
                     Ok(&api.class)
                 }

--- a/src/wrapper/objects/jset.rs
+++ b/src/wrapper/objects/jset.rs
@@ -5,7 +5,7 @@ use once_cell::sync::OnceCell;
 use crate::{
     env::Env,
     errors::Result,
-    objects::{Cast, GlobalRef, JClass, JCollection, JIterator, JObject, LoaderContext},
+    objects::{Cast, Global, JClass, JCollection, JIterator, JObject, LoaderContext},
     strings::JNIStr,
     sys::jobject,
     JavaVM,
@@ -52,7 +52,7 @@ impl<'local> From<JSet<'local>> for JCollection<'local> {
 }
 
 struct JSetAPI {
-    class: GlobalRef<JClass<'static>>,
+    class: Global<JClass<'static>>,
 }
 
 impl JSetAPI {
@@ -208,7 +208,7 @@ unsafe impl JObjectRef for JSet<'_> {
     fn lookup_class<'vm>(
         vm: &'vm JavaVM,
         loader_context: LoaderContext,
-    ) -> crate::errors::Result<impl Deref<Target = GlobalRef<JClass<'static>>> + 'vm> {
+    ) -> crate::errors::Result<impl Deref<Target = Global<JClass<'static>>> + 'vm> {
         let api = JSetAPI::get(vm, &loader_context)?;
         Ok(&api.class)
     }

--- a/src/wrapper/objects/jstring.rs
+++ b/src/wrapper/objects/jstring.rs
@@ -5,7 +5,7 @@ use thiserror::Error;
 
 use crate::{
     errors::Result,
-    objects::{GlobalRef, JClass, JMethodID, JObject, LoaderContext},
+    objects::{Global, JClass, JMethodID, JObject, LoaderContext},
     strings::{JNIStr, MUTF8Chars},
     sys::{jobject, jstring},
     Env, JavaVM,
@@ -125,7 +125,7 @@ impl<'local> std::fmt::Display for JString<'local> {
 }
 
 struct JStringAPI {
-    class: GlobalRef<JClass<'static>>,
+    class: Global<JClass<'static>>,
     intern_method: JMethodID,
 }
 
@@ -278,7 +278,7 @@ unsafe impl JObjectRef for JString<'_> {
     fn lookup_class<'vm>(
         vm: &'vm JavaVM,
         loader_context: LoaderContext,
-    ) -> crate::errors::Result<impl Deref<Target = GlobalRef<JClass<'static>>> + 'vm> {
+    ) -> crate::errors::Result<impl Deref<Target = Global<JClass<'static>>> + 'vm> {
         let api = JStringAPI::get(vm, &loader_context)?;
         Ok(&api.class)
     }

--- a/src/wrapper/objects/jthread.rs
+++ b/src/wrapper/objects/jthread.rs
@@ -6,7 +6,7 @@ use crate::{
     env::Env,
     errors::Result,
     objects::{
-        GlobalRef, JClass, JClassLoader, JMethodID, JObject, JStaticMethodID, JValue, LoaderContext,
+        Global, JClass, JClassLoader, JMethodID, JObject, JStaticMethodID, JValue, LoaderContext,
     },
     strings::JNIStr,
     sys::{jobject, jthrowable},
@@ -48,7 +48,7 @@ impl<'local> From<JThread<'local>> for JObject<'local> {
 }
 
 struct JThreadAPI {
-    class: GlobalRef<JClass<'static>>,
+    class: Global<JClass<'static>>,
     current_thread_method: JStaticMethodID,
     get_context_class_loader_method: JMethodID,
     set_context_class_loader_method: JMethodID,
@@ -205,7 +205,7 @@ unsafe impl JObjectRef for JThread<'_> {
     fn lookup_class<'vm>(
         vm: &'vm JavaVM,
         _loader_context: LoaderContext,
-    ) -> crate::errors::Result<impl Deref<Target = GlobalRef<JClass<'static>>> + 'vm> {
+    ) -> crate::errors::Result<impl Deref<Target = Global<JClass<'static>>> + 'vm> {
         // As a special-case; we ignore loader_context just to be clear that there's no risk of
         // recursion. (`LoaderContext::load_class` depends on the `JThreadAPI`)
         let api = JThreadAPI::get(vm)?;

--- a/src/wrapper/objects/jthrowable.rs
+++ b/src/wrapper/objects/jthrowable.rs
@@ -5,7 +5,7 @@ use once_cell::sync::OnceCell;
 use crate::{
     env::Env,
     errors::Result,
-    objects::{GlobalRef, JClass, JMethodID, JObject, JString, LoaderContext},
+    objects::{Global, JClass, JMethodID, JObject, JString, LoaderContext},
     strings::JNIStr,
     sys::{jobject, jthrowable},
     JavaVM,
@@ -46,7 +46,7 @@ impl<'local> From<JThrowable<'local>> for JObject<'local> {
 }
 
 struct JThrowableAPI {
-    class: GlobalRef<JClass<'static>>,
+    class: Global<JClass<'static>>,
     get_message_method: JMethodID,
     get_cause_method: JMethodID,
 }
@@ -151,7 +151,7 @@ unsafe impl JObjectRef for JThrowable<'_> {
     fn lookup_class<'vm>(
         vm: &'vm JavaVM,
         loader_context: LoaderContext,
-    ) -> crate::errors::Result<impl Deref<Target = GlobalRef<JClass<'static>>> + 'vm> {
+    ) -> crate::errors::Result<impl Deref<Target = Global<JClass<'static>>> + 'vm> {
         let api = JThrowableAPI::get(vm, &loader_context)?;
         Ok(&api.class)
     }

--- a/src/wrapper/objects/mod.rs
+++ b/src/wrapper/objects/mod.rs
@@ -57,11 +57,11 @@ mod jthread;
 pub use self::jthread::*;
 
 // For storing a reference to a java object
-mod global_ref;
-pub use self::global_ref::*;
+mod global;
+pub use self::global::*;
 
-mod weak_ref;
-pub use self::weak_ref::*;
+mod weak;
+pub use self::weak::*;
 
 // For automatic local ref deletion
 mod auto_local;

--- a/tests/jni_api.rs
+++ b/tests/jni_api.rs
@@ -8,7 +8,7 @@ use jni::{
     errors::{CharToJavaError, Error},
     objects::{
         AutoElements, IntoAutoLocal as _, JByteBuffer, JList, JObject, JObjectRef as _, JString,
-        JThrowable, JValue, ReleaseMode, WeakRef,
+        JThrowable, JValue, ReleaseMode, Weak,
     },
     signature::{JavaType, Primitive, ReturnType},
     strings::{JNIStr, JNIString},
@@ -1457,7 +1457,7 @@ fn new_weak_ref_null() {
         let result = env.new_weak_ref(null_obj);
         assert!(matches!(result, Err(Error::ObjectFreed)));
 
-        let null_weak: WeakRef<JObject<'static>> = WeakRef::null();
+        let null_weak: Weak<JObject<'static>> = Weak::null();
         assert!(null_weak.is_garbage_collected(env));
 
         Ok(())

--- a/tests/jni_global_refs.rs
+++ b/tests/jni_global_refs.rs
@@ -6,7 +6,7 @@ use std::{
 };
 
 use jni::{
-    objects::{GlobalRef, IntoAutoLocal as _, JObject, JValue},
+    objects::{Global, IntoAutoLocal as _, JObject, JValue},
     sys::jint,
 };
 
@@ -31,7 +31,7 @@ pub fn global_ref_works_in_other_threads() {
     })
     .unwrap();
 
-    static ATOMIC_INT: OnceLock<GlobalRef<JObject<'static>>> = OnceLock::new();
+    static ATOMIC_INT: OnceLock<Global<JObject<'static>>> = OnceLock::new();
     ATOMIC_INT.set(atomic_integer).unwrap();
 
     let mut join_handlers = Vec::new();

--- a/tests/jni_weak_refs.rs
+++ b/tests/jni_weak_refs.rs
@@ -6,7 +6,7 @@ use std::{
 };
 
 use jni::{
-    objects::{IntoAutoLocal as _, JObject, JValue, WeakRef},
+    objects::{IntoAutoLocal as _, JObject, JValue, Weak},
     sys::jint,
     Env,
 };
@@ -30,7 +30,7 @@ pub fn weak_ref_works_in_other_threads() {
         .auto();
         let atomic_integer_weak = unwrap(env.new_weak_ref(&atomic_integer_local), env);
 
-        static ATOMIC_INT: OnceLock<WeakRef<JObject<'static>>> = OnceLock::new();
+        static ATOMIC_INT: OnceLock<Weak<JObject<'static>>> = OnceLock::new();
         ATOMIC_INT.set(atomic_integer_weak).unwrap();
 
         let mut join_handlers = Vec::new();

--- a/tests/util/example_proxy.rs
+++ b/tests/util/example_proxy.rs
@@ -4,7 +4,7 @@ use std::{ops::Deref, sync::Arc};
 
 use jni::{
     errors::*,
-    objects::{GlobalRef, JObject, JValue},
+    objects::{Global, JObject, JValue},
     sys::jint,
     JavaVM, DEFAULT_LOCAL_FRAME_CAPACITY,
 };
@@ -23,7 +23,7 @@ impl Deref for AtomicIntegerProxy {
 }
 
 pub struct AtomicIntegerProxyInner {
-    obj: GlobalRef<JObject<'static>>,
+    obj: Global<JObject<'static>>,
 }
 
 impl AtomicIntegerProxy {


### PR DESCRIPTION
`GlobalRef` and `WeakRef` have recently (#596) been changed so they are generic over a reference type and so since there is inherently going to be some churn to update global + weak reference usage when migrating to 0.22 then it won't make much practical difference to also handle a rename too.

I feel like the use of `Ref` is a little overloaded in this crate and it doesn't really help clarify anything.

Yes from a Java/JNI point of view these are wrappers for references, but it's not like we put `Ref` as a suffix for any of the other reference types like `JObject`, `JClass`, `JString` etc. We also don't have a `Ref` suffix for the `AutoLocal` wrapper type.

In Rust APIs a `Ref` type is sometimes used to represent a temporary guard that is borrowing from something which could make these names misleading (e.g. a `Ref` from a `RefCell` or an `EntryRef` from a `hashbrown::HashMap`).

All things equal, the names "Global" and "Weak" seem like they would be just as clear and slightly less verbose.

This adds deprecated type aliases to at least help sign post that these have been renamed when migrating to 0.22

Addresses: #633
