### PR TITLE
Reference::lookup_class: Don't tie return value to `&Env` lifetime

### DIFF
--- a/src/objects/jbytebuffer.rs
+++ b/src/objects/jbytebuffer.rs
@@ -90,10 +90,10 @@ unsafe impl Reference for JByteBuffer<'_> {
         self.0.as_raw()
     }
 
-    fn lookup_class<'env>(
-        env: &'env Env<'_>,
+    fn lookup_class<'caller>(
+        env: &Env<'_>,
         loader_context: LoaderContext,
-    ) -> crate::errors::Result<impl Deref<Target = Global<JClass<'static>>> + 'env> {
+    ) -> crate::errors::Result<impl Deref<Target = Global<JClass<'static>>> + 'caller> {
         let api = JByteBufferAPI::get(env, &loader_context)?;
         Ok(&api.class)
     }

--- a/src/objects/jclass.rs
+++ b/src/objects/jclass.rs
@@ -228,10 +228,10 @@ unsafe impl Reference for JClass<'_> {
         self.0.as_raw()
     }
 
-    fn lookup_class<'env>(
-        env: &'env Env<'_>,
+    fn lookup_class<'caller>(
+        env: &Env<'_>,
         _loader_context: LoaderContext,
-    ) -> crate::errors::Result<impl Deref<Target = Global<JClass<'static>>> + 'env> {
+    ) -> crate::errors::Result<impl Deref<Target = Global<JClass<'static>>> + 'caller> {
         // As a special-case; we ignore loader_context just to be clear that there's no risk of
         // recursion. (`LoaderContext::load_class` depends on the `JClassAPI`)
         let api = JClassAPI::get(env)?;

--- a/src/objects/jclass_loader.rs
+++ b/src/objects/jclass_loader.rs
@@ -142,10 +142,10 @@ unsafe impl Reference for JClassLoader<'_> {
         self.0.as_raw()
     }
 
-    fn lookup_class<'env>(
-        env: &'env Env<'_>,
+    fn lookup_class<'caller>(
+        env: &Env<'_>,
         _loader_context: LoaderContext,
-    ) -> crate::errors::Result<impl Deref<Target = Global<JClass<'static>>> + 'env> {
+    ) -> crate::errors::Result<impl Deref<Target = Global<JClass<'static>>> + 'caller> {
         // As a special-case; we ignore loader_context just to be clear that there's no risk of
         // recursion. (`LoaderContext::load_class` depends on the `JClassLoaderAPI`)
         let api = JClassLoaderAPI::get(env)?;

--- a/src/objects/jcollection.rs
+++ b/src/objects/jcollection.rs
@@ -284,10 +284,10 @@ unsafe impl Reference for JCollection<'_> {
         self.0.as_raw()
     }
 
-    fn lookup_class<'env>(
-        env: &'env Env<'_>,
+    fn lookup_class<'caller>(
+        env: &Env<'_>,
         loader_context: LoaderContext,
-    ) -> crate::errors::Result<impl Deref<Target = Global<JClass<'static>>> + 'env> {
+    ) -> crate::errors::Result<impl Deref<Target = Global<JClass<'static>>> + 'caller> {
         let api = JCollectionAPI::get(env, &loader_context)?;
         Ok(&api.class)
     }

--- a/src/objects/jiterator.rs
+++ b/src/objects/jiterator.rs
@@ -204,10 +204,10 @@ unsafe impl Reference for JIterator<'_> {
         self.0.as_raw()
     }
 
-    fn lookup_class<'env>(
-        env: &'env Env<'_>,
+    fn lookup_class<'caller>(
+        env: &Env<'_>,
         loader_context: LoaderContext,
-    ) -> crate::errors::Result<impl Deref<Target = Global<JClass<'static>>> + 'env> {
+    ) -> crate::errors::Result<impl Deref<Target = Global<JClass<'static>>> + 'caller> {
         let api = JIteratorAPI::get(env, &loader_context)?;
         Ok(&api.class)
     }

