### PR TITLE
Replace `Reference::CLASS_NAME` with `class_name() -> Cow<'static, JNIStr` method

### DIFF
--- a/src/objects/jbytebuffer.rs
+++ b/src/objects/jbytebuffer.rs
@@ -1,4 +1,4 @@
-use std::ops::Deref;
+use std::{borrow::Cow, ops::Deref};
 
 use once_cell::sync::OnceCell;
 
@@ -81,13 +81,15 @@ impl JByteBuffer<'_> {
 
 // SAFETY: JByteBuffer is a transparent JObject wrapper with no Drop side effects
 unsafe impl Reference for JByteBuffer<'_> {
-    const CLASS_NAME: &'static JNIStr = JNIStr::from_cstr(c"[Ljava.nio.ByteBuffer;");
-
     type Kind<'env> = JByteBuffer<'env>;
     type GlobalKind = JByteBuffer<'static>;
 
     fn as_raw(&self) -> jobject {
         self.0.as_raw()
+    }
+
+    fn class_name() -> Cow<'static, JNIStr> {
+        Cow::Borrowed(JNIStr::from_cstr(c"[Ljava.nio.ByteBuffer;"))
     }
 
     fn lookup_class<'caller>(

--- a/src/objects/jclass.rs
+++ b/src/objects/jclass.rs
@@ -1,4 +1,4 @@
-use std::ops::Deref;
+use std::{borrow::Cow, ops::Deref};
 
 use once_cell::sync::OnceCell;
 
@@ -219,13 +219,15 @@ impl JClass<'_> {
 
 // SAFETY: JClass is a transparent JObject wrapper with no Drop side effects
 unsafe impl Reference for JClass<'_> {
-    const CLASS_NAME: &'static JNIStr = JNIStr::from_cstr(c"java.lang.Class");
-
     type Kind<'env> = JClass<'env>;
     type GlobalKind = JClass<'static>;
 
     fn as_raw(&self) -> jobject {
         self.0.as_raw()
+    }
+
+    fn class_name() -> Cow<'static, JNIStr> {
+        Cow::Borrowed(JNIStr::from_cstr(c"java.lang.Class"))
     }
 
     fn lookup_class<'caller>(

--- a/src/objects/jclass_loader.rs
+++ b/src/objects/jclass_loader.rs
@@ -1,4 +1,4 @@
-use std::ops::Deref;
+use std::{borrow::Cow, ops::Deref};
 
 use once_cell::sync::OnceCell;
 
@@ -133,13 +133,15 @@ impl JClassLoader<'_> {
 
 // SAFETY: JClassLoader is a transparent JObject wrapper with no Drop side effects
 unsafe impl Reference for JClassLoader<'_> {
-    const CLASS_NAME: &'static JNIStr = JNIStr::from_cstr(c"java.lang.ClassLoader");
-
     type Kind<'env> = JClassLoader<'env>;
     type GlobalKind = JClassLoader<'static>;
 
     fn as_raw(&self) -> jobject {
         self.0.as_raw()
+    }
+
+    fn class_name() -> Cow<'static, JNIStr> {
+        Cow::Borrowed(JNIStr::from_cstr(c"java.lang.ClassLoader"))
     }
 
     fn lookup_class<'caller>(

--- a/src/objects/jcollection.rs
+++ b/src/objects/jcollection.rs
@@ -1,4 +1,4 @@
-use std::ops::Deref;
+use std::{borrow::Cow, ops::Deref};
 
 use once_cell::sync::OnceCell;
 
@@ -275,13 +275,15 @@ impl<'local> JCollection<'local> {
 
 // SAFETY: JCollection is a transparent JObject wrapper with no Drop side effects
 unsafe impl Reference for JCollection<'_> {
-    const CLASS_NAME: &'static JNIStr = JNIStr::from_cstr(c"java.util.Collection");
-
     type Kind<'env> = JCollection<'env>;
     type GlobalKind = JCollection<'static>;
 
     fn as_raw(&self) -> jobject {
         self.0.as_raw()
+    }
+
+    fn class_name() -> Cow<'static, JNIStr> {
+        Cow::Borrowed(JNIStr::from_cstr(c"java.util.Collection"))
     }
 
     fn lookup_class<'caller>(

