### PR TITLE
Use `LoaderContext::load_class` in `Desc<JClass>::lookup`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -87,6 +87,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `Env::get_array_length` is deprecated in favor of `JPrimitiveArray::len` and `JObjectArray::len`
 - `Env::new_object_unchecked` now takes a `Desc<JMethodID>` for consistency/flexibility instead of directly taking a `JMethodID`
 - `AutoLocal` has been renamed to `Auto` with a deprecated type alias for `AutoLocal` to sign post the rename.
+- The documentation for `Env::find_class` now recommends considering `LoaderContext::load_class` instead.
+- `Desc<JClass>::lookup()` is now based on `LoaderContext::load_class` (instead of `Env::find_class`), which checks for a thread context class loader by default.
 
 ### Removed
 - `JavaVM::attach_current_thread_as_daemon` (and general support for 'daemon' threads) has been removed, since their semantics are inherently poorly defined and unsafe (the distinction relates to the poorly defined limbo state after calling `JavaDestroyVM`, where it becomes undefined to touch the JVM) ([#593](https://github.com/jni-rs/jni-rs/pull/593))

--- a/src/wrapper/descriptors/class_desc.rs
+++ b/src/wrapper/descriptors/class_desc.rs
@@ -2,7 +2,7 @@ use crate::{
     descriptors::Desc,
     env::Env,
     errors::*,
-    objects::{Auto, IntoAuto as _, JClass},
+    objects::{Auto, IntoAuto as _, JClass, LoaderContext},
     strings::JNIStr,
 };
 
@@ -13,7 +13,9 @@ where
     type Output = Auto<'local, JClass<'local>>;
 
     fn lookup(self, env: &mut Env<'local>) -> Result<Self::Output> {
-        Ok(env.find_class(self.as_ref())?.auto())
+        Ok(LoaderContext::None
+            .find_class(self.as_ref(), false, env)?
+            .auto())
     }
 }
 

--- a/src/wrapper/errors.rs
+++ b/src/wrapper/errors.rs
@@ -4,8 +4,8 @@ use std::char::{CharTryFromError, DecodeUtf16Error};
 
 use thiserror::Error;
 
+use crate::sys;
 use crate::wrapper::signature::TypeSignature;
-use crate::{strings::JNIStr, sys};
 
 pub type Result<T> = std::result::Result<T, Error>;
 
@@ -28,7 +28,7 @@ pub enum Error {
     #[error("Object behind weak reference freed")]
     ObjectFreed,
     #[error("Class not found: {name:?}")]
-    ClassNotFound { name: &'static JNIStr },
+    ClassNotFound { name: String },
     #[error("Method not found: {name} {sig}")]
     MethodNotFound { name: String, sig: String },
     #[error("Field not found: {name} {sig}")]


### PR DESCRIPTION
We now use `LoaderContext::find_class` instead of directly using `Env::find_class`.

`LoaderContext::find_class` is a new shim in front of `LoaderContext::load_class` that accepts names with slashes instead of dots, like `FindClass`.

This updates `Error::ClassNotFound` to take a `name: String` instead of `&'static JNIStr` so that `load_class` and `find_class` are no longer required to take a `'static` name.

This has the benefit of checking for a thread context class loader, which may be particularly useful on Android where native threads will not typically find any application classes when calling `FindClass`.

The documentation for `Env::find_class` has been updated to recommend:

1. Using `JObjectRef::lookup_class` when possible (for types like `JString`)
2. Using `LoaderContext::load_class` or `LoaderContext::find_class` in all other cases (unless you specifically need to use JNI `FindClass`)

Fixes: #637