### PR TITLE
Have `AutoElements[Critical]::discard()` take ownership and drop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -89,6 +89,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `AutoLocal` has been renamed to `Auto` with a deprecated type alias for `AutoLocal` to sign post the rename.
 - The documentation for `Env::find_class` now recommends considering `LoaderContext::load_class` instead.
 - `Desc<JClass>::lookup()` is now based on `LoaderContext::load_class` (instead of `Env::find_class`), which checks for a thread context class loader by default.
+- `AutoElements[Critical]::discard()` now takes ownership of the elements and drops them to release the pointer after setting the mode to `NoCopyBack` ([#645](https://github.com/jni-rs/jni-rs/pull/645))
 
 ### Removed
 - `JavaVM::attach_current_thread_as_daemon` (and general support for 'daemon' threads) has been removed, since their semantics are inherently poorly defined and unsafe (the distinction relates to the poorly defined limbo state after calling `JavaDestroyVM`, where it becomes undefined to touch the JVM) ([#593](https://github.com/jni-rs/jni-rs/pull/593))

--- a/src/elements/auto_elements.rs
+++ b/src/elements/auto_elements.rs
@@ -98,8 +98,9 @@ where
     ///
     /// This method is useful to change the release mode of an array originally created
     /// with `ReleaseMode::CopyBack`.
-    pub fn discard(&mut self) {
+    pub fn discard(mut self) {
         self.mode = ReleaseMode::NoCopyBack;
+        // drop
     }
 
     /// Indicates if the array is a copy or not

--- a/src/elements/auto_elements_critical.rs
+++ b/src/elements/auto_elements_critical.rs
@@ -103,8 +103,9 @@ where
     ///
     /// This method is useful to change the release mode of an array originally created
     /// with `ReleaseMode::CopyBack`.
-    pub fn discard(&mut self) {
+    pub fn discard(mut self) {
         self.mode = ReleaseMode::NoCopyBack;
+        // drop
     }
 
     /// Indicates if the array is a copy or not


### PR DESCRIPTION
It seems logical that if you've explicitly decided to "discard" the elements you have, then you're probably ready for the pointer to be released and for the `AutoElements` to be dropped.

This updates `discard()` to take ownership of `self` so it can be dropped after setting the mode to `NoCopyBack`.

Fixes: #402
