### PR TITLE
Rename `JObjectRef` -> `Reference`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,8 +74,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `Env::define_class_bytearray` was renamed to `Env::define_class_jbyte` and is identical to `define_class` except for taking a `&[jbyte]` slice instead of `&[u8]`, which is a convenience if you have a `JByteArray` or `AutoElements<JByteArray>`.
 - `AutoElements` was simplified to only be parameterized by one lifetime for the array reference, and accepts any `AsRef<JPrimitiveArray<T>>` as a reference. ([#508](https://github.com/jni-rs/jni-rs/pull/508))
 - `JavaType` was simplified to not capture object names or array details (like `ReturnType`) since these details don't affect `JValue` type checks and had a hidden cost that was redundant.
-- `Env::with_local_frame_returning_local` can now return any kind of `JObjectRef` local reference, not just `JObject`
-- `JList` is a simpler, transparent reference wrapper implementing `JObjectRef`, like `JObject`, `JClass`, `JString` etc
+- `Env::with_local_frame_returning_local` can now return any kind of local `Reference`, not just `JObject`
+- `JList` is a simpler, transparent reference wrapper implementing `Reference`, like `JObject`, `JClass`, `JString` etc
 - `JList::add` returns the boolean returned by the Java API
 - `JList::remove` no longer returns an `Option` since there's nothing special about getting a `null` from the Java `remove` API.
 - `JList::pop` is deprecated since this doesn't map to standard Java `List` method.
@@ -100,6 +100,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `Env::define_unnamed_class` was removed in favor of having the `define_class[_jbyte]` APIs take a `name: Option` instead.
 
 ### Added
+- A `Reference` trait for all reference types like `JObject`, `JClass`, `JString`, enabling `Global` and `Weak` to be generic over `Reference` and enabling safe casting and global caching of `JClass` references. ([#596](https://github.com/jni-rs/jni-rs/pull/596))
 - New functions for converting Rust `char` to and from Java `char` and `int` ([#427](https://github.com/jni-rs/jni-rs/issues/427) / [#434](https://github.com/jni-rs/jni-rs/pull/434))
 - `Env::call_nonvirtual_method` and `Env::call_nonvirtual_method_unchecked` to call non-virtual method. ([#454](https://github.com/jni-rs/jni-rs/issues/454))
 - `JavaStr/MUTF8Chars`, `JNIStr`, and `JNIString` have several new methods and traits, most notably a `to_str` method that converts to a regular Rust string. ([#510](https://github.com/jni-rs/jni-rs/issues/510) / [#512](https://github.com/jni-rs/jni-rs/pull/512))
@@ -122,15 +123,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `JNIStr::from_cstr` safely does a zero-copy cast of a `CStr` to a `JNIStr` after a `const` modified-utf8 encoding validation (with a panic on failure)
 - `AsRef<JNIStr>` is implemented for `CStr` (based on `JNIStr::from_cstr`) allows use of literals like `c"java/lang/Foo"` to be passed to JNI APIs without needing to be copied. ([#615](https://github.com/jni-rs/jni-rs/pull/615))
 - `JNIStr::to_bytes` gives access to a `&[u8]` slice over the bytes of a JNI string (like `CStr::to_bytes`) ([#615](https://github.com/jni-rs/jni-rs/pull/615))
-- `JThread` as a `JObjectRef` wrapper for `java.lang.Thread` references ([#612](https://github.com/jni-rs/jni-rs/pull/612))
-- `JClassLoader` as a `JObjectRef` wrapper for `java.lang.ClassLoader` references ([#612](https://github.com/jni-rs/jni-rs/pull/612))
+- `JThread` as a `Reference` wrapper for `java.lang.Thread` references ([#612](https://github.com/jni-rs/jni-rs/pull/612))
+- `JClassLoader` as a `Reference` wrapper for `java.lang.ClassLoader` references ([#612](https://github.com/jni-rs/jni-rs/pull/612))
 - `LoaderContext` + `LoaderContext::load_class` for loading classes, depending on available context ([#612](https://github.com/jni-rs/jni-rs/pull/612))
-- `JObjectRef::load_class` exposes a cached `Global<JClass>` for all `JObjectRef` implementations ([#612](https://github.com/jni-rs/jni-rs/pull/612))
+- `Reference::lookup_class` exposes a cached `Global<JClass>` for all `Reference` implementations ([#612](https://github.com/jni-rs/jni-rs/pull/612))
 - `Env::new_cast_global_ref` acts like `new_global_ref` with a type cast ([#612](https://github.com/jni-rs/jni-rs/pull/612))
 - `Env::cast_global` takes an owned `Global<From>` and returns a `Global<To>` ([#612](https://github.com/jni-rs/jni-rs/pull/612))
 - `Env::new_cast_local_ref` acts like `new_local_ref` with a type cast ([#612](https://github.com/jni-rs/jni-rs/pull/612))
 - `Env::cast_local` takes an owned local reference and returns a newly type cast wrapper ([#612](https://github.com/jni-rs/jni-rs/pull/612))
-- `Env::as_cast` borrows any `From: JObjectRef` (global or local) reference and returns  a `Cast<To>` that will Deref into `&To` ([#612](https://github.com/jni-rs/jni-rs/pull/612))
+- `Env::as_cast` borrows any `From: Reference` (global or local) reference and returns  a `Cast<To>` that will Deref into `&To` ([#612](https://github.com/jni-rs/jni-rs/pull/612))
 - `JCollection`, `JSet` and `JIterator` reference wrappers for `java.util.Collection`, `java.util.Set` and `java.util.Iterator` interfaces.
 - `JList::remove_item` for removing a given value, by-reference, from the list (instead of by index).
 - `JList::clear` allows a list to be cleared.

--- a/src/descriptors/desc.rs
+++ b/src/descriptors/desc.rs
@@ -1,6 +1,6 @@
 use crate::{
     errors::*,
-    objects::{Auto, Global, JObject, JObjectRef},
+    objects::{Auto, Global, JObject, Reference},
     Env,
 };
 
@@ -134,7 +134,7 @@ where
 
 unsafe impl<'local, 'obj_ref, T> Desc<'local, T> for &'obj_ref Global<T>
 where
-    T: JObjectRef
+    T: Reference
         + AsRef<T>
         + AsRef<JObject<'static>>
         + Into<JObject<'static>>

--- a/src/elements/auto_elements.rs
+++ b/src/elements/auto_elements.rs
@@ -2,7 +2,7 @@ use log::error;
 use std::marker::PhantomData;
 use std::ptr::NonNull;
 
-use crate::objects::{JObjectRef, JPrimitiveArray, ReleaseMode, TypeArray};
+use crate::objects::{JPrimitiveArray, Reference, ReleaseMode, TypeArray};
 use crate::sys::jboolean;
 use crate::{env::Env, errors::*, sys, JavaVM};
 
@@ -123,7 +123,7 @@ impl<'array_local, T, TArrayRef> AsRef<AutoElements<'array_local, T, TArrayRef>>
     for AutoElements<'array_local, T, TArrayRef>
 where
     T: TypeArray + 'array_local,
-    TArrayRef: AsRef<JPrimitiveArray<'array_local, T>> + JObjectRef,
+    TArrayRef: AsRef<JPrimitiveArray<'array_local, T>> + Reference,
 {
     fn as_ref(&self) -> &AutoElements<'array_local, T, TArrayRef> {
         self
@@ -149,7 +149,7 @@ where
 impl<'array_local, T, TArrayRef> From<&AutoElements<'array_local, T, TArrayRef>> for *mut T
 where
     T: TypeArray,
-    TArrayRef: AsRef<JPrimitiveArray<'array_local, T>> + JObjectRef,
+    TArrayRef: AsRef<JPrimitiveArray<'array_local, T>> + Reference,
 {
     fn from(other: &AutoElements<'array_local, T, TArrayRef>) -> *mut T {
         other.as_ptr()
@@ -159,7 +159,7 @@ where
 impl<'array_local, T, TArrayRef> std::ops::Deref for AutoElements<'array_local, T, TArrayRef>
 where
     T: TypeArray,
-    TArrayRef: AsRef<JPrimitiveArray<'array_local, T>> + JObjectRef,
+    TArrayRef: AsRef<JPrimitiveArray<'array_local, T>> + Reference,
 {
     type Target = [T];
 
@@ -171,7 +171,7 @@ where
 impl<'array_local, T, TArrayRef> std::ops::DerefMut for AutoElements<'array_local, T, TArrayRef>
 where
     T: TypeArray,
-    TArrayRef: AsRef<JPrimitiveArray<'array_local, T>> + JObjectRef,
+    TArrayRef: AsRef<JPrimitiveArray<'array_local, T>> + Reference,
 {
     fn deref_mut(&mut self) -> &mut Self::Target {
         unsafe { std::slice::from_raw_parts_mut(self.ptr.as_mut(), self.len) }

--- a/src/objects/jbytebuffer.rs
+++ b/src/objects/jbytebuffer.rs
@@ -4,7 +4,7 @@ use once_cell::sync::OnceCell;
 
 use crate::{
     errors::Result,
-    objects::{Global, JClass, JObject, JObjectRef, LoaderContext},
+    objects::{Global, JClass, JObject, LoaderContext, Reference},
     strings::JNIStr,
     sys::jobject,
     Env,
@@ -80,7 +80,7 @@ impl JByteBuffer<'_> {
 }
 
 // SAFETY: JByteBuffer is a transparent JObject wrapper with no Drop side effects
-unsafe impl JObjectRef for JByteBuffer<'_> {
+unsafe impl Reference for JByteBuffer<'_> {
     const CLASS_NAME: &'static JNIStr = JNIStr::from_cstr(c"[Ljava.nio.ByteBuffer;");
 
     type Kind<'env> = JByteBuffer<'env>;

--- a/src/objects/jclass.rs
+++ b/src/objects/jclass.rs
@@ -11,7 +11,7 @@ use crate::{
     sys::{jclass, jobject},
 };
 
-use super::JObjectRef;
+use super::Reference;
 
 /// Lifetime'd representation of a `jclass`. Just a `JObject` wrapped in a new
 /// class.
@@ -218,7 +218,7 @@ impl JClass<'_> {
 }
 
 // SAFETY: JClass is a transparent JObject wrapper with no Drop side effects
-unsafe impl JObjectRef for JClass<'_> {
+unsafe impl Reference for JClass<'_> {
     const CLASS_NAME: &'static JNIStr = JNIStr::from_cstr(c"java.lang.Class");
 
     type Kind<'env> = JClass<'env>;

--- a/src/objects/jclass_loader.rs
+++ b/src/objects/jclass_loader.rs
@@ -11,7 +11,7 @@ use crate::{
     sys::{jclass, jobject},
 };
 
-use super::JObjectRef;
+use super::Reference;
 
 /// A `java.lang.ClassLoader` reference
 #[repr(transparent)]
@@ -132,7 +132,7 @@ impl JClassLoader<'_> {
 }
 
 // SAFETY: JClassLoader is a transparent JObject wrapper with no Drop side effects
-unsafe impl JObjectRef for JClassLoader<'_> {
+unsafe impl Reference for JClassLoader<'_> {
     const CLASS_NAME: &'static JNIStr = JNIStr::from_cstr(c"java.lang.ClassLoader");
 
     type Kind<'env> = JClassLoader<'env>;

--- a/src/objects/jcollection.rs
+++ b/src/objects/jcollection.rs
@@ -11,7 +11,7 @@ use crate::{
     sys::jobject,
 };
 
-use super::JObjectRef;
+use super::Reference;
 
 #[cfg(doc)]
 use crate::errors::Error;
@@ -131,7 +131,7 @@ impl<'local> JCollection<'local> {
     ///
     /// Returns [Error::WrongObjectType] if the `IsInstanceOf` check fails.
     pub fn cast_local<'any_local>(
-        obj: impl JObjectRef + Into<JObject<'any_local>> + AsRef<JObject<'any_local>>,
+        obj: impl Reference + Into<JObject<'any_local>> + AsRef<JObject<'any_local>>,
         env: &mut Env<'_>,
     ) -> Result<JCollection<'any_local>> {
         env.cast_local::<JCollection>(obj)
@@ -274,7 +274,7 @@ impl<'local> JCollection<'local> {
 }
 
 // SAFETY: JCollection is a transparent JObject wrapper with no Drop side effects
-unsafe impl JObjectRef for JCollection<'_> {
+unsafe impl Reference for JCollection<'_> {
     const CLASS_NAME: &'static JNIStr = JNIStr::from_cstr(c"java.util.Collection");
 
     type Kind<'env> = JCollection<'env>;

--- a/src/objects/jiterator.rs
+++ b/src/objects/jiterator.rs
@@ -11,7 +11,7 @@ use crate::{
     sys::jobject,
 };
 
-use super::JObjectRef;
+use super::Reference;
 
 /// Wrapper for `java.utils.Map.Entry` references. Provides methods to get the key and value.
 #[repr(transparent)]
@@ -113,7 +113,7 @@ impl<'local> JIterator<'local> {
     ///
     /// Returns [Error::WrongObjectType] if the `IsInstanceOf` check fails.
     pub fn cast_local<'any_local>(
-        obj: impl JObjectRef + Into<JObject<'any_local>> + AsRef<JObject<'any_local>>,
+        obj: impl Reference + Into<JObject<'any_local>> + AsRef<JObject<'any_local>>,
         env: &mut Env<'_>,
     ) -> Result<JIterator<'any_local>> {
         env.cast_local::<JIterator>(obj)
@@ -194,7 +194,7 @@ impl<'local> JIterator<'local> {
 }
 
 // SAFETY: JIterator is a transparent JObject wrapper with no Drop side effects
-unsafe impl JObjectRef for JIterator<'_> {
+unsafe impl Reference for JIterator<'_> {
     const CLASS_NAME: &'static JNIStr = JNIStr::from_cstr(c"java.util.Iterator");
 
     type Kind<'env> = JIterator<'env>;

--- a/src/objects/jlist.rs
+++ b/src/objects/jlist.rs
@@ -4,8 +4,8 @@ use once_cell::sync::OnceCell;
 use crate::{
     errors::*,
     objects::{
-        Cast, Global, JClass, JCollection, JIterator, JMethodID, JObject, JObjectRef, JValue,
-        LoaderContext,
+        Cast, Global, JClass, JCollection, JIterator, JMethodID, JObject, JValue, LoaderContext,
+        Reference,
     },
     signature::{Primitive, ReturnType},
     strings::JNIStr,
@@ -125,7 +125,7 @@ impl<'local> JList<'local> {
     ///
     /// Returns [Error::WrongObjectType] if the `IsInstanceOf` check fails.
     pub fn cast_local<'any_local>(
-        obj: impl JObjectRef + Into<JObject<'any_local>> + AsRef<JObject<'any_local>>,
+        obj: impl Reference + Into<JObject<'any_local>> + AsRef<JObject<'any_local>>,
         env: &mut Env<'_>,
     ) -> Result<JList<'any_local>> {
         env.cast_local::<JList>(obj)
@@ -139,7 +139,7 @@ impl<'local> JList<'local> {
         note = "use JList::cast_local instead or Env::new_cast_local_ref/cast_local/as_cast_local or Env::new_cast_global_ref/cast_global/as_cast_global"
     )]
     pub fn from_env<'any_local>(
-        obj: impl JObjectRef + Into<JObject<'any_local>> + AsRef<JObject<'any_local>>,
+        obj: impl Reference + Into<JObject<'any_local>> + AsRef<JObject<'any_local>>,
         env: &mut Env<'_>,
     ) -> Result<JList<'any_local>> {
         env.cast_local::<JList>(obj)
@@ -321,7 +321,7 @@ impl<'local> JList<'local> {
 }
 
 // SAFETY: JList is a transparent JObject wrapper with no Drop side effects
-unsafe impl JObjectRef for JList<'_> {
+unsafe impl Reference for JList<'_> {
     const CLASS_NAME: &'static JNIStr = JNIStr::from_cstr(c"java.util.List");
 
     type Kind<'env> = JList<'env>;

--- a/src/objects/jmap.rs
+++ b/src/objects/jmap.rs
@@ -4,7 +4,7 @@ use once_cell::sync::OnceCell;
 use crate::{
     errors::*,
     objects::{
-        Global, JClass, JIterator, JMethodID, JObject, JObjectRef, JSet, JValue, LoaderContext,
+        Global, JClass, JIterator, JMethodID, JObject, JSet, JValue, LoaderContext, Reference,
     },
     signature::{Primitive, ReturnType},
     strings::JNIStr,
@@ -127,7 +127,7 @@ impl<'local> JMap<'local> {
     ///
     /// Returns [Error::WrongObjectType] if the `IsInstanceOf` check fails.
     pub fn cast_local<'any_local>(
-        obj: impl JObjectRef + Into<JObject<'any_local>> + AsRef<JObject<'any_local>>,
+        obj: impl Reference + Into<JObject<'any_local>> + AsRef<JObject<'any_local>>,
         env: &mut Env<'_>,
     ) -> Result<JMap<'any_local>> {
         env.cast_local::<JMap>(obj)
@@ -141,7 +141,7 @@ impl<'local> JMap<'local> {
         note = "use JMap::cast_local instead or Env::new_cast_local_ref/cast_local/as_cast_local or Env::new_cast_global_ref/cast_global/as_cast_global"
     )]
     pub fn from_env<'any_local>(
-        obj: impl JObjectRef + Into<JObject<'any_local>> + AsRef<JObject<'any_local>>,
+        obj: impl Reference + Into<JObject<'any_local>> + AsRef<JObject<'any_local>>,
         env: &mut Env<'_>,
     ) -> Result<JMap<'any_local>> {
         env.cast_local::<JMap>(obj)
@@ -289,7 +289,7 @@ impl<'local> JMap<'local> {
 }
 
 // SAFETY: JMap is a transparent JObject wrapper with no Drop side effects
-unsafe impl JObjectRef for JMap<'_> {
+unsafe impl Reference for JMap<'_> {
     const CLASS_NAME: &'static JNIStr = JNIStr::from_cstr(c"java.util.Map");
 
     type Kind<'env> = JMap<'env>;
@@ -421,7 +421,7 @@ impl<'local> JMapEntry<'local> {
     ///
     /// Returns [Error::WrongObjectType] if the `IsInstanceOf` check fails.
     pub fn cast_local<'any_local>(
-        obj: impl JObjectRef + Into<JObject<'any_local>> + AsRef<JObject<'any_local>>,
+        obj: impl Reference + Into<JObject<'any_local>> + AsRef<JObject<'any_local>>,
         env: &mut Env<'_>,
     ) -> Result<JMapEntry<'any_local>> {
         env.cast_local::<JMapEntry>(obj)
@@ -481,7 +481,7 @@ impl<'local> JMapEntry<'local> {
 }
 
 // SAFETY: JMapEntry is a transparent JObject wrapper with no Drop side effects
-unsafe impl JObjectRef for JMapEntry<'_> {
+unsafe impl Reference for JMapEntry<'_> {
     const CLASS_NAME: &'static JNIStr = JNIStr::from_cstr(c"java.util.Map$Entry");
 
     type Kind<'env> = JMapEntry<'env>;

--- a/src/objects/jobject.rs
+++ b/src/objects/jobject.rs
@@ -10,7 +10,7 @@ use crate::{
     Env,
 };
 
-use super::JObjectRef;
+use super::Reference;
 
 /// Wrapper around [`jni_sys::jobject`] that adds a lifetime to ensure that
 /// the underlying JNI pointer won't be accessible to safe Rust code if the
@@ -128,7 +128,7 @@ impl std::default::Default for JObject<'_> {
 }
 
 // SAFETY: JObject is a transparent jobject wrapper with no Drop side effects
-unsafe impl JObjectRef for JObject<'_> {
+unsafe impl Reference for JObject<'_> {
     const CLASS_NAME: &'static JNIStr = JNIStr::from_cstr(c"java.lang.Object");
 
     type Kind<'env> = JObject<'env>;

--- a/src/objects/jobject_array.rs
+++ b/src/objects/jobject_array.rs
@@ -5,7 +5,7 @@ use once_cell::sync::OnceCell;
 use crate::{
     env::Env,
     errors::Result,
-    objects::{Global, JClass, JObject, JObjectRef, LoaderContext},
+    objects::{Global, JClass, JObject, LoaderContext, Reference},
     strings::JNIStr,
     sys::{jobject, jobjectArray},
 };
@@ -100,7 +100,7 @@ impl JObjectArray<'_> {
 }
 
 // SAFETY: JObjectArray is a transparent JObject wrapper with no Drop side effects
-unsafe impl JObjectRef for JObjectArray<'_> {
+unsafe impl Reference for JObjectArray<'_> {
     const CLASS_NAME: &'static JNIStr = JNIStr::from_cstr(c"[Ljava.lang.Object;");
 
     type Kind<'env> = JObjectArray<'env>;

--- a/src/objects/jprimitive_array.rs
+++ b/src/objects/jprimitive_array.rs
@@ -7,7 +7,7 @@ use crate::{
     env::Env,
     errors::Result,
     objects::{
-        AutoElements, AutoElementsCritical, Global, JClass, JObject, JObjectRef, LoaderContext,
+        AutoElements, AutoElementsCritical, Global, JClass, JObject, LoaderContext, Reference,
         ReleaseMode,
     },
     strings::JNIStr,
@@ -362,7 +362,7 @@ macro_rules! impl_ref_for_jprimitive_array {
             }
 
             // SAFETY: JPrimitiveArray is a transparent JObject wrapper with no Drop side effects
-            unsafe impl JObjectRef for JPrimitiveArray<'_, crate::sys::$type> {
+            unsafe impl Reference for JPrimitiveArray<'_, crate::sys::$type> {
                 const CLASS_NAME: &'static JNIStr = JNIStr::from_cstr($class_name);
 
                 type Kind<'env> = JPrimitiveArray<'env, crate::sys::$type>;

--- a/src/objects/jset.rs
+++ b/src/objects/jset.rs
@@ -10,7 +10,7 @@ use crate::{
     sys::jobject,
 };
 
-use super::JObjectRef;
+use super::Reference;
 
 #[cfg(doc)]
 use crate::errors::Error;
@@ -110,7 +110,7 @@ impl<'local> JSet<'local> {
     ///
     /// Returns [Error::WrongObjectType] if the `IsInstanceOf` check fails.
     pub fn cast_local<'any_local>(
-        obj: impl JObjectRef + Into<JObject<'any_local>> + AsRef<JObject<'any_local>>,
+        obj: impl Reference + Into<JObject<'any_local>> + AsRef<JObject<'any_local>>,
         env: &mut Env<'_>,
     ) -> Result<JSet<'any_local>> {
         env.cast_local::<JSet>(obj)
@@ -197,7 +197,7 @@ impl<'local> JSet<'local> {
 }
 
 // SAFETY: JSet is a transparent JObject wrapper with no Drop side effects
-unsafe impl JObjectRef for JSet<'_> {
+unsafe impl Reference for JSet<'_> {
     const CLASS_NAME: &'static JNIStr = JNIStr::from_cstr(c"java.util.Set");
 
     type Kind<'env> = JSet<'env>;

--- a/src/objects/jstring.rs
+++ b/src/objects/jstring.rs
@@ -11,7 +11,7 @@ use crate::{
     Env, JavaVM,
 };
 
-use super::JObjectRef;
+use super::Reference;
 
 #[cfg(doc)]
 use crate::errors::Error;
@@ -267,7 +267,7 @@ impl JString<'_> {
 }
 
 // SAFETY: JString is a transparent JObject wrapper with no Drop side effects
-unsafe impl JObjectRef for JString<'_> {
+unsafe impl Reference for JString<'_> {
     const CLASS_NAME: &'static JNIStr = JNIStr::from_cstr(c"java.lang.String");
 
     type Kind<'env> = JString<'env>;

--- a/src/objects/jthread.rs
+++ b/src/objects/jthread.rs
@@ -12,7 +12,7 @@ use crate::{
     sys::{jobject, jthrowable},
 };
 
-use super::JObjectRef;
+use super::Reference;
 
 /// Lifetime'd representation of a `jthrowable`. Just a `JObject` wrapped in a
 /// new class.
@@ -189,7 +189,7 @@ impl JThread<'_> {
 }
 
 // SAFETY: JThread is a transparent JObject wrapper with no Drop side effects
-unsafe impl JObjectRef for JThread<'_> {
+unsafe impl Reference for JThread<'_> {
     const CLASS_NAME: &'static JNIStr = JNIStr::from_cstr(c"java.lang.Thread");
 
     type Kind<'env> = JThread<'env>;

--- a/src/objects/jthrowable.rs
+++ b/src/objects/jthrowable.rs
@@ -10,7 +10,7 @@ use crate::{
     sys::{jobject, jthrowable},
 };
 
-use super::JObjectRef;
+use super::Reference;
 
 /// Lifetime'd representation of a `jthrowable`. Just a `JObject` wrapped in a
 /// new class.
@@ -136,7 +136,7 @@ impl JThrowable<'_> {
 }
 
 // SAFETY: JThrowable is a transparent JObject wrapper with no Drop side effects
-unsafe impl JObjectRef for JThrowable<'_> {
+unsafe impl Reference for JThrowable<'_> {
     const CLASS_NAME: &'static JNIStr = JNIStr::from_cstr(c"java.lang.Throwable");
 
     type Kind<'env> = JThrowable<'env>;

--- a/src/refs/auto.rs
+++ b/src/refs/auto.rs
@@ -9,7 +9,7 @@ use crate::{
     Env, JavaVM,
 };
 
-use super::JObjectRef;
+use super::Reference;
 
 /// A wrapper to `Auto` delete local references early (before the JNI stack
 /// frame unwinds).
@@ -268,9 +268,9 @@ where
 
 // SAFETY: Kind and GlobalKind are implicitly transparent wrappers if T is
 // implemented correctly / safely.
-unsafe impl<'local, T> JObjectRef for Auto<'local, T>
+unsafe impl<'local, T> Reference for Auto<'local, T>
 where
-    T: JObjectRef + Into<JObject<'local>>,
+    T: Reference + Into<JObject<'local>>,
 {
     const CLASS_NAME: &'static JNIStr = T::CLASS_NAME;
 

--- a/src/refs/global.rs
+++ b/src/refs/global.rs
@@ -14,7 +14,7 @@ use crate::{
 #[cfg(doc)]
 use crate::objects::Weak;
 
-use super::JObjectRef;
+use super::Reference;
 
 // Note: `Global` must not implement `Into<JObject>`! If it did, then it would be possible to
 // wrap it in `Auto`, which would cause undefined behavior upon drop as a result of calling
@@ -90,7 +90,7 @@ where
     T: Into<JObject<'static>>
         + AsRef<JObject<'static>>
         + Default
-        + JObjectRef
+        + Reference
         + Send
         + Sync
         + 'static,
@@ -109,7 +109,7 @@ unsafe impl<T> Send for Global<T> where
     T: Into<JObject<'static>>
         + AsRef<JObject<'static>>
         + Default
-        + JObjectRef
+        + Reference
         + Send
         + Sync
         + 'static
@@ -120,7 +120,7 @@ unsafe impl<T> Sync for Global<T> where
     T: Into<JObject<'static>>
         + AsRef<JObject<'static>>
         + Default
-        + JObjectRef
+        + Reference
         + Send
         + Sync
         + 'static
@@ -132,7 +132,7 @@ where
     T: Into<JObject<'static>>
         + AsRef<JObject<'static>>
         + Default
-        + JObjectRef
+        + Reference
         + Send
         + Sync
         + 'static,
@@ -148,7 +148,7 @@ where
         + Into<JObject<'static>>
         + AsRef<JObject<'static>>
         + Default
-        + JObjectRef
+        + Reference
         + Send
         + Sync,
 {
@@ -162,7 +162,7 @@ where
     T: Into<JObject<'static>>
         + AsRef<JObject<'static>>
         + Default
-        + JObjectRef
+        + Reference
         + Send
         + Sync
         + 'static,
@@ -179,7 +179,7 @@ where
     T: Into<JObject<'static>>
         + AsRef<JObject<'static>>
         + Default
-        + JObjectRef
+        + Reference
         + Send
         + Sync
         + 'static,
@@ -266,7 +266,7 @@ where
     T: Into<JObject<'static>>
         + AsRef<JObject<'static>>
         + Default
-        + JObjectRef
+        + Reference
         + Send
         + Sync
         + 'static,
@@ -304,9 +304,9 @@ where
 
 // SAFETY: Kind and GlobalKind are implicitly transparent wrappers if T is
 // implemented correctly / safely.
-unsafe impl<T> JObjectRef for Global<T>
+unsafe impl<T> Reference for Global<T>
 where
-    T: Into<JObject<'static>> + AsRef<JObject<'static>> + Default + JObjectRef + Send + Sync,
+    T: Into<JObject<'static>> + AsRef<JObject<'static>> + Default + Reference + Send + Sync,
 {
     const CLASS_NAME: &'static JNIStr = T::CLASS_NAME;
 

--- a/src/refs/mod.rs
+++ b/src/refs/mod.rs
@@ -1,8 +1,8 @@
 mod cast;
 pub use cast::*;
 
-mod jobject_ref;
-pub use jobject_ref::*;
+mod reference;
+pub use reference::*;
 
 // For storing a reference to a java object
 mod global;

--- a/src/refs/reference.rs
+++ b/src/refs/reference.rs
@@ -26,7 +26,7 @@ use crate::objects::{Auto, JString};
 /// The associated `Kind` and `GlobalKind` types must be transparent wrappers
 /// around the underlying JNI object reference types (such as `JObject` or
 /// `jobject`) and must not have any `Drop` side effects.
-pub unsafe trait JObjectRef: Sized {
+pub unsafe trait Reference: Sized {
     /// The fully qualified class name of the Java class represented by this
     /// reference.
     ///
@@ -51,7 +51,7 @@ pub unsafe trait JObjectRef: Sized {
     ///
     /// This must be a transparent `JObject` or `jobject` wrapper type that
     /// has no `Drop` side effects.
-    type Kind<'local>: JObjectRef + Default + Into<JObject<'local>> + AsRef<JObject<'local>>;
+    type Kind<'local>: Reference + Default + Into<JObject<'local>> + AsRef<JObject<'local>>;
     // XXX: the compiler blows up if we try and specify a Send + Sync bound
     // here: "overflow evaluating the requirement..."
     //where
@@ -67,7 +67,7 @@ pub unsafe trait JObjectRef: Sized {
     ///
     /// This must be a transparent `JObject` or `jobject` wrapper type that
     /// has no `Drop` side effects.
-    type GlobalKind: JObjectRef
+    type GlobalKind: Reference
         + Default
         + Into<JObject<'static>>
         + AsRef<JObject<'static>>
@@ -347,7 +347,7 @@ impl<'a, 'any_local> LoaderContext<'a, 'any_local> {
     /// class could not be found.
     ///
     /// The strategy for loading the class depends on the loader context (See [Self]).
-    pub fn load_class_for_type<'env_local, T: JObjectRef>(
+    pub fn load_class_for_type<'env_local, T: Reference>(
         &self,
         initialize: bool,
         env: &mut crate::env::Env<'env_local>,
@@ -358,9 +358,9 @@ impl<'a, 'any_local> LoaderContext<'a, 'any_local> {
 
 // SAFETY: Kind and GlobalKind are implicitly transparent wrappers if T is
 // implemented correctly / safely.
-unsafe impl<T> JObjectRef for &T
+unsafe impl<T> Reference for &T
 where
-    T: JObjectRef,
+    T: Reference,
 {
     const CLASS_NAME: &'static JNIStr = T::CLASS_NAME;
 

--- a/src/refs/weak.rs
+++ b/src/refs/weak.rs
@@ -11,7 +11,7 @@ use crate::{
     sys, JavaVM,
 };
 
-use super::JObjectRef;
+use super::Reference;
 
 // Note: `Weak` must not implement `Into<JObject>`! If it did, then it would be possible to
 // wrap it in `Auto`, which would cause undefined behavior upon drop as a result of calling
@@ -72,7 +72,7 @@ use super::JObjectRef;
 #[derive(Debug)]
 pub struct Weak<T>
 where
-    T: Into<JObject<'static>> + AsRef<JObject<'static>> + Default + JObjectRef + Send + Sync,
+    T: Into<JObject<'static>> + AsRef<JObject<'static>> + Default + Reference + Send + Sync,
 {
     obj: T,
 }
@@ -85,18 +85,18 @@ where
 pub type WeakRef<T> = Weak<T>;
 
 unsafe impl<T> Send for Weak<T> where
-    T: Into<JObject<'static>> + AsRef<JObject<'static>> + Default + JObjectRef + Send + Sync
+    T: Into<JObject<'static>> + AsRef<JObject<'static>> + Default + Reference + Send + Sync
 {
 }
 
 unsafe impl<T> Sync for Weak<T> where
-    T: Into<JObject<'static>> + AsRef<JObject<'static>> + Default + JObjectRef + Send + Sync
+    T: Into<JObject<'static>> + AsRef<JObject<'static>> + Default + Reference + Send + Sync
 {
 }
 
 impl<T> Default for Weak<T>
 where
-    T: Into<JObject<'static>> + AsRef<JObject<'static>> + Default + JObjectRef + Send + Sync,
+    T: Into<JObject<'static>> + AsRef<JObject<'static>> + Default + Reference + Send + Sync,
 {
     fn default() -> Self {
         Self::null()
@@ -109,7 +109,7 @@ where
         + Into<JObject<'static>>
         + AsRef<JObject<'static>>
         + Default
-        + JObjectRef
+        + Reference
         + Send
         + Sync,
 {
@@ -120,7 +120,7 @@ where
 
 impl<T> Deref for Weak<T>
 where
-    T: Into<JObject<'static>> + AsRef<JObject<'static>> + Default + JObjectRef + Send + Sync,
+    T: Into<JObject<'static>> + AsRef<JObject<'static>> + Default + Reference + Send + Sync,
 {
     type Target = T;
 
@@ -131,7 +131,7 @@ where
 
 impl<T> Weak<T>
 where
-    T: Into<JObject<'static>> + AsRef<JObject<'static>> + Default + JObjectRef + Send + Sync,
+    T: Into<JObject<'static>> + AsRef<JObject<'static>> + Default + Reference + Send + Sync,
 {
     /// Creates a new auto-delete wrapper for the `'static` weak global reference
     ///
@@ -244,7 +244,7 @@ where
 
 impl<T> Drop for Weak<T>
 where
-    T: Into<JObject<'static>> + AsRef<JObject<'static>> + Default + JObjectRef + Send + Sync,
+    T: Into<JObject<'static>> + AsRef<JObject<'static>> + Default + Reference + Send + Sync,
 {
     fn drop(&mut self) {
         let obj = std::mem::take(&mut self.obj);
@@ -280,9 +280,9 @@ where
 
 // SAFETY: Kind and GlobalKind are implicitly transparent wrappers if T is
 // implemented correctly / safely.
-unsafe impl<T> JObjectRef for Weak<T>
+unsafe impl<T> Reference for Weak<T>
 where
-    T: Into<JObject<'static>> + AsRef<JObject<'static>> + Default + JObjectRef + Send + Sync,
+    T: Into<JObject<'static>> + AsRef<JObject<'static>> + Default + Reference + Send + Sync,
 {
     const CLASS_NAME: &'static JNIStr = T::CLASS_NAME;
 

--- a/src/strings/mutf8_chars.rs
+++ b/src/strings/mutf8_chars.rs
@@ -5,7 +5,7 @@ use log::warn;
 
 use crate::{
     errors::*,
-    objects::{JObjectRef, JString},
+    objects::{JString, Reference},
     strings::{JNIStr, JNIString},
     Env, JavaVM,
 };
@@ -57,7 +57,7 @@ use ::{
 /// [modified UTF-8]: https://en.wikipedia.org/wiki/UTF-8#Modified_UTF-8
 pub struct MUTF8Chars<'local, StringRef>
 where
-    StringRef: AsRef<JString<'local>> + JObjectRef,
+    StringRef: AsRef<JString<'local>> + Reference,
 {
     obj: StringRef,
     chars: *const c_char,
@@ -67,7 +67,7 @@ where
 
 impl<'local, StringRef> std::fmt::Debug for MUTF8Chars<'local, StringRef>
 where
-    StringRef: AsRef<JString<'local>> + JObjectRef,
+    StringRef: AsRef<JString<'local>> + Reference,
 {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("MUTF8Chars")
@@ -85,7 +85,7 @@ pub type JavaStr<'local, StringRef> = MUTF8Chars<'local, StringRef>;
 
 impl<'local, StringRef> MUTF8Chars<'local, StringRef>
 where
-    StringRef: AsRef<JString<'local>> + JObjectRef,
+    StringRef: AsRef<JString<'local>> + Reference,
 {
     /// Constructs a [`MUTF8Chars`] from a `Env` and a `JString`.
     ///
@@ -207,7 +207,7 @@ where
 
 impl<'local, StringRef> std::fmt::Display for MUTF8Chars<'local, StringRef>
 where
-    StringRef: AsRef<JString<'local>> + JObjectRef,
+    StringRef: AsRef<JString<'local>> + Reference,
 {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let jni_str: &JNIStr = self;
@@ -217,7 +217,7 @@ where
 
 impl<'local, StringRef> ::std::ops::Deref for MUTF8Chars<'local, StringRef>
 where
-    StringRef: AsRef<JString<'local>> + JObjectRef,
+    StringRef: AsRef<JString<'local>> + Reference,
 {
     type Target = JNIStr;
     fn deref(&self) -> &Self::Target {
@@ -228,7 +228,7 @@ where
 impl<'local, 'java_str, StringRef> From<&'java_str MUTF8Chars<'local, StringRef>>
     for &'java_str JNIStr
 where
-    StringRef: AsRef<JString<'local>> + JObjectRef,
+    StringRef: AsRef<JString<'local>> + Reference,
 {
     fn from(other: &'java_str MUTF8Chars<'local, StringRef>) -> &'java_str JNIStr {
         unsafe { JNIStr::from_ptr(other.chars) }
@@ -237,7 +237,7 @@ where
 
 impl<'local, StringRef> From<MUTF8Chars<'local, StringRef>> for JNIString
 where
-    StringRef: AsRef<JString<'local>> + JObjectRef,
+    StringRef: AsRef<JString<'local>> + Reference,
 {
     fn from(other: MUTF8Chars<'local, StringRef>) -> JNIString {
         let jni_str: &JNIStr = &other;
@@ -248,7 +248,7 @@ where
 impl<'local, 'java_str, StringRef> From<&'java_str MUTF8Chars<'local, StringRef>>
     for Cow<'java_str, str>
 where
-    StringRef: AsRef<JString<'local>> + JObjectRef,
+    StringRef: AsRef<JString<'local>> + Reference,
 {
     fn from(other: &'java_str MUTF8Chars<'local, StringRef>) -> Cow<'java_str, str> {
         let jni_str: &JNIStr = other;
@@ -258,7 +258,7 @@ where
 
 impl<'local, StringRef> From<MUTF8Chars<'local, StringRef>> for String
 where
-    StringRef: AsRef<JString<'local>> + JObjectRef,
+    StringRef: AsRef<JString<'local>> + Reference,
 {
     fn from(other: MUTF8Chars<'local, StringRef>) -> String {
         let cow: Cow<str> = (&other).into();
@@ -268,7 +268,7 @@ where
 
 impl<'local, StringRef> Drop for MUTF8Chars<'local, StringRef>
 where
-    StringRef: AsRef<JString<'local>> + JObjectRef,
+    StringRef: AsRef<JString<'local>> + Reference,
 {
     fn drop(&mut self) {
         unsafe fn release_string_utf_chars(
@@ -294,7 +294,7 @@ where
 
 impl<'local, StringRef> AsRef<JNIStr> for MUTF8Chars<'local, StringRef>
 where
-    StringRef: AsRef<JString<'local>> + JObjectRef,
+    StringRef: AsRef<JString<'local>> + Reference,
 {
     fn as_ref(&self) -> &JNIStr {
         self

--- a/src/vm/java_vm.rs
+++ b/src/vm/java_vm.rs
@@ -11,7 +11,7 @@ use log::{debug, error};
 use crate::{
     env::Env,
     errors::*,
-    objects::{Global, JObject, JObjectRef},
+    objects::{Global, JObject, Reference},
     strings::JNIString,
     sys, JNIVersion,
 };
@@ -1332,7 +1332,7 @@ impl AttachGuard {
         F: for<'new_local> FnOnce(
             &mut Env<'new_local>,
         ) -> std::result::Result<T::Kind<'new_local>, E>,
-        T: JObjectRef,
+        T: Reference,
         E: From<Error>,
     {
         // Assuming that the application doesn't break the safety rules for

--- a/tests/jni_api.rs
+++ b/tests/jni_api.rs
@@ -7,8 +7,8 @@ use jni::{
     descriptors::Desc,
     errors::{CharToJavaError, Error},
     objects::{
-        AutoElements, IntoAuto as _, JByteBuffer, JList, JObject, JObjectRef as _, JString,
-        JThrowable, JValue, ReleaseMode, Weak,
+        AutoElements, IntoAuto as _, JByteBuffer, JList, JObject, JString, JThrowable, JValue,
+        Reference as _, ReleaseMode, Weak,
     },
     signature::{JavaType, Primitive, ReturnType},
     strings::{JNIStr, JNIString},


### PR DESCRIPTION
This trait was only very recently added in #596 so it's not a breaking change.

Considering that `GlobalRef` and `WeakRef` were recently renamed `Global` and `Weak`, I think it also makes sense to avoid a "Ref" suffix here that could suggest it represents a temporary borrow from something (it doesn't).