--- a/src/objects/jlist.rs
+++ b/src/objects/jlist.rs
@@ -331,10 +331,10 @@ unsafe impl Reference for JList<'_> {
         self.0.as_raw()
     }
 
-    fn lookup_class<'env>(
-        env: &'env Env<'_>,
+    fn lookup_class<'caller>(
+        env: &Env<'_>,
         loader_context: LoaderContext,
-    ) -> crate::errors::Result<impl Deref<Target = Global<JClass<'static>>> + 'env> {
+    ) -> crate::errors::Result<impl Deref<Target = Global<JClass<'static>>> + 'caller> {
         let api = JListAPI::get(env, &loader_context)?;
         Ok(&api.class)
     }

--- a/src/objects/jmap.rs
+++ b/src/objects/jmap.rs
@@ -299,10 +299,10 @@ unsafe impl Reference for JMap<'_> {
         self.0.as_raw()
     }
 
-    fn lookup_class<'env>(
-        env: &'env Env<'_>,
+    fn lookup_class<'caller>(
+        env: &Env<'_>,
         loader_context: LoaderContext,
-    ) -> crate::errors::Result<impl Deref<Target = Global<JClass<'static>>> + 'env> {
+    ) -> crate::errors::Result<impl Deref<Target = Global<JClass<'static>>> + 'caller> {
         let api = JMapAPI::get(env, &loader_context)?;
         Ok(&api.class)
     }
@@ -491,10 +491,10 @@ unsafe impl Reference for JMapEntry<'_> {
         self.0.as_raw()
     }
 
-    fn lookup_class<'env>(
-        env: &'env Env<'_>,
+    fn lookup_class<'caller>(
+        env: &Env<'_>,
         loader_context: LoaderContext,
-    ) -> crate::errors::Result<impl Deref<Target = Global<JClass<'static>>> + 'env> {
+    ) -> crate::errors::Result<impl Deref<Target = Global<JClass<'static>>> + 'caller> {
         let api = JMapEntryAPI::get(env, &loader_context)?;
         Ok(&api.class)
     }

--- a/src/objects/jobject.rs
+++ b/src/objects/jobject.rs
@@ -138,10 +138,10 @@ unsafe impl Reference for JObject<'_> {
         self.as_raw()
     }
 
-    fn lookup_class<'env>(
-        env: &'env Env<'_>,
+    fn lookup_class<'caller>(
+        env: &Env<'_>,
         _loader_context: LoaderContext,
-    ) -> crate::errors::Result<impl Deref<Target = Global<JClass<'static>>> + 'env> {
+    ) -> crate::errors::Result<impl Deref<Target = Global<JClass<'static>>> + 'caller> {
         // As a special-case; we ignore loader_context just to be clear that there's no risk of
         // recursion. (`LoaderContext::load_class` depends on the `JObjectAPI`)
         let api = JObjectAPI::get(env)?;

--- a/src/objects/jobject_array.rs
+++ b/src/objects/jobject_array.rs
@@ -110,10 +110,10 @@ unsafe impl Reference for JObjectArray<'_> {
         self.0.as_raw()
     }
 
-    fn lookup_class<'env>(
-        env: &'env Env<'_>,
+    fn lookup_class<'caller>(
+        env: &Env<'_>,
         loader_context: LoaderContext,
-    ) -> crate::errors::Result<impl Deref<Target = Global<JClass<'static>>> + 'env> {
+    ) -> crate::errors::Result<impl Deref<Target = Global<JClass<'static>>> + 'caller> {
         let api = JObjectArrayAPI::get(env, &loader_context)?;
         Ok(&api.class)
     }

--- a/src/objects/jprimitive_array.rs
+++ b/src/objects/jprimitive_array.rs
@@ -372,10 +372,10 @@ macro_rules! impl_ref_for_jprimitive_array {
                     self.obj.as_raw()
                 }
 