--- a/src/objects/jiterator.rs
+++ b/src/objects/jiterator.rs
@@ -1,4 +1,4 @@
-use std::ops::Deref;
+use std::{borrow::Cow, ops::Deref};
 
 use once_cell::sync::OnceCell;
 
@@ -195,8 +195,6 @@ impl<'local> JIterator<'local> {
 
 // SAFETY: JIterator is a transparent JObject wrapper with no Drop side effects
 unsafe impl Reference for JIterator<'_> {
-    const CLASS_NAME: &'static JNIStr = JNIStr::from_cstr(c"java.util.Iterator");
-
     type Kind<'env> = JIterator<'env>;
     type GlobalKind = JIterator<'static>;
 
@@ -204,6 +202,9 @@ unsafe impl Reference for JIterator<'_> {
         self.0.as_raw()
     }
 
+    fn class_name() -> Cow<'static, JNIStr> {
+        Cow::Borrowed(JNIStr::from_cstr(c"java.util.Iterator"))
+    }
     fn lookup_class<'caller>(
         env: &Env<'_>,
         loader_context: LoaderContext,

--- a/src/objects/jlist.rs
+++ b/src/objects/jlist.rs
@@ -13,7 +13,7 @@ use crate::{
     Env,
 };
 
-use std::ops::Deref;
+use std::{borrow::Cow, ops::Deref};
 
 /// Wrapper for `java.utils.List` references. Provides methods to get, add, and
 /// remove elements.
@@ -322,13 +322,15 @@ impl<'local> JList<'local> {
 
 // SAFETY: JList is a transparent JObject wrapper with no Drop side effects
 unsafe impl Reference for JList<'_> {
-    const CLASS_NAME: &'static JNIStr = JNIStr::from_cstr(c"java.util.List");
-
     type Kind<'env> = JList<'env>;
     type GlobalKind = JList<'static>;
 
     fn as_raw(&self) -> jobject {
         self.0.as_raw()
+    }
+
+    fn class_name() -> Cow<'static, JNIStr> {
+        Cow::Borrowed(JNIStr::from_cstr(c"java.util.List"))
     }
 
     fn lookup_class<'caller>(

--- a/src/objects/jmap.rs
+++ b/src/objects/jmap.rs
@@ -11,7 +11,7 @@ use crate::{
     Env,
 };
 
-use std::ops::Deref;
+use std::{borrow::Cow, ops::Deref};
 
 /// Wrapper for `java.utils.Map` references. Provides methods to get, add, and
 /// set entries and a way to iterate over key/value pairs.
@@ -290,13 +290,15 @@ impl<'local> JMap<'local> {
 
 // SAFETY: JMap is a transparent JObject wrapper with no Drop side effects
 unsafe impl Reference for JMap<'_> {
-    const CLASS_NAME: &'static JNIStr = JNIStr::from_cstr(c"java.util.Map");
-
     type Kind<'env> = JMap<'env>;
     type GlobalKind = JMap<'static>;
 
     fn as_raw(&self) -> jobject {
         self.0.as_raw()
+    }
+
+    fn class_name() -> Cow<'static, JNIStr> {
+        Cow::Borrowed(JNIStr::from_cstr(c"java.util.Map"))
     }
 
     fn lookup_class<'caller>(
@@ -482,13 +484,15 @@ impl<'local> JMapEntry<'local> {
 
 // SAFETY: JMapEntry is a transparent JObject wrapper with no Drop side effects
 unsafe impl Reference for JMapEntry<'_> {
-    const CLASS_NAME: &'static JNIStr = JNIStr::from_cstr(c"java.util.Map$Entry");
-
     type Kind<'env> = JMapEntry<'env>;
     type GlobalKind = JMapEntry<'static>;
 
     fn as_raw(&self) -> jobject {
         self.0.as_raw()
+    }
+
+    fn class_name() -> Cow<'static, JNIStr> {
+        Cow::Borrowed(JNIStr::from_cstr(c"java.util.Map$Entry"))
     }
 
     fn lookup_class<'caller>(

