### PR TITLE
Check `Env::thow_new` class and add `Env::throw_new_void`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -136,6 +136,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `JList::clear` allows a list to be cleared.
 - `JList::is_empty` checks if a list is empty.
 - `JList::as_collection` casts a list into a `JCollection`
+- `Env::throw_new_void` provides an easy way to throw an exception that's constructed with no message argument
 
 ### Fixed
 - `Env::get_string` no longer leaks local references. ([#528](https://github.com/jni-rs/jni-rs/pull/528), [#557](https://github.com/jni-rs/jni-rs/pull/557))


### PR DESCRIPTION
This adds an `IsAssignableFrom` check in `Env::throw_new` to make sure that the given class is a `java.lang.Throwable` subclass.

The JNI spec says that the class must be a Throwable and does not define can happen if it isn't.

On the other hand, the JNI spec does allow for the message argument to be null and although it's not well specified, that will result in the exception being constructed with no arguments.

To expose that functionality, this adds an `Env::thow_new_void` that only takes a `class`, without a `msg` argument.

Alternatively we could wrap the `msg` for `throw_new` in an `Option` but since `msg` is generic it becomes awkward to pass None without specifying what the `Some` value would have been.

Also, since it's probably much more common to throw with a message, it seems worthwhile not making that common case more verbose by needing to wrap every message in `Some()`.

Fixes: #644
Fixes: #486

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Change is covered by [automated tests](https://github.com/jni-rs/jni-rs/blob/master/CONTRIBUTING.md#tests)
- [x] The [coding guidelines](https://github.com/jni-rs/jni-rs/blob/master/CONTRIBUTING.md#the-code-style) are followed
- [x] Public API has documentation
- [x] User-visible changes are mentioned in the Changelog
- [x] The continuous integration build passes