-                fn lookup_class<'env>(
-                    env: &'env Env<'_>,
+                fn lookup_class<'caller>(
+                    env: &Env<'_>,
                     loader_context: LoaderContext,
-                ) -> crate::errors::Result<impl Deref<Target = Global<JClass<'static>>> + 'env> {
+                ) -> crate::errors::Result<impl Deref<Target = Global<JClass<'static>>> + 'caller> {
                     let api = [<JPrimitiveArrayAPI _ $type>]::get(env, &loader_context)?;
                     Ok(&api.class)
                 }

--- a/src/objects/jset.rs
+++ b/src/objects/jset.rs
@@ -207,10 +207,10 @@ unsafe impl Reference for JSet<'_> {
         self.0.as_raw()
     }
 
-    fn lookup_class<'env>(
-        env: &'env Env<'_>,
+    fn lookup_class<'caller>(
+        env: &Env<'_>,
         loader_context: LoaderContext,
-    ) -> crate::errors::Result<impl Deref<Target = Global<JClass<'static>>> + 'env> {
+    ) -> crate::errors::Result<impl Deref<Target = Global<JClass<'static>>> + 'caller> {
         let api = JSetAPI::get(env, &loader_context)?;
         Ok(&api.class)
     }

--- a/src/objects/jstring.rs
+++ b/src/objects/jstring.rs
@@ -277,10 +277,10 @@ unsafe impl Reference for JString<'_> {
         self.0.as_raw()
     }
 
-    fn lookup_class<'env>(
-        env: &'env Env<'_>,
+    fn lookup_class<'caller>(
+        env: &Env<'_>,
         loader_context: LoaderContext,
-    ) -> crate::errors::Result<impl Deref<Target = Global<JClass<'static>>> + 'env> {
+    ) -> crate::errors::Result<impl Deref<Target = Global<JClass<'static>>> + 'caller> {
         let api = JStringAPI::get(env, &loader_context)?;
         Ok(&api.class)
     }

--- a/src/objects/jthread.rs
+++ b/src/objects/jthread.rs
@@ -199,10 +199,10 @@ unsafe impl Reference for JThread<'_> {
         self.0.as_raw()
     }
 
-    fn lookup_class<'env>(
-        env: &'env Env<'_>,
+    fn lookup_class<'caller>(
+        env: &Env<'_>,
         _loader_context: LoaderContext,
-    ) -> crate::errors::Result<impl Deref<Target = Global<JClass<'static>>> + 'env> {
+    ) -> crate::errors::Result<impl Deref<Target = Global<JClass<'static>>> + 'caller> {
         // As a special-case; we ignore loader_context just to be clear that there's no risk of
         // recursion. (`LoaderContext::load_class` depends on the `JThreadAPI`)
         let api = JThreadAPI::get(env)?;

--- a/src/objects/jthrowable.rs
+++ b/src/objects/jthrowable.rs
@@ -146,10 +146,10 @@ unsafe impl Reference for JThrowable<'_> {
         self.0.as_raw()
     }
 
-    fn lookup_class<'env>(
-        env: &'env Env<'_>,
+    fn lookup_class<'caller>(
+        env: &Env<'_>,
         loader_context: LoaderContext,
-    ) -> crate::errors::Result<impl Deref<Target = Global<JClass<'static>>> + 'env> {
+    ) -> crate::errors::Result<impl Deref<Target = Global<JClass<'static>>> + 'caller> {
         let api = JThrowableAPI::get(env, &loader_context)?;
         Ok(&api.class)
     }

--- a/src/refs/auto.rs
+++ b/src/refs/auto.rs
@@ -281,10 +281,10 @@ where
         self.obj.as_raw()
     }
 
