### PR TITLE
Rename AutoLocal -> Auto

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,6 +86,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `Env::get_*_array_region` and `Env::set_*_array_region` are deprecated in favor of `JPrimitiveArray::get/set_region`
 - `Env::get_array_length` is deprecated in favor of `JPrimitiveArray::len` and `JObjectArray::len`
 - `Env::new_object_unchecked` now takes a `Desc<JMethodID>` for consistency/flexibility instead of directly taking a `JMethodID`
+- `AutoLocal` has been renamed to `Auto` with a deprecated type alias for `AutoLocal` to sign post the rename.
 
 ### Removed
 - `JavaVM::attach_current_thread_as_daemon` (and general support for 'daemon' threads) has been removed, since their semantics are inherently poorly defined and unsafe (the distinction relates to the poorly defined limbo state after calling `JavaDestroyVM`, where it becomes undefined to touch the JVM) ([#593](https://github.com/jni-rs/jni-rs/pull/593))

--- a/benches/api_calls.rs
+++ b/benches/api_calls.rs
@@ -5,7 +5,7 @@ use jni_sys::jvalue;
 use lazy_static::lazy_static;
 
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
-use jni::objects::{Global, IntoAutoLocal as _};
+use jni::objects::{Global, IntoAuto as _};
 use jni::{
     descriptors::Desc,
     objects::{JClass, JMethodID, JObject, JStaticMethodID, JValue},

--- a/src/wrapper/descriptors/class_desc.rs
+++ b/src/wrapper/descriptors/class_desc.rs
@@ -2,7 +2,7 @@ use crate::{
     descriptors::Desc,
     env::Env,
     errors::*,
-    objects::{AutoLocal, IntoAutoLocal as _, JClass},
+    objects::{Auto, IntoAuto as _, JClass},
     strings::JNIStr,
 };
 
@@ -10,7 +10,7 @@ unsafe impl<'local, T> Desc<'local, JClass<'local>> for T
 where
     T: AsRef<JNIStr>,
 {
-    type Output = AutoLocal<'local, JClass<'local>>;
+    type Output = Auto<'local, JClass<'local>>;
 
     fn lookup(self, env: &mut Env<'local>) -> Result<Self::Output> {
         Ok(env.find_class(self.as_ref())?.auto())

--- a/src/wrapper/descriptors/desc.rs
+++ b/src/wrapper/descriptors/desc.rs
@@ -1,6 +1,6 @@
 use crate::{
     errors::*,
-    objects::{AutoLocal, Global, JObject, JObjectRef},
+    objects::{Auto, Global, JObject, JObjectRef},
     Env,
 };
 
@@ -45,7 +45,7 @@ pub unsafe trait Desc<'local, T> {
     /// ```
     ///
     /// **Warning:** Many built-in implementations of this trait return
-    /// [`AutoLocal`] from this method. If you then call [`JObject::as_raw`] on
+    /// [`Auto`] from this method. If you then call [`JObject::as_raw`] on
     /// the returned object reference, this may result in the reference being
     /// [deleted][Env::delete_local_ref] before it is used, causing
     /// undefined behavior.
@@ -110,7 +110,7 @@ where
     }
 }
 
-unsafe impl<'local, 'other_local, T> Desc<'local, T> for AutoLocal<'other_local, T>
+unsafe impl<'local, 'other_local, T> Desc<'local, T> for Auto<'other_local, T>
 where
     T: AsRef<T> + Into<JObject<'other_local>>,
 {
@@ -121,7 +121,7 @@ where
     }
 }
 
-unsafe impl<'local, 'other_local, T> Desc<'local, T> for &AutoLocal<'other_local, T>
+unsafe impl<'local, 'other_local, T> Desc<'local, T> for &Auto<'other_local, T>
 where
     T: AsRef<T> + Into<JObject<'other_local>>,
 {

--- a/src/wrapper/descriptors/exception_desc.rs
+++ b/src/wrapper/descriptors/exception_desc.rs
@@ -2,7 +2,7 @@ use crate::{
     descriptors::Desc,
     env::Env,
     errors::*,
-    objects::{AutoLocal, IntoAutoLocal as _, JClass, JObject, JThrowable, JValue},
+    objects::{Auto, IntoAuto as _, JClass, JObject, JThrowable, JValue},
     strings::{JNIStr, JNIString},
 };
 
@@ -13,7 +13,7 @@ where
     C: Desc<'local, JClass<'other_local>>,
     M: AsRef<JNIStr>,
 {
-    type Output = AutoLocal<'local, JThrowable<'local>>;
+    type Output = Auto<'local, JThrowable<'local>>;
 
     fn lookup(self, env: &mut Env<'local>) -> Result<Self::Output> {
         let jmsg = env.new_string(self.1.as_ref())?.auto();
@@ -25,7 +25,7 @@ where
 }
 
 unsafe impl<'local> Desc<'local, JThrowable<'local>> for Exception {
-    type Output = AutoLocal<'local, JThrowable<'local>>;
+    type Output = Auto<'local, JThrowable<'local>>;
 
     fn lookup(self, env: &mut Env<'local>) -> Result<Self::Output> {
         let jni_class: JNIString = self.class.into();
@@ -35,7 +35,7 @@ unsafe impl<'local> Desc<'local, JThrowable<'local>> for Exception {
 }
 
 unsafe impl<'local> Desc<'local, JThrowable<'local>> for &str {
-    type Output = AutoLocal<'local, JThrowable<'local>>;
+    type Output = Auto<'local, JThrowable<'local>>;
 
     fn lookup(self, env: &mut Env<'local>) -> Result<Self::Output> {
         let jni_msg: JNIString = self.into();
@@ -44,7 +44,7 @@ unsafe impl<'local> Desc<'local, JThrowable<'local>> for &str {
 }
 
 unsafe impl<'local> Desc<'local, JThrowable<'local>> for String {
-    type Output = AutoLocal<'local, JThrowable<'local>>;
+    type Output = Auto<'local, JThrowable<'local>>;
 
     fn lookup(self, env: &mut Env<'local>) -> Result<Self::Output> {
         let jni_msg: JNIString = self.into();
@@ -56,7 +56,7 @@ unsafe impl<'local, T> Desc<'local, JThrowable<'local>> for T
 where
     T: AsRef<JNIStr>,
 {
-    type Output = AutoLocal<'local, JThrowable<'local>>;
+    type Output = Auto<'local, JThrowable<'local>>;
 
     fn lookup(self, env: &mut Env<'local>) -> Result<Self::Output> {
         Desc::<JThrowable>::lookup((DEFAULT_EXCEPTION_CLASS, self.as_ref()), env)

--- a/src/wrapper/java_vm/vm.rs
+++ b/src/wrapper/java_vm/vm.rs
@@ -98,7 +98,7 @@ static JAVA_VM_SINGLETON: once_cell::sync::OnceCell<JavaVM> = once_cell::sync::O
 ///
 /// A common approach is to push appropriately-sized local frames for larger
 /// code fragments (see [`Env::with_local_frame`] or [`JavaVM::with_env`])
-/// and [`objects::AutoLocal`] for temporary references in loops.
+/// and [`objects::Auto`] for temporary references in loops.
 ///
 /// See also the [JNI specification][spec-references] for details on referencing Java objects.
 ///
@@ -914,11 +914,11 @@ impl JavaVM {
     /// - `AttachGuard`
     /// - `AutoElements`
     /// - `AutoElementsCritical`
-    /// - `AutoLocal`
+    /// - `Auto`
     /// - `Global`
+    /// - `Weak`
     /// - `MUTF8Chars`
     /// - `JMap`
-    /// - `Weak`
     ///
     /// ## Invalid `JavaVM` on return
     ///

--- a/src/wrapper/objects/global.rs
+++ b/src/wrapper/objects/global.rs
@@ -17,7 +17,7 @@ use crate::objects::Weak;
 use super::JObjectRef;
 
 // Note: `Global` must not implement `Into<JObject>`! If it did, then it would be possible to
-// wrap it in `AutoLocal`, which would cause undefined behavior upon drop as a result of calling
+// wrap it in `Auto`, which would cause undefined behavior upon drop as a result of calling
 // the wrong JNI function to delete the reference.
 
 /// A global reference to a Java object.
@@ -229,7 +229,7 @@ where
     /// lifetime bounds for trait implementations.
     ///
     /// For example the returned type will implement `Into<JObject>` which means
-    /// it could be wrapped by `AutoLocal`, which would lead to undefined behavior.
+    /// it could be wrapped by [`Auto`], which would lead to undefined behavior.
     ///
     /// Reference types with a `'static` lifetime are an unsafe liability that
     /// should not be exposed by-value in the public API because they will implement

--- a/src/wrapper/objects/jiterator.rs
+++ b/src/wrapper/objects/jiterator.rs
@@ -150,11 +150,11 @@ impl<'local> JIterator<'local> {
     ///
     /// This method creates a new local reference. To prevent excessive memory
     /// usage or overflow errors (when called repeatedly in a loop), the local
-    /// reference should be deleted using [`Env::delete_local_ref`] or
-    /// [`Env::auto_local`] before the next loop iteration. Alternatively, if
-    /// the collection is known to have a small, predictable size, the loop could be
-    /// wrapped in [`Env::with_local_frame`] to delete all of the local
-    /// references at once.
+    /// reference should be deleted using [`Env::delete_local_ref`] or wrapped
+    /// with [`crate::objects::IntoAuto::auto`] before the next loop iteration.
+    /// Alternatively, if the collection is known to have a small, predictable
+    /// size, the loop could be wrapped in [`Env::with_local_frame`] to delete
+    /// all of the local references at once.
     pub fn next<'env_local>(
         &self,
         env: &mut Env<'env_local>,

--- a/src/wrapper/objects/jlist.rs
+++ b/src/wrapper/objects/jlist.rs
@@ -288,21 +288,22 @@ impl<'local> JList<'local> {
         self.remove(env, size - 1).map(Some)
     }
 
-    /// Returns an iterator (`java.util.Iterator`) over the elements in this list.
+    /// Returns an iterator (`java.util.Iterator`) over the elements in this
+    /// list.
     ///
     /// The returned iterator does not implement [`std::iter::Iterator`] and
-    /// cannot be used with a `for` loop. This is because its `next` method
-    /// uses a `&mut Env` to call the Java iterator. Use a `while let` loop
-    /// instead:
+    /// cannot be used with a `for` loop. This is because its `next` method uses
+    /// a `&mut Env` to call the Java iterator. Use a `while let` loop instead:
     ///
     /// ```rust,no_run
-    /// # use jni::{errors::Result, Env, objects::{IntoAutoLocal as _, JList, JObject}};
+    /// # use jni::{errors::Result, Env, objects::{JList, JObject}};
     /// #
     /// # fn example(env: &mut Env, list: JList) -> Result<()> {
+    /// use jni::objects::IntoAuto as _; // for .auto()
     /// let mut iterator = list.iter(env)?;
     ///
     /// while let Some(obj) = iterator.next(env)? {
-    ///     let obj = obj.auto(); // Wrap as AutoLocal to avoid leaking while iterating
+    ///     let obj = obj.auto(); // Wrap as Auto<T> to avoid leaking while iterating
     ///
     ///     // Do something with `obj` here.
     /// }
@@ -312,11 +313,11 @@ impl<'local> JList<'local> {
     ///
     /// Each call to `next` creates a new local reference. To prevent excessive
     /// memory usage or overflow errors, the local reference should be deleted
-    /// using [`Env::delete_local_ref`] or [`Env::auto_local`] before the
-    /// next loop iteration. Alternatively, if the list is known to have a
-    /// small, predictable size, the loop could be wrapped in
-    /// [`Env::with_local_frame`] to delete all of the local references at
-    /// once.
+    /// using [`Env::delete_local_ref`] or wrapped with
+    /// [`crate::objects::IntoAuto::auto`] before the next loop iteration.
+    /// Alternatively, if the list is known to have a small, predictable size,
+    /// the loop could be wrapped in [`Env::with_local_frame`] to delete all of
+    /// the local references at once.
     pub fn iter<'env_local>(&self, env: &mut Env<'env_local>) -> Result<JIterator<'env_local>> {
         self.as_collection().iterator(env)
     }

--- a/src/wrapper/objects/jmap.rs
+++ b/src/wrapper/objects/jmap.rs
@@ -256,18 +256,18 @@ impl<'local> JMap<'local> {
     /// `EntrySet` from java and iterating over it.
     ///
     /// The returned iterator does not implement [`std::iter::Iterator`] and
-    /// cannot be used with a `for` loop. This is because its `next` method
-    /// uses a `&mut Env` to call the Java iterator. Use a `while let` loop
-    /// instead:
+    /// cannot be used with a `for` loop. This is because its `next` method uses
+    /// a `&mut Env` to call the Java iterator. Use a `while let` loop instead:
     ///
     /// ```rust,no_run
-    /// # use jni::{errors::Result, Env, objects::{IntoAutoLocal as _, JMap, JObject}};
+    /// # use jni::{errors::Result, Env, objects::{JMap, JObject}};
     /// #
     /// # fn example(env: &mut Env, map: JMap) -> Result<()> {
+    /// use jni::objects::IntoAuto as _; // for .auto()
     /// let mut iterator = map.iter(env)?;
     ///
     /// while let Some(entry) = iterator.next(env)? {
-    ///     // Wrap as AutoLocals to avoid leaking while iterating
+    ///     // Wrap as Auto<T> to avoid leaking while iterating
     ///     let key = entry.key(env)?.auto();
     ///     let value = entry.value(env)?.auto();
     ///
@@ -278,12 +278,12 @@ impl<'local> JMap<'local> {
     /// ```
     ///
     /// Each call to `next` creates two new local references. To prevent
-    /// excessive memory usage or overflow error, the local references should
-    /// be deleted using [`Env::delete_local_ref`] or [`Env::auto_local`]
-    /// before the next loop iteration. Alternatively, if the map is known to
-    /// have a small, predictable size, the loop could be wrapped in
-    /// [`Env::with_local_frame`] to delete all of the local references at
-    /// once.
+    /// excessive memory usage or overflow error, the local references should be
+    /// deleted using [`Env::delete_local_ref`] or wrapped with
+    /// [`crate::objects::IntoAuto::auto`] before the next loop iteration.
+    /// Alternatively, if the map is known to have a small, predictable size,
+    /// the loop could be wrapped in [`Env::with_local_frame`] to delete all of
+    /// the local references at once.
     pub fn iter<'env_local>(&self, env: &mut Env<'env_local>) -> Result<JMapIter<'env_local>> {
         let set = self.entry_set(env)?;
         let iterator = set.iterator(env)?;
@@ -544,18 +544,18 @@ impl<'local> JMapIter<'local> {
     ///
     /// This method creates two new local references. To prevent excessive
     /// memory usage or overflow error, the local references should be deleted
-    /// using [`Env::delete_local_ref`] or [`Env::auto_local`] before the
-    /// next loop iteration. Alternatively, if the map is known to have a
-    /// small, predictable size, the loop could be wrapped in
-    /// [`Env::with_local_frame`] to delete all of the local references at
-    /// once.
+    /// using [`Env::delete_local_ref`] or wrapped with
+    /// [`crate::objects::IntoAuto::auto`] before the next loop iteration.
+    /// Alternatively, if the map is known to have a small, predictable size,
+    /// the loop could be wrapped in [`Env::with_local_frame`] to delete all of
+    /// the local references at once.
     ///
     /// This method returns:
     ///
     /// * `Ok(Some(_))`: if there was another key-value pair in the map.
     /// * `Ok(None)`: if there are no more key-value pairs in the map.
-    /// * `Err(_)`: if there was an error calling the Java method to
-    ///   get the next key-value pair.
+    /// * `Err(_)`: if there was an error calling the Java method to get the
+    ///   next key-value pair.
     ///
     /// This is like [`std::iter::Iterator::next`], but requires a parameter of
     /// type `&mut Env` in order to call into Java.

--- a/src/wrapper/objects/jobject_ref.rs
+++ b/src/wrapper/objects/jobject_ref.rs
@@ -10,22 +10,22 @@ use crate::{
 };
 
 #[cfg(doc)]
-use crate::objects::{AutoLocal, JString};
+use crate::objects::{Auto, JString};
 
 /// A trait for types that represents a JNI reference (could be local, global or
-/// weak global as well as wrapper types like [`AutoLocal`] and [`Global`])
+/// weak global as well as wrapper types like [`Auto`] and [`Global`])
 ///
 ///
-/// This makes it possible for APIs like [`Env::new_global_ref`] to be given
-/// a non-static local reference type like [`JString<'local>`] (or an
-/// [`AutoLocal`] wrapper) and return a [`Global`] that is instead
-/// parameterized by [`JString<'static>`].
+/// This makes it possible for APIs like [`Env::new_global_ref`] to be given a
+/// non-static local reference type like [`JString<'local>`] (or an [`Auto`]
+/// wrapper) and return a [`Global`] that is instead parameterized by
+/// [`JString<'static>`].
 ///
 /// # Safety
 ///
-/// The associated `Kind` and `GlobalKind` types must be transparent wrappers around
-/// the underlying JNI object reference types (such as `JObject` or `jobject`) and
-/// must not have any `Drop` side effects.
+/// The associated `Kind` and `GlobalKind` types must be transparent wrappers
+/// around the underlying JNI object reference types (such as `JObject` or
+/// `jobject`) and must not have any `Drop` side effects.
 pub unsafe trait JObjectRef: Sized {
     /// The fully qualified class name of the Java class represented by this
     /// reference.

--- a/src/wrapper/objects/mod.rs
+++ b/src/wrapper/objects/mod.rs
@@ -64,8 +64,8 @@ mod weak;
 pub use self::weak::*;
 
 // For automatic local ref deletion
-mod auto_local;
-pub use self::auto_local::*;
+mod auto;
+pub use self::auto::*;
 
 mod release_mode;
 pub use self::release_mode::*;

--- a/src/wrapper/objects/weak.rs
+++ b/src/wrapper/objects/weak.rs
@@ -14,7 +14,7 @@ use crate::{
 use super::JObjectRef;
 
 // Note: `Weak` must not implement `Into<JObject>`! If it did, then it would be possible to
-// wrap it in `AutoLocal`, which would cause undefined behavior upon drop as a result of calling
+// wrap it in `Auto`, which would cause undefined behavior upon drop as a result of calling
 // the wrong JNI function to delete the reference.
 
 /// A global reference to a Java object that does *not* prevent it from being

--- a/tests/descriptors.rs
+++ b/tests/descriptors.rs
@@ -5,7 +5,7 @@ use util::attach_current_thread;
 
 use jni::{
     descriptors::Desc,
-    objects::{AutoLocal, JClass},
+    objects::{Auto, JClass},
 };
 
 #[test]
@@ -15,7 +15,7 @@ fn test_descriptors() {
         let class_as_ref = Desc::<JClass>::lookup(&class_local, env).unwrap();
         let class_global = env.new_global_ref(class_as_ref).unwrap();
         let _class_as_ref = Desc::<JClass>::lookup(&class_global, env).unwrap();
-        let class_auto: AutoLocal<_> = Desc::<JClass>::lookup(c"java/lang/String", env).unwrap();
+        let class_auto: Auto<_> = Desc::<JClass>::lookup(c"java/lang/String", env).unwrap();
         let _class_as_ref = Desc::<JClass>::lookup(&class_auto, env).unwrap();
 
         Ok(())

--- a/tests/jlist.rs
+++ b/tests/jlist.rs
@@ -1,7 +1,7 @@
 #![cfg(feature = "invocation")]
 
 use jni::{
-    objects::{IntoAutoLocal, JList, JString},
+    objects::{IntoAuto, JList, JString},
     strings::JNIStr,
     sys::jint,
 };
@@ -244,7 +244,7 @@ pub fn jlist_iterator_empty() {
 }
 
 #[test]
-pub fn jlist_iterator_with_auto_local() {
+pub fn jlist_iterator_with_auto() {
     attach_current_thread(|env| {
         let data = &[
             JNIStr::from_cstr(c"item1"),
@@ -267,12 +267,12 @@ pub fn jlist_iterator_with_auto_local() {
             env,
         );
 
-        // Test iterator with auto_local to prevent memory leaks
+        // Test iterator with Auto<T> to prevent memory leaks
         let mut collected = Vec::new();
         unwrap(
             list.iter(env).and_then(|iter| {
                 while let Some(obj) = iter.next(env)? {
-                    let obj = obj.auto(); // Wrap as AutoLocal to avoid leaking while iterating
+                    let obj = obj.auto(); // Wrap as Auto<T> to avoid leaking while iterating
                     let s = env.as_cast::<JString>(&obj)?;
                     let s = s.mutf8_chars(env)?;
                     collected.push(s.to_owned());

--- a/tests/jni_api.rs
+++ b/tests/jni_api.rs
@@ -7,7 +7,7 @@ use jni::{
     descriptors::Desc,
     errors::{CharToJavaError, Error},
     objects::{
-        AutoElements, IntoAutoLocal as _, JByteBuffer, JList, JObject, JObjectRef as _, JString,
+        AutoElements, IntoAuto as _, JByteBuffer, JList, JObject, JObjectRef as _, JString,
         JThrowable, JValue, ReleaseMode, Weak,
     },
     signature::{JavaType, Primitive, ReturnType},
@@ -1466,7 +1466,7 @@ fn new_weak_ref_null() {
 }
 
 #[test]
-fn auto_local_null() {
+fn auto_null() {
     let null_obj = JObject::null();
     {
         let auto_ref = null_obj.auto();

--- a/tests/jni_global_refs.rs
+++ b/tests/jni_global_refs.rs
@@ -6,7 +6,7 @@ use std::{
 };
 
 use jni::{
-    objects::{Global, IntoAutoLocal as _, JObject, JValue},
+    objects::{Global, IntoAuto as _, JObject, JValue},
     sys::jint,
 };
 

--- a/tests/jni_weak_refs.rs
+++ b/tests/jni_weak_refs.rs
@@ -6,7 +6,7 @@ use std::{
 };
 
 use jni::{
-    objects::{IntoAutoLocal as _, JObject, JValue, Weak},
+    objects::{IntoAuto as _, JObject, JValue, Weak},
     sys::jint,
     Env,
 };

--- a/tests/threads_atomic_int_proxy.rs
+++ b/tests/threads_atomic_int_proxy.rs
@@ -10,7 +10,7 @@ use std::{
 };
 
 use jni::{
-    errors, objects::IntoAutoLocal as _, strings::JNIStr, sys::jint, AttachGuard, JavaVM,
+    errors, objects::IntoAuto as _, strings::JNIStr, sys::jint, AttachGuard, JavaVM,
     DEFAULT_LOCAL_FRAME_CAPACITY,
 };
 
@@ -151,7 +151,7 @@ fn test_destroy() {
         let atomic = atomic.clone();
         let jh = spawn(move || {
             // We have to be _very_ careful to ensure we have finished accessing the
-            // JavaVM before it gets destroyed, including dropping the AutoLocal
+            // JavaVM before it gets destroyed, including dropping the Auto<T>
             // for the `MATH_CLASS`
             {
                 // Safety: there is no other mutable `Env` in scope, so we aren't


### PR DESCRIPTION
Since the introduction of the `IntoAuto` trait, there's a more ergonomic way to wrap a local reference so that it's automatically deleted when dropped. For example:

```rust
use jni::objects::IntoAuto as _;
for i in 0..1000 {
    // Ensure we aren't left with a new local for each iteration by
    // wrapping the reference in an `Auto` wrapper.
    let auto_delete_string = env.new_string(c"Hello, world!")?.auto();
}
```

with that in mind (if some level of churn around this part of the API already exists) it felt like a good opportunity to also move to a more succinct name.

Even though `Auto` does only apply to local references it doesn't seem necessary to spell that out in the type name.

The `Global` and `Weak` docs make it clear enough that these will delete their wrapped reference when dropped, such that it should be clear that attempting to wrap these in `Auto<T>` would be redundant.

It's nice to have a slightly shorter name in case you're typing out the full `T` parameter too, like `Auto<JString<'local>>`

This makes a pass over the documentation related to `Auto` to hopefully clarify a few details.

This adds a deprecated type alias for `AutoLocal` that can sign post that the type has been renamed without technically breaking the API yet.

Closes: #633