--- a/src/objects/jobject.rs
+++ b/src/objects/jobject.rs
@@ -1,4 +1,4 @@
-use std::{marker::PhantomData, ops::Deref};
+use std::{borrow::Cow, marker::PhantomData, ops::Deref};
 
 use once_cell::sync::OnceCell;
 
@@ -129,13 +129,15 @@ impl std::default::Default for JObject<'_> {
 
 // SAFETY: JObject is a transparent jobject wrapper with no Drop side effects
 unsafe impl Reference for JObject<'_> {
-    const CLASS_NAME: &'static JNIStr = JNIStr::from_cstr(c"java.lang.Object");
-
     type Kind<'env> = JObject<'env>;
     type GlobalKind = JObject<'static>;
 
     fn as_raw(&self) -> jobject {
         self.as_raw()
+    }
+
+    fn class_name() -> Cow<'static, JNIStr> {
+        Cow::Borrowed(JNIStr::from_cstr(c"java.lang.Object"))
     }
 
     fn lookup_class<'caller>(

--- a/src/objects/jobject_array.rs
+++ b/src/objects/jobject_array.rs
@@ -1,4 +1,4 @@
-use std::ops::Deref;
+use std::{borrow::Cow, ops::Deref};
 
 use once_cell::sync::OnceCell;
 
@@ -149,13 +149,15 @@ impl JObjectArray<'_> {
 
 // SAFETY: JObjectArray is a transparent JObject wrapper with no Drop side effects
 unsafe impl Reference for JObjectArray<'_> {
-    const CLASS_NAME: &'static JNIStr = JNIStr::from_cstr(c"[Ljava.lang.Object;");
-
     type Kind<'env> = JObjectArray<'env>;
     type GlobalKind = JObjectArray<'static>;
 
     fn as_raw(&self) -> jobject {
         self.0.as_raw()
+    }
+
+    fn class_name() -> Cow<'static, JNIStr> {
+        Cow::Borrowed(JNIStr::from_cstr(c"[Ljava.lang.Object;"))
     }
 
     fn lookup_class<'caller>(

--- a/src/objects/jprimitive_array.rs
+++ b/src/objects/jprimitive_array.rs
@@ -1,3 +1,4 @@
+use std::borrow::Cow;
 use std::marker::PhantomData;
 use std::ops::Deref;
 
@@ -363,13 +364,15 @@ macro_rules! impl_ref_for_jprimitive_array {
 
             // SAFETY: JPrimitiveArray is a transparent JObject wrapper with no Drop side effects
             unsafe impl Reference for JPrimitiveArray<'_, crate::sys::$type> {
-                const CLASS_NAME: &'static JNIStr = JNIStr::from_cstr($class_name);
-
                 type Kind<'env> = JPrimitiveArray<'env, crate::sys::$type>;
                 type GlobalKind = JPrimitiveArray<'static, crate::sys::$type>;
 
                 fn as_raw(&self) -> jobject {
                     self.obj.as_raw()
+                }
+
+                fn class_name() -> Cow<'static, JNIStr> {
+                    Cow::Borrowed(JNIStr::from_cstr($class_name))
                 }
 
                 fn lookup_class<'caller>(

--- a/src/objects/jset.rs
+++ b/src/objects/jset.rs
@@ -1,4 +1,4 @@
-use std::ops::Deref;
+use std::{borrow::Cow, ops::Deref};
 
 use once_cell::sync::OnceCell;
 
@@ -198,13 +198,15 @@ impl<'local> JSet<'local> {
 
 // SAFETY: JSet is a transparent JObject wrapper with no Drop side effects
 unsafe impl Reference for JSet<'_> {
-    const CLASS_NAME: &'static JNIStr = JNIStr::from_cstr(c"java.util.Set");
-
     type Kind<'env> = JSet<'env>;
     type GlobalKind = JSet<'static>;
 
     fn as_raw(&self) -> jobject {
         self.0.as_raw()
+    }
+
+    fn class_name() -> Cow<'static, JNIStr> {
+        Cow::Borrowed(JNIStr::from_cstr(c"java.util.Set"))
     }
 
     fn lookup_class<'caller>(