-    fn lookup_class<'env>(
-        env: &'env Env<'_>,
+    fn lookup_class<'caller>(
+        env: &Env<'_>,
         loader_context: LoaderContext,
-    ) -> crate::errors::Result<impl Deref<Target = Global<JClass<'static>>> + 'env> {
+    ) -> crate::errors::Result<impl Deref<Target = Global<JClass<'static>>> + 'caller> {
         T::lookup_class(env, loader_context)
     }
 

--- a/src/refs/cast.rs
+++ b/src/refs/cast.rs
@@ -126,10 +126,10 @@ unsafe impl<'any, 'from, To: Reference> Reference for Cast<'any, 'from, To> {
         self.to.as_raw()
     }
 
-    fn lookup_class<'env>(
-        env: &'env Env<'_>,
+    fn lookup_class<'caller>(
+        env: &Env<'_>,
         loader_context: LoaderContext,
-    ) -> crate::errors::Result<impl Deref<Target = Global<JClass<'static>>> + 'env> {
+    ) -> crate::errors::Result<impl Deref<Target = Global<JClass<'static>>> + 'caller> {
         To::lookup_class(env, loader_context)
     }
 

--- a/src/refs/global.rs
+++ b/src/refs/global.rs
@@ -317,10 +317,10 @@ where
         self.obj.as_raw()
     }
 
-    fn lookup_class<'env>(
-        env: &'env Env<'_>,
+    fn lookup_class<'caller>(
+        env: &Env<'_>,
         loader_context: LoaderContext,
-    ) -> crate::errors::Result<impl Deref<Target = Global<JClass<'static>>> + 'env> {
+    ) -> crate::errors::Result<impl Deref<Target = Global<JClass<'static>>> + 'caller> {
         T::lookup_class(env, loader_context)
     }
 

--- a/src/refs/reference.rs
+++ b/src/refs/reference.rs
@@ -99,10 +99,10 @@ pub unsafe trait Reference: Sized {
     /// In case no class reference is already cached then use [`LoaderContext::load_class`] to
     /// lookup a class reference.
     ///
-    fn lookup_class<'env>(
-        env: &'env Env<'_>,
+    fn lookup_class<'caller>(
+        env: &Env<'_>,
         loader_context: LoaderContext,
-    ) -> crate::errors::Result<impl Deref<Target = Global<JClass<'static>>> + 'env>;
+    ) -> crate::errors::Result<impl Deref<Target = Global<JClass<'static>>> + 'caller>;
 
     /// Returns a new reference type based on [`Self::Kind`] for the given `reference` that is tied
     /// to the specified lifetime.
@@ -371,10 +371,10 @@ where
         (*self).as_raw()
     }
 
-    fn lookup_class<'env>(
-        env: &'env Env<'_>,
+    fn lookup_class<'caller>(
+        env: &Env<'_>,
         loader_context: LoaderContext,
-    ) -> crate::errors::Result<impl Deref<Target = Global<JClass<'static>>> + 'env> {
+    ) -> crate::errors::Result<impl Deref<Target = Global<JClass<'static>>> + 'caller> {
         T::lookup_class(env, loader_context)
     }
 

--- a/src/refs/weak.rs
+++ b/src/refs/weak.rs
@@ -293,10 +293,10 @@ where
         self.obj.as_raw()
     }
 
-    fn lookup_class<'env>(
-        env: &'env Env<'_>,
+    fn lookup_class<'caller>(
+        env: &Env<'_>,
         loader_context: LoaderContext,
-    ) -> crate::errors::Result<impl Deref<Target = Global<JClass<'static>>> + 'env> {
+    ) -> crate::errors::Result<impl Deref<Target = Global<JClass<'static>>> + 'caller> {
         T::lookup_class(env, loader_context)
     }
 


### PR DESCRIPTION
This makes it possible to use `Reference::lookup_class` before e.g. calling `Desc::lookup` (which requires a mutable `Env` reference).

Fixes: #648
