### PR TITLE
Add `Env::as_cast_raw` for casting raw JNI references

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,10 +39,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `Reference::lookup_class` exposes a cached `Global<JClass>` for all `Reference` implementations ([#612](https://github.com/jni-rs/jni-rs/pull/612))
 - `LoaderContext` + `LoaderContext::load_class` for loading classes, depending on available context ([#612](https://github.com/jni-rs/jni-rs/pull/612))
 - `Env::new_cast_global_ref` acts like `new_global_ref` with a type cast ([#612](https://github.com/jni-rs/jni-rs/pull/612))
-- `Env::cast_global` takes an owned `Global<From>` and returns a `Global<To>` ([#612](https://github.com/jni-rs/jni-rs/pull/612))
+- `Env::cast_global` takes an owned `Global<From>` and returns an owned `Global<To>` ([#612](https://github.com/jni-rs/jni-rs/pull/612))
 - `Env::new_cast_local_ref` acts like `new_local_ref` with a type cast ([#612](https://github.com/jni-rs/jni-rs/pull/612))
-- `Env::cast_local` takes an owned local reference and returns a newly type cast wrapper ([#612](https://github.com/jni-rs/jni-rs/pull/612))
-- `Env::as_cast` borrows any `From: Reference` (global or local) reference and returns  a `Cast<To>` that will Deref into `&To` ([#612](https://github.com/jni-rs/jni-rs/pull/612))
+- `Env::cast_local` takes an owned local reference and returns a new type-cast wrapper (owned) ([#612](https://github.com/jni-rs/jni-rs/pull/612))
+- `Env::as_cast` or `Cast::new` borrows any `From: Reference` (global or local) reference and returns  a `Cast<To>` that will Deref into `&To` ([#612](https://github.com/jni-rs/jni-rs/pull/612))
+- `Env::as_cast_raw` or `Cast::from_raw` borrows a raw `jobject` reference and returns a `Cast<To>` that will Deref into `&To`
+- `Cast::new_unchecked` and `Cast::from_raw_unchecked` let you borrow a reference with an (`unsafe`) type cast, with no runtime check
 
 #### JNI Environment APIs
 

--- a/src/refs/cast.rs
+++ b/src/refs/cast.rs
@@ -34,8 +34,8 @@ impl<'any, 'from, To: Reference> Cast<'any, 'from, To> {
     ///
     /// Returns [Error::WrongObjectType] if the object is not of the expected type.
     pub(crate) fn new<'env_local, From: Reference + AsRef<JObject<'any>>>(
-        from: &'from From,
         env: &Env<'env_local>,
+        from: &'from From,
     ) -> Result<Self>
     where
         'any: 'from,
@@ -71,14 +71,68 @@ impl<'any, 'from, To: Reference> Cast<'any, 'from, To> {
         }
     }
 
+    /// Creates a [`Cast`] from a raw JNI reference pointer
+    ///
+    /// Returns [Error::WrongObjectType] if the object is not of the expected type.
+    ///
+    /// # Safety
+    ///
+    /// The caller must ensure that `from` is a valid reference (local or global) - which may be
+    /// `null`.
+    ///
+    /// The caller must ensure the `from` reference will not be deleted while the `Cast` exists.
+    ///
+    /// Note: even though this API is `unsafe`, it will still do a runtime check that `from` is a
+    /// valid instance of `To`, so you are not required to know this.
+    ///
+    /// Note: this API is agnostic about whether the reference is local or global because the `Cast`
+    /// wrapper doesn't give ownership over the reference and so you can't accidentally attempt to
+    /// delete it using the wrong JNI API.
+    pub unsafe fn from_raw<'env_local>(env: &Env<'env_local>, from: &'from jobject) -> Result<Self>
+    where
+        'any: 'from,
+    {
+        let from = JObject::from_raw(*from);
+        let from = &from; // make it clear, we don't own `from`
+
+        // Note we can't just chain up to Cast::new since the from lifetime would be incorrect.
+
+        if from.is_null() {
+            return Ok(Self {
+                _from: PhantomData,
+                to: To::null(),
+            });
+        }
+
+        if env.is_instance_of_cast_type::<To>(from)? {
+            // Safety:
+            // - We have just checked that `from` is an instance of `T`
+            // - Although we are creating a second wrapper for the raw reference, we will be
+            //   borrowing the original wrapper (so the caller won't own two wrappers around the
+            //   same reference) and this wrapper will be hidden.
+            // - A pre-condition of `Reference` is that `T::Kind` must not have any `Drop` side
+            //   effects so we don't have to worry that creating a second wrapper could lead to a
+            //   double free when dropped.
+            // - We're allowed to potentially create a `JObject::Kind` wrapper for a `'static`
+            //   global reference in this situation where we're not giving ownership of the cast
+            //   wrapper and we're borrowing from the original reference.
+            unsafe {
+                Ok(Self {
+                    _from: PhantomData,
+                    to: To::from_raw::<'any>(from.as_raw()),
+                })
+            }
+        } else {
+            Err(Error::WrongObjectType)
+        }
+    }
+
     /// Creates a new cast from one object type to another without a runtime check.
     ///
     /// # Safety
     ///
     /// The caller must ensure that `from` is an instance of `To`.
-    pub unsafe fn new_unchecked<'env_local, From: Reference + AsRef<JObject<'any>>>(
-        from: &'from From,
-    ) -> Self
+    pub unsafe fn new_unchecked<From: Reference + AsRef<JObject<'any>>>(from: &'from From) -> Self
     where
         'any: 'from,
     {
@@ -97,6 +151,35 @@ impl<'any, 'from, To: Reference> Cast<'any, 'from, To> {
             Self {
                 _from: PhantomData,
                 to: To::from_raw::<'any>(from.as_raw()),
+            }
+        }
+    }
+
+    /// Creates a [`Cast`] from a raw JNI object reference without a runtime check.
+    ///
+    /// # Safety
+    ///
+    /// The caller must ensure that `from` is a valid JNI reference to an instance of `To` (or
+    /// null).
+    pub unsafe fn from_raw_unchecked(from: &'from jobject) -> Self
+    where
+        'any: 'from,
+    {
+        // Safety:
+        // - The caller has promised that `from` is an instance of `T`, or null
+        // - Although we are creating a second wrapper for the raw reference, we will be
+        //   borrowing the original wrapper (so the caller won't own two wrappers around the
+        //   same reference) and this wrapper will be hidden.
+        // - A pre-condition of `Reference` is that `T::Kind` must not have any `Drop` side
+        //   effects so we don't have to worry that creating a second wrapper could lead to a
+        //   double free when dropped.
+        // - We're allowed to potentially create a `JObject::Kind` wrapper for a `'static`
+        //   global reference in this situation where we're not giving ownership of the cast
+        //   wrapper and we're borrowing from the original reference.
+        unsafe {
+            Self {
+                _from: PhantomData,
+                to: To::from_raw::<'any>(*from),
             }
         }
     }


### PR DESCRIPTION
This makes it possible to borrow a raw JNI jobject pointer and cast it as a type-safe `jni` reference with a runtime `IsInstanceOf` check.

This also makes it possible to borrow raw global references without acquiring any kind of owned reference type that could accidentally be used to deleted the reference.

Fixes: #658