--- a/src/objects/jstack_trace_element.rs
+++ b/src/objects/jstack_trace_element.rs
@@ -1,4 +1,4 @@
-use std::ops::Deref;
+use std::{borrow::Cow, ops::Deref};
 
 use once_cell::sync::OnceCell;
 
@@ -246,13 +246,15 @@ impl JStackTraceElement<'_> {
 
 // SAFETY: JStackTraceElement is a transparent JObject wrapper with no Drop side effects
 unsafe impl Reference for JStackTraceElement<'_> {
-    const CLASS_NAME: &'static JNIStr = JNIStr::from_cstr(c"java.lang.StackTraceElement");
-
     type Kind<'env> = JStackTraceElement<'env>;
     type GlobalKind = JStackTraceElement<'static>;
 
     fn as_raw(&self) -> jobject {
         self.0.as_raw()
+    }
+
+    fn class_name() -> Cow<'static, JNIStr> {
+        Cow::Borrowed(JNIStr::from_cstr(c"java.lang.StackTraceElement"))
     }
 
     fn lookup_class<'caller>(

--- a/src/objects/jstring.rs
+++ b/src/objects/jstring.rs
@@ -1,4 +1,4 @@
-use std::ops::Deref;
+use std::{borrow::Cow, ops::Deref};
 
 use once_cell::sync::OnceCell;
 use thiserror::Error;
@@ -268,13 +268,15 @@ impl JString<'_> {
 
 // SAFETY: JString is a transparent JObject wrapper with no Drop side effects
 unsafe impl Reference for JString<'_> {
-    const CLASS_NAME: &'static JNIStr = JNIStr::from_cstr(c"java.lang.String");
-
     type Kind<'env> = JString<'env>;
     type GlobalKind = JString<'static>;
 
     fn as_raw(&self) -> jobject {
         self.0.as_raw()
+    }
+
+    fn class_name() -> Cow<'static, JNIStr> {
+        Cow::Borrowed(JNIStr::from_cstr(c"java.lang.String"))
     }
 
     fn lookup_class<'caller>(

--- a/src/objects/jthread.rs
+++ b/src/objects/jthread.rs
@@ -1,4 +1,4 @@
-use std::ops::Deref;
+use std::{borrow::Cow, ops::Deref};
 
 use once_cell::sync::OnceCell;
 
@@ -261,13 +261,15 @@ impl JThread<'_> {
 
 // SAFETY: JThread is a transparent JObject wrapper with no Drop side effects
 unsafe impl Reference for JThread<'_> {
-    const CLASS_NAME: &'static JNIStr = JNIStr::from_cstr(c"java.lang.Thread");
-
     type Kind<'env> = JThread<'env>;
     type GlobalKind = JThread<'static>;
 
     fn as_raw(&self) -> jobject {
         self.0.as_raw()
+    }
+
+    fn class_name() -> Cow<'static, JNIStr> {
+        Cow::Borrowed(JNIStr::from_cstr(c"java.lang.Thread"))
     }
 
     fn lookup_class<'caller>(

--- a/src/objects/jthrowable.rs
+++ b/src/objects/jthrowable.rs
@@ -1,4 +1,4 @@
-use std::ops::Deref;
+use std::{borrow::Cow, ops::Deref};
 
 use once_cell::sync::OnceCell;
 
@@ -177,13 +177,15 @@ impl JThrowable<'_> {
 
 // SAFETY: JThrowable is a transparent JObject wrapper with no Drop side effects
 unsafe impl Reference for JThrowable<'_> {
-    const CLASS_NAME: &'static JNIStr = JNIStr::from_cstr(c"java.lang.Throwable");
-
     type Kind<'env> = JThrowable<'env>;
     type GlobalKind = JThrowable<'static>;
 
     fn as_raw(&self) -> jobject {
         self.0.as_raw()
+    }
+
+    fn class_name() -> Cow<'static, JNIStr> {
+        Cow::Borrowed(JNIStr::from_cstr(c"java.lang.Throwable"))
     }
 
     fn lookup_class<'caller>(

