### PR TITLE
Move static_assertions to dev-only dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,6 @@ combine = "4.1.0"
 jni-sys = "0.4"
 log = "0.4.4"
 once_cell = "1.19.0"
-static_assertions = "1"
 thiserror = "2"
 paste = "1"
 
@@ -50,6 +49,7 @@ assert_matches = "1.5.0"
 lazy_static = "1"
 rusty-fork = "0.3.0"
 trybuild = "1.0.0"
+static_assertions = "1"
 
 [target.'cfg(windows)'.dev-dependencies]
 bytemuck = "1.13.0"

--- a/src/env.rs
+++ b/src/env.rs
@@ -4008,8 +4008,6 @@ pub struct MonitorGuard<'local> {
     life: PhantomData<&'local ()>,
 }
 
-static_assertions::assert_not_impl_any!(MonitorGuard: Send);
-
 impl Drop for MonitorGuard<'_> {
     fn drop(&mut self) {
         // Panics:
@@ -4043,3 +4041,6 @@ impl Drop for MonitorGuard<'_> {
             .expect("MonitorGuard dropped on detached thread");
     }
 }
+
+#[cfg(test)]
+static_assertions::assert_not_impl_any!(MonitorGuard: Send);


### PR DESCRIPTION
## Overview

While reviewing the upcoming`0.22` release in `rustls-platform-verifier`, I noticed that `jni` began to use `static_assertions`. This crate is generally for tests/CI verification of code so it usually shouldn't be propagated into downstream user's lockfiles. This PR makes a very small change to move the single use of `static_assertions` behind `#[cfg(test)]` to accomplish this.

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Change is covered by [automated tests](https://github.com/jni-rs/jni-rs/blob/master/CONTRIBUTING.md#tests)
- [x] The [coding guidelines](https://github.com/jni-rs/jni-rs/blob/master/CONTRIBUTING.md#the-code-style) are followed
- [x] Public API has documentation
- [x] User-visible changes are mentioned in the Changelog
- [x] The continuous integration build passes
