### PR TITLE
Have `JObjectRef::lookup_class` take an `&Env` not `&JavaVM`

### DIFF
--- a/src/wrapper/jnienv.rs
+++ b/src/wrapper/jnienv.rs
@@ -383,8 +383,7 @@ impl<'local> Env<'local> {
     /// #
     /// # fn example<'local>(env: &mut Env<'local>) -> Result<()> {
     /// use jni::objects::{JString, JObjectRef as _, LoaderContext};
-    /// let vm = env.get_java_vm();
-    /// let string_class = JString::lookup_class(&vm, LoaderContext::None)?;
+    /// let string_class = JString::lookup_class(env, LoaderContext::None)?;
     /// let string_class_ref: &JClass = string_class.as_ref();
     /// # Ok(())
     /// # }
@@ -482,8 +481,7 @@ impl<'local> Env<'local> {
 
     /// Checks if an object can be cast to a specific reference type.
     pub(crate) fn is_instance_of_cast_type<To: JObjectRef>(&self, obj: &JObject) -> Result<bool> {
-        let vm = self.get_java_vm();
-        let class = match To::lookup_class(&vm, LoaderContext::FromObject(obj)) {
+        let class = match To::lookup_class(self, LoaderContext::FromObject(obj)) {
             Ok(class) => class,
             Err(Error::ClassNotFound { name: _ }) => return Ok(false),
             Err(e) => return Err(e),

--- a/src/wrapper/objects/auto.rs
+++ b/src/wrapper/objects/auto.rs
@@ -6,7 +6,7 @@ use crate::{
     errors,
     objects::{Global, JClass, JObject, LoaderContext},
     strings::JNIStr,
-    JavaVM,
+    Env, JavaVM,
 };
 
 use super::JObjectRef;
@@ -281,11 +281,11 @@ where
         self.obj.as_raw()
     }
 
-    fn lookup_class<'vm>(
-        vm: &'vm JavaVM,
+    fn lookup_class<'env>(
+        env: &'env Env<'_>,
         loader_context: LoaderContext,
-    ) -> crate::errors::Result<impl Deref<Target = Global<JClass<'static>>> + 'vm> {
-        T::lookup_class(vm, loader_context)
+    ) -> crate::errors::Result<impl Deref<Target = Global<JClass<'static>>> + 'env> {
+        T::lookup_class(env, loader_context)
     }
 
     unsafe fn from_raw<'env>(local_ref: jobject) -> Self::Kind<'env> {

--- a/src/wrapper/objects/cast.rs
+++ b/src/wrapper/objects/cast.rs
@@ -7,7 +7,6 @@ use crate::{
     errors::{Error, Result},
     objects::{Global, JClass, JObject, JObjectRef, LoaderContext},
     strings::JNIStr,
-    JavaVM,
 };
 
 /// Represents a runtime checked (via `IsInstanceOf`) cast of a reference from one type to another
@@ -126,11 +125,11 @@ unsafe impl<'any, 'from, To: JObjectRef> JObjectRef for Cast<'any, 'from, To> {
         self.to.as_raw()
     }
 
-    fn lookup_class<'vm>(
-        vm: &'vm JavaVM,
+    fn lookup_class<'env>(
+        env: &'env Env<'_>,
         loader_context: LoaderContext,
-    ) -> crate::errors::Result<impl Deref<Target = Global<JClass<'static>>> + 'vm> {
-        To::lookup_class(vm, loader_context)
+    ) -> crate::errors::Result<impl Deref<Target = Global<JClass<'static>>> + 'env> {
+        To::lookup_class(env, loader_context)
     }
 
     unsafe fn from_raw<'env>(local_ref: jobject) -> Self::Kind<'env> {

--- a/src/wrapper/objects/global.rs
+++ b/src/wrapper/objects/global.rs
@@ -317,11 +317,11 @@ where
         self.obj.as_raw()
     }
 
-    fn lookup_class<'vm>(
-        vm: &'vm JavaVM,
+    fn lookup_class<'env>(
+        env: &'env Env<'_>,
         loader_context: LoaderContext,
-    ) -> crate::errors::Result<impl Deref<Target = Global<JClass<'static>>> + 'vm> {
-        T::lookup_class(vm, loader_context)
+    ) -> crate::errors::Result<impl Deref<Target = Global<JClass<'static>>> + 'env> {
+        T::lookup_class(env, loader_context)
     }
 
     unsafe fn from_raw<'env>(local_ref: jobject) -> Self::Kind<'env> {

--- a/src/wrapper/objects/jobject_array.rs
+++ b/src/wrapper/objects/jobject_array.rs
@@ -8,7 +8,6 @@ use crate::{
     objects::{Global, JClass, JObject, JObjectRef, LoaderContext},
     strings::JNIStr,
     sys::{jobject, jobjectArray},
-    JavaVM,
 };
 
 use super::AsJArrayRaw;
@@ -52,11 +51,12 @@ struct JObjectArrayAPI {
 
 impl JObjectArrayAPI {
     fn get<'any_local>(
-        vm: &JavaVM,
+        env: &Env<'_>,
         loader_context: &LoaderContext<'any_local, '_>,
     ) -> Result<&'static Self> {
         static JOBJECT_ARRAY_API: OnceCell<JObjectArrayAPI> = OnceCell::new();
         JOBJECT_ARRAY_API.get_or_try_init(|| {
+            let vm = env.get_java_vm();
             vm.with_env_current_frame(|env| {
                 let class = loader_context.load_class_for_type::<JObjectArray>(false, env)?;
                 let class = env.new_global_ref(&class).unwrap();
@@ -110,11 +110,11 @@ unsafe impl JObjectRef for JObjectArray<'_> {
         self.0.as_raw()
     }
 
-    fn lookup_class<'vm>(
-        vm: &'vm JavaVM,
+    fn lookup_class<'env>(
+        env: &'env Env<'_>,
         loader_context: LoaderContext,
-    ) -> crate::errors::Result<impl Deref<Target = Global<JClass<'static>>> + 'vm> {
-        let api = JObjectArrayAPI::get(vm, &loader_context)?;
+    ) -> crate::errors::Result<impl Deref<Target = Global<JClass<'static>>> + 'env> {
+        let api = JObjectArrayAPI::get(env, &loader_context)?;
         Ok(&api.class)
     }
 

--- a/src/wrapper/objects/jobject_ref.rs
+++ b/src/wrapper/objects/jobject_ref.rs
@@ -6,7 +6,7 @@ use crate::{
     errors::Error,
     objects::{Global, JClass, JClassLoader, JObject, JThread},
     strings::{JNIStr, JNIString},
-    JavaVM,
+    Env,
 };
 
 #[cfg(doc)]
@@ -99,10 +99,10 @@ pub unsafe trait JObjectRef: Sized {
     /// In case no class reference is already cached then use `loader_source.lookup_class()` to
     /// lookup a class reference.
     ///
-    fn lookup_class<'vm>(
-        vm: &'vm JavaVM,
+    fn lookup_class<'env>(
+        env: &'env Env<'_>,
         loader_context: LoaderContext,
-    ) -> crate::errors::Result<impl Deref<Target = Global<JClass<'static>>> + 'vm>;
+    ) -> crate::errors::Result<impl Deref<Target = Global<JClass<'static>>> + 'env>;
 
     /// Returns a new reference type based on [`Self::Kind`] for the given `reference` that is tied
     /// to the specified lifetime.
@@ -371,11 +371,11 @@ where
         (*self).as_raw()
     }
 
-    fn lookup_class<'vm>(
-        vm: &'vm JavaVM,
+    fn lookup_class<'env>(
+        env: &'env Env<'_>,
         loader_context: LoaderContext,
-    ) -> crate::errors::Result<impl Deref<Target = Global<JClass<'static>>> + 'vm> {
-        T::lookup_class(vm, loader_context)
+    ) -> crate::errors::Result<impl Deref<Target = Global<JClass<'static>>> + 'env> {
+        T::lookup_class(env, loader_context)
     }
 
     unsafe fn from_raw<'env>(local_ref: jobject) -> Self::Kind<'env> {

--- a/src/wrapper/objects/jprimitive_array.rs
+++ b/src/wrapper/objects/jprimitive_array.rs
@@ -12,7 +12,6 @@ use crate::{
     },
     strings::JNIStr,
     sys::{jarray, jobject},
-    JavaVM,
 };
 
 use super::TypeArray;
@@ -341,11 +340,12 @@ macro_rules! impl_ref_for_jprimitive_array {
 
             impl [<JPrimitiveArrayAPI _ $type>] {
                 fn get<'any_local>(
-                    vm: &JavaVM,
+                    env: &Env<'_>,
                     loader_context: &LoaderContext<'any_local, '_>,
                 ) -> Result<&'static Self> {
                     static JPRIMITIVE_ARRAY_API: OnceCell<[<JPrimitiveArrayAPI _ $type>]> = OnceCell::new();
                     JPRIMITIVE_ARRAY_API.get_or_try_init(|| {
+                        let vm = env.get_java_vm();
                         vm.with_env_current_frame(|env| {
                             let class =
                                 loader_context.load_class_for_type::<JPrimitiveArray::<crate::sys::$type>>(false, env)?;
@@ -369,11 +369,11 @@ macro_rules! impl_ref_for_jprimitive_array {
                     self.obj.as_raw()
                 }
 
-                fn lookup_class<'vm>(
-                    vm: &'vm JavaVM,
+                fn lookup_class<'env>(
+                    env: &'env Env<'_>,
                     loader_context: LoaderContext,
-                ) -> crate::errors::Result<impl Deref<Target = Global<JClass<'static>>> + 'vm> {
-                    let api = [<JPrimitiveArrayAPI _ $type>]::get(vm, &loader_context)?;
+                ) -> crate::errors::Result<impl Deref<Target = Global<JClass<'static>>> + 'env> {
+                    let api = [<JPrimitiveArrayAPI _ $type>]::get(env, &loader_context)?;
                     Ok(&api.class)
                 }
 

--- a/src/wrapper/objects/weak.rs
+++ b/src/wrapper/objects/weak.rs
@@ -293,11 +293,11 @@ where
         self.obj.as_raw()
     }
 
-    fn lookup_class<'vm>(
-        vm: &'vm JavaVM,
+    fn lookup_class<'env>(
+        env: &'env Env<'_>,
         loader_context: LoaderContext,
-    ) -> crate::errors::Result<impl Deref<Target = Global<JClass<'static>>> + 'vm> {
-        T::lookup_class(vm, loader_context)
+    ) -> crate::errors::Result<impl Deref<Target = Global<JClass<'static>>> + 'env> {
+        T::lookup_class(env, loader_context)
     }
 
     unsafe fn from_raw<'env>(local_ref: jobject) -> Self::Kind<'env> {


### PR DESCRIPTION
The implementations of `JObjectRef::lookup_class` all expect that the current thread is attached which can only be guaranteed if they get an `&Env`, not a `&JavaVM`.

Internally the implementations will still end up using `env.get_java_vm()` followed by `vm.with_env_current_frame()` so that `lookup_class` doesn't need a mutable Env reference, but it still makes sense to be passed an `Env` reference to prove that the current thread is attached.

Fixes: #639