--- a/src/refs/auto.rs
+++ b/src/refs/auto.rs
@@ -1,4 +1,4 @@
-use std::{marker::PhantomData, mem::ManuallyDrop, ops::Deref, ptr};
+use std::{borrow::Cow, marker::PhantomData, mem::ManuallyDrop, ops::Deref, ptr};
 
 use jni_sys::jobject;
 
@@ -272,13 +272,15 @@ unsafe impl<'local, T> Reference for Auto<'local, T>
 where
     T: Reference + Into<JObject<'local>>,
 {
-    const CLASS_NAME: &'static JNIStr = T::CLASS_NAME;
-
     type Kind<'env> = T::Kind<'env>;
     type GlobalKind = T::GlobalKind;
 
     fn as_raw(&self) -> jobject {
         self.obj.as_raw()
+    }
+
+    fn class_name() -> Cow<'static, JNIStr> {
+        T::class_name()
     }
 
     fn lookup_class<'caller>(

--- a/src/refs/cast.rs
+++ b/src/refs/cast.rs
@@ -1,4 +1,4 @@
-use std::{marker::PhantomData, ops::Deref};
+use std::{borrow::Cow, marker::PhantomData, ops::Deref};
 
 use jni_sys::jobject;
 
@@ -117,13 +117,15 @@ impl<'local, 'from, To: Reference> AsRef<To::Kind<'local>> for Cast<'local, 'fro
 }
 
 unsafe impl<'any, 'from, To: Reference> Reference for Cast<'any, 'from, To> {
-    const CLASS_NAME: &'static JNIStr = To::CLASS_NAME;
-
     type Kind<'local> = To::Kind<'local>;
     type GlobalKind = To::GlobalKind;
 
     fn as_raw(&self) -> jobject {
         self.to.as_raw()
+    }
+
+    fn class_name() -> Cow<'static, JNIStr> {
+        To::class_name()
     }
 
     fn lookup_class<'caller>(

--- a/src/refs/global.rs
+++ b/src/refs/global.rs
@@ -1,4 +1,4 @@
-use std::ops::Deref;
+use std::{borrow::Cow, ops::Deref};
 
 use jni_sys::jobject;
 use log::{debug, warn};
@@ -308,13 +308,15 @@ unsafe impl<T> Reference for Global<T>
 where
     T: Into<JObject<'static>> + AsRef<JObject<'static>> + Default + Reference + Send + Sync,
 {
-    const CLASS_NAME: &'static JNIStr = T::CLASS_NAME;
-
     type Kind<'env> = T::Kind<'env>;
     type GlobalKind = T::GlobalKind;
 
     fn as_raw(&self) -> jobject {
         self.obj.as_raw()
+    }
+
+    fn class_name() -> Cow<'static, JNIStr> {
+        T::class_name()
     }
 
     fn lookup_class<'caller>(

--- a/src/refs/weak.rs
+++ b/src/refs/weak.rs
@@ -1,4 +1,4 @@
-use std::ops::Deref;
+use std::{borrow::Cow, ops::Deref};
 
 use jni_sys::jobject;
 use log::{debug, warn};
@@ -284,13 +284,15 @@ unsafe impl<T> Reference for Weak<T>
 where
     T: Into<JObject<'static>> + AsRef<JObject<'static>> + Default + Reference + Send + Sync,
 {
-    const CLASS_NAME: &'static JNIStr = T::CLASS_NAME;
-
     type Kind<'env> = T::Kind<'env>;
     type GlobalKind = T::GlobalKind;
 
     fn as_raw(&self) -> jobject {
         self.obj.as_raw()
+    }
+
+    fn class_name() -> Cow<'static, JNIStr> {
+        T::class_name()
     }
 
     fn lookup_class<'caller>(


### PR DESCRIPTION
Most Reference implementations can continue to return a `'static` `JNIStr` literal, but a generic Reference type like `JObjectArray<T>` will be able to compose the class descriptor dynamically based on it's element type and return a `Cow::Owned(JString)` instead.

This will make it possible to implement a generic `JObjectArray<T>`.

Fixes: #651
