### PR TITLE
Rename `Reference::from_raw` -> `kind_from_raw`

### DIFF
--- a/src/env.rs
+++ b/src/env.rs
@@ -1040,8 +1040,12 @@ impl<'local> Env<'local> {
         // - we know there's no other wrapper for the reference passed to from_global_raw
         //   since we have just created it.
         let global_ref = unsafe {
-            let global_ref =
-                O::from_global_raw(jni_call_unchecked!(self, v1_1, NewGlobalRef, obj.as_raw()));
+            let global_ref = O::global_kind_from_raw(jni_call_unchecked!(
+                self,
+                v1_1,
+                NewGlobalRef,
+                obj.as_raw()
+            ));
             Global::new(self, global_ref)
         };
 
@@ -1115,7 +1119,7 @@ impl<'local> Env<'local> {
             // Safety:
             // - we have just checked that `new` is an instance of `To`
             unsafe {
-                let cast = To::from_global_raw(new.into_raw());
+                let cast = To::global_kind_from_raw(new.into_raw());
                 Ok(Global::new(self, cast))
             }
         } else {
@@ -1173,7 +1177,7 @@ impl<'local> Env<'local> {
             // - we have just checked that `obj` is an instance of `T`
             // - there won't be multiple wrappers since we are creating one from the other
             unsafe {
-                let cast = To::from_global_raw(obj.into_raw());
+                let cast = To::global_kind_from_raw(obj.into_raw());
                 Ok(Global::new(self, cast))
             }
         } else {
@@ -1213,7 +1217,7 @@ impl<'local> Env<'local> {
         // - we know there's no other wrapper for the reference passed to from_global_raw
         //   since we have just created it.
         let weak_ref = unsafe {
-            let weak = O::from_global_raw(jni_call_check_ex!(
+            let weak = O::global_kind_from_raw(jni_call_check_ex!(
                 self,
                 v1_2,
                 NewWeakGlobalRef,
@@ -1351,7 +1355,7 @@ impl<'local> Env<'local> {
         // - we know there's no other wrapper for the reference passed to from_local_raw
         //   since we have just created it.
         let local =
-            unsafe { O::from_raw(jni_call_unchecked!(self, v1_2, NewLocalRef, obj.as_raw())) };
+            unsafe { O::kind_from_raw(jni_call_unchecked!(self, v1_2, NewLocalRef, obj.as_raw())) };
 
         // Per JNI spec, `NewLocalRef` will return a null pointer if the object was GC'd
         // (which could happen if `obj` is a `Weak`):
@@ -1419,7 +1423,7 @@ impl<'local> Env<'local> {
             // Safety:
             // - we have just checked that `new` is an instance of `To`
             // - as it's a new reference, it's assigned the `'local` Env lifetime
-            unsafe { Ok(To::from_raw::<'local>(new.into_raw())) }
+            unsafe { Ok(To::kind_from_raw::<'local>(new.into_raw())) }
         } else {
             Err(Error::WrongObjectType)
         }
@@ -1465,7 +1469,7 @@ impl<'local> Env<'local> {
             // Safety:
             // - we have just checked that `obj` is an instance of `T`
             // - it is associated with the same lifetime that it was created with
-            unsafe { Ok(To::from_raw::<'any_local>(obj.into_raw())) }
+            unsafe { Ok(To::kind_from_raw::<'any_local>(obj.into_raw())) }
         } else {
             Err(Error::WrongObjectType)
         }
@@ -1657,7 +1661,7 @@ impl<'local> Env<'local> {
         // This method is safe to call in case of pending exceptions (see chapter 2 of the spec)
         // We check for JNI > 1.2 in `from_raw`
         let raw = jni_call_unchecked!(self, v1_2, PopLocalFrame, result.into_raw());
-        Ok(T::from_raw(raw))
+        Ok(T::kind_from_raw(raw))
     }
 
     /// Executes the given function in a new local reference frame, in which at least a given number

--- a/src/objects/jbytebuffer.rs
+++ b/src/objects/jbytebuffer.rs
@@ -99,11 +99,11 @@ unsafe impl Reference for JByteBuffer<'_> {
         let api = JByteBufferAPI::get(env, &loader_context)?;
         Ok(&api.class)
     }
-    unsafe fn from_raw<'env>(local_ref: jobject) -> Self::Kind<'env> {
+    unsafe fn kind_from_raw<'env>(local_ref: jobject) -> Self::Kind<'env> {
         JByteBuffer::from_raw(local_ref)
     }
 
-    unsafe fn from_global_raw(global_ref: jobject) -> Self::GlobalKind {
+    unsafe fn global_kind_from_raw(global_ref: jobject) -> Self::GlobalKind {
         JByteBuffer::from_raw(global_ref)
     }
 }

--- a/src/objects/jclass.rs
+++ b/src/objects/jclass.rs
@@ -240,11 +240,11 @@ unsafe impl Reference for JClass<'_> {
         Ok(&api.class)
     }
 
-    unsafe fn from_raw<'env>(local_ref: jobject) -> Self::Kind<'env> {
+    unsafe fn kind_from_raw<'env>(local_ref: jobject) -> Self::Kind<'env> {
         JClass::from_raw(local_ref)
     }
 
-    unsafe fn from_global_raw(global_ref: jobject) -> Self::GlobalKind {
+    unsafe fn global_kind_from_raw(global_ref: jobject) -> Self::GlobalKind {
         JClass::from_raw(global_ref)
     }
 }

--- a/src/objects/jclass_loader.rs
+++ b/src/objects/jclass_loader.rs
@@ -154,11 +154,11 @@ unsafe impl Reference for JClassLoader<'_> {
         Ok(&api.class)
     }
 
-    unsafe fn from_raw<'env>(local_ref: jobject) -> Self::Kind<'env> {
+    unsafe fn kind_from_raw<'env>(local_ref: jobject) -> Self::Kind<'env> {
         JClassLoader::from_raw(local_ref)
     }
 
-    unsafe fn from_global_raw(global_ref: jobject) -> Self::GlobalKind {
+    unsafe fn global_kind_from_raw(global_ref: jobject) -> Self::GlobalKind {
         JClassLoader::from_raw(global_ref)
     }
 }

--- a/src/objects/jcollection.rs
+++ b/src/objects/jcollection.rs
@@ -294,11 +294,11 @@ unsafe impl Reference for JCollection<'_> {
         Ok(&api.class)
     }
 
-    unsafe fn from_raw<'env>(local_ref: jobject) -> Self::Kind<'env> {
+    unsafe fn kind_from_raw<'env>(local_ref: jobject) -> Self::Kind<'env> {
         JCollection::from_raw(local_ref)
     }
 
-    unsafe fn from_global_raw(global_ref: jobject) -> Self::GlobalKind {
+    unsafe fn global_kind_from_raw(global_ref: jobject) -> Self::GlobalKind {
         JCollection::from_raw(global_ref)
     }
 }

--- a/src/objects/jiterator.rs
+++ b/src/objects/jiterator.rs
@@ -213,11 +213,11 @@ unsafe impl Reference for JIterator<'_> {
         Ok(&api.class)
     }
 
-    unsafe fn from_raw<'env>(local_ref: jobject) -> Self::Kind<'env> {
+    unsafe fn kind_from_raw<'env>(local_ref: jobject) -> Self::Kind<'env> {
         JIterator::from_raw(local_ref)
     }
 
-    unsafe fn from_global_raw(global_ref: jobject) -> Self::GlobalKind {
+    unsafe fn global_kind_from_raw(global_ref: jobject) -> Self::GlobalKind {
         JIterator::from_raw(global_ref)
     }
 }

--- a/src/objects/jlist.rs
+++ b/src/objects/jlist.rs
@@ -341,11 +341,11 @@ unsafe impl Reference for JList<'_> {
         Ok(&api.class)
     }
 
-    unsafe fn from_raw<'env>(local_ref: jobject) -> Self::Kind<'env> {
+    unsafe fn kind_from_raw<'env>(local_ref: jobject) -> Self::Kind<'env> {
         JList::from_raw(local_ref)
     }
 
-    unsafe fn from_global_raw(global_ref: jobject) -> Self::GlobalKind {
+    unsafe fn global_kind_from_raw(global_ref: jobject) -> Self::GlobalKind {
         JList::from_raw(global_ref)
     }
 }

--- a/src/objects/jmap.rs
+++ b/src/objects/jmap.rs
@@ -309,11 +309,11 @@ unsafe impl Reference for JMap<'_> {
         Ok(&api.class)
     }
 
-    unsafe fn from_raw<'env>(local_ref: jobject) -> Self::Kind<'env> {
+    unsafe fn kind_from_raw<'env>(local_ref: jobject) -> Self::Kind<'env> {
         JMap::from_raw(local_ref)
     }
 
-    unsafe fn from_global_raw(global_ref: jobject) -> Self::GlobalKind {
+    unsafe fn global_kind_from_raw(global_ref: jobject) -> Self::GlobalKind {
         JMap::from_raw(global_ref)
     }
 }
@@ -503,11 +503,11 @@ unsafe impl Reference for JMapEntry<'_> {
         Ok(&api.class)
     }
 
-    unsafe fn from_raw<'env>(local_ref: jobject) -> Self::Kind<'env> {
+    unsafe fn kind_from_raw<'env>(local_ref: jobject) -> Self::Kind<'env> {
         JMapEntry::from_raw(local_ref)
     }
 
-    unsafe fn from_global_raw(global_ref: jobject) -> Self::GlobalKind {
+    unsafe fn global_kind_from_raw(global_ref: jobject) -> Self::GlobalKind {
         JMapEntry::from_raw(global_ref)
     }
 }

--- a/src/objects/jobject.rs
+++ b/src/objects/jobject.rs
@@ -150,11 +150,11 @@ unsafe impl Reference for JObject<'_> {
         Ok(&api.class)
     }
 
-    unsafe fn from_raw<'env>(local_ref: jobject) -> Self::Kind<'env> {
+    unsafe fn kind_from_raw<'env>(local_ref: jobject) -> Self::Kind<'env> {
         JObject::from_raw(local_ref)
     }
 
-    unsafe fn from_global_raw(global_ref: jobject) -> Self::GlobalKind {
+    unsafe fn global_kind_from_raw(global_ref: jobject) -> Self::GlobalKind {
         JObject::from_raw(global_ref)
     }
 }

--- a/src/objects/jobject_array.rs
+++ b/src/objects/jobject_array.rs
@@ -191,7 +191,7 @@ impl<'local, E: Reference + 'local> JObjectArray<'local, E> {
         }
         unsafe {
             jni_call_check_ex!(env, v1_1, GetObjectArrayElement, array, index as i32)
-                .map(|obj| E::from_raw(obj))
+                .map(|obj| E::kind_from_raw(obj))
         }
     }
 
@@ -256,11 +256,11 @@ unsafe impl<'local, E: Reference + 'local> Reference for JObjectArray<'local, E>
         Ok(&api.class)
     }
 
-    unsafe fn from_raw<'env>(local_ref: jobject) -> Self::Kind<'env> {
+    unsafe fn kind_from_raw<'env>(local_ref: jobject) -> Self::Kind<'env> {
         JObjectArray::<E::Kind<'env>>::from_raw(local_ref as jobjectArray)
     }
 
-    unsafe fn from_global_raw(global_ref: jobject) -> Self::GlobalKind {
+    unsafe fn global_kind_from_raw(global_ref: jobject) -> Self::GlobalKind {
         JObjectArray::<E::GlobalKind>::from_raw(global_ref as jobjectArray)
     }
 }

--- a/src/objects/jprimitive_array.rs
+++ b/src/objects/jprimitive_array.rs
@@ -383,11 +383,11 @@ macro_rules! impl_ref_for_jprimitive_array {
                     Ok(&api.class)
                 }
 
-                unsafe fn from_raw<'env>(local_ref: jobject) -> Self::Kind<'env> {
+                unsafe fn kind_from_raw<'env>(local_ref: jobject) -> Self::Kind<'env> {
                     JPrimitiveArray::from_raw(local_ref)
                 }
 
-                unsafe fn from_global_raw(global_ref: jobject) -> Self::GlobalKind {
+                unsafe fn global_kind_from_raw(global_ref: jobject) -> Self::GlobalKind {
                     JPrimitiveArray::from_raw(global_ref)
                 }
             }

--- a/src/objects/jset.rs
+++ b/src/objects/jset.rs
@@ -217,11 +217,11 @@ unsafe impl Reference for JSet<'_> {
         Ok(&api.class)
     }
 
-    unsafe fn from_raw<'env>(local_ref: jobject) -> Self::Kind<'env> {
+    unsafe fn kind_from_raw<'env>(local_ref: jobject) -> Self::Kind<'env> {
         JSet::from_raw(local_ref)
     }
 
-    unsafe fn from_global_raw(global_ref: jobject) -> Self::GlobalKind {
+    unsafe fn global_kind_from_raw(global_ref: jobject) -> Self::GlobalKind {
         JSet::from_raw(global_ref)
     }
 }

--- a/src/objects/jstack_trace_element.rs
+++ b/src/objects/jstack_trace_element.rs
@@ -265,11 +265,11 @@ unsafe impl Reference for JStackTraceElement<'_> {
         Ok(&api.class)
     }
 
-    unsafe fn from_raw<'env>(local_ref: jobject) -> Self::Kind<'env> {
+    unsafe fn kind_from_raw<'env>(local_ref: jobject) -> Self::Kind<'env> {
         JStackTraceElement::from_raw(local_ref)
     }
 
-    unsafe fn from_global_raw(global_ref: jobject) -> Self::GlobalKind {
+    unsafe fn global_kind_from_raw(global_ref: jobject) -> Self::GlobalKind {
         JStackTraceElement::from_raw(global_ref)
     }
 }

--- a/src/objects/jstring.rs
+++ b/src/objects/jstring.rs
@@ -287,11 +287,11 @@ unsafe impl Reference for JString<'_> {
         Ok(&api.class)
     }
 
-    unsafe fn from_raw<'env>(local_ref: jobject) -> Self::Kind<'env> {
+    unsafe fn kind_from_raw<'env>(local_ref: jobject) -> Self::Kind<'env> {
         JString::from_raw(local_ref)
     }
 
-    unsafe fn from_global_raw(global_ref: jobject) -> Self::GlobalKind {
+    unsafe fn global_kind_from_raw(global_ref: jobject) -> Self::GlobalKind {
         JString::from_raw(global_ref)
     }
 }

--- a/src/objects/jthread.rs
+++ b/src/objects/jthread.rs
@@ -282,11 +282,11 @@ unsafe impl Reference for JThread<'_> {
         Ok(&api.class)
     }
 
-    unsafe fn from_raw<'env>(local_ref: jobject) -> Self::Kind<'env> {
+    unsafe fn kind_from_raw<'env>(local_ref: jobject) -> Self::Kind<'env> {
         JThread::from_raw(local_ref)
     }
 
-    unsafe fn from_global_raw(global_ref: jobject) -> Self::GlobalKind {
+    unsafe fn global_kind_from_raw(global_ref: jobject) -> Self::GlobalKind {
         JThread::from_raw(global_ref)
     }
 }

--- a/src/objects/jthrowable.rs
+++ b/src/objects/jthrowable.rs
@@ -199,11 +199,11 @@ unsafe impl Reference for JThrowable<'_> {
         Ok(&api.class)
     }
 
-    unsafe fn from_raw<'env>(local_ref: jobject) -> Self::Kind<'env> {
+    unsafe fn kind_from_raw<'env>(local_ref: jobject) -> Self::Kind<'env> {
         JThrowable::from_raw(local_ref)
     }
 
-    unsafe fn from_global_raw(global_ref: jobject) -> Self::GlobalKind {
+    unsafe fn global_kind_from_raw(global_ref: jobject) -> Self::GlobalKind {
         JThrowable::from_raw(global_ref)
     }
 }

--- a/src/refs/auto.rs
+++ b/src/refs/auto.rs
@@ -290,11 +290,11 @@ where
         T::lookup_class(env, loader_context)
     }
 
-    unsafe fn from_raw<'env>(local_ref: jobject) -> Self::Kind<'env> {
-        T::from_raw(local_ref)
+    unsafe fn kind_from_raw<'env>(local_ref: jobject) -> Self::Kind<'env> {
+        T::kind_from_raw(local_ref)
     }
 
-    unsafe fn from_global_raw(global_ref: jobject) -> Self::GlobalKind {
-        T::from_global_raw(global_ref)
+    unsafe fn global_kind_from_raw(global_ref: jobject) -> Self::GlobalKind {
+        T::global_kind_from_raw(global_ref)
     }
 }

--- a/src/refs/cast.rs
+++ b/src/refs/cast.rs
@@ -63,7 +63,7 @@ impl<'any, 'from, To: Reference> Cast<'any, 'from, To> {
             unsafe {
                 Ok(Self {
                     _from: PhantomData,
-                    to: To::from_raw::<'any>(from.as_raw()),
+                    to: To::kind_from_raw::<'any>(from.as_raw()),
                 })
             }
         } else {
@@ -119,7 +119,7 @@ impl<'any, 'from, To: Reference> Cast<'any, 'from, To> {
             unsafe {
                 Ok(Self {
                     _from: PhantomData,
-                    to: To::from_raw::<'any>(from.as_raw()),
+                    to: To::kind_from_raw::<'any>(from.as_raw()),
                 })
             }
         } else {
@@ -150,7 +150,7 @@ impl<'any, 'from, To: Reference> Cast<'any, 'from, To> {
         unsafe {
             Self {
                 _from: PhantomData,
-                to: To::from_raw::<'any>(from.as_raw()),
+                to: To::kind_from_raw::<'any>(from.as_raw()),
             }
         }
     }
@@ -179,7 +179,7 @@ impl<'any, 'from, To: Reference> Cast<'any, 'from, To> {
         unsafe {
             Self {
                 _from: PhantomData,
-                to: To::from_raw::<'any>(*from),
+                to: To::kind_from_raw::<'any>(*from),
             }
         }
     }
@@ -218,11 +218,11 @@ unsafe impl<'any, 'from, To: Reference> Reference for Cast<'any, 'from, To> {
         To::lookup_class(env, loader_context)
     }
 
-    unsafe fn from_raw<'env>(local_ref: jobject) -> Self::Kind<'env> {
-        To::from_raw(local_ref)
+    unsafe fn kind_from_raw<'env>(local_ref: jobject) -> Self::Kind<'env> {
+        To::kind_from_raw(local_ref)
     }
 
-    unsafe fn from_global_raw(global_ref: jobject) -> Self::GlobalKind {
-        To::from_global_raw(global_ref)
+    unsafe fn global_kind_from_raw(global_ref: jobject) -> Self::GlobalKind {
+        To::global_kind_from_raw(global_ref)
     }
 }

--- a/src/refs/global.rs
+++ b/src/refs/global.rs
@@ -326,12 +326,12 @@ where
         T::lookup_class(env, loader_context)
     }
 
-    unsafe fn from_raw<'env>(local_ref: jobject) -> Self::Kind<'env> {
-        T::from_raw::<'env>(local_ref)
+    unsafe fn kind_from_raw<'env>(local_ref: jobject) -> Self::Kind<'env> {
+        T::kind_from_raw::<'env>(local_ref)
     }
 
-    unsafe fn from_global_raw(global_ref: jobject) -> Self::GlobalKind {
-        T::from_global_raw(global_ref)
+    unsafe fn global_kind_from_raw(global_ref: jobject) -> Self::GlobalKind {
+        T::global_kind_from_raw(global_ref)
     }
 }
 

--- a/src/refs/reference.rs
+++ b/src/refs/reference.rs
@@ -130,7 +130,7 @@ pub unsafe trait Reference: Sized {
     ///
     /// You are responsible to knowing that `Self::Kind` is a suitable wrapper type for the given
     /// `reference`. E.g. because the `reference` came from an `into_raw` call from the same type.
-    unsafe fn from_raw<'env>(reference: jobject) -> Self::Kind<'env>;
+    unsafe fn kind_from_raw<'env>(reference: jobject) -> Self::Kind<'env>;
 
     /// Returns a (`'static`) reference type based on [`Self::GlobalKind`] for the given `global_ref`.
     ///
@@ -143,7 +143,7 @@ pub unsafe trait Reference: Sized {
     /// given `global_ref` reference. E.g. because the `global_ref` came from an `into_raw`
     /// call from the same type.
     ///
-    unsafe fn from_global_raw(global_ref: jobject) -> Self::GlobalKind;
+    unsafe fn global_kind_from_raw(global_ref: jobject) -> Self::GlobalKind;
 }
 
 /// Represents the context that influences how a class may be loaded.
@@ -389,11 +389,11 @@ where
         T::lookup_class(env, loader_context)
     }
 
-    unsafe fn from_raw<'env>(local_ref: jobject) -> Self::Kind<'env> {
-        T::from_raw(local_ref)
+    unsafe fn kind_from_raw<'env>(local_ref: jobject) -> Self::Kind<'env> {
+        T::kind_from_raw(local_ref)
     }
 
-    unsafe fn from_global_raw(global_ref: jobject) -> Self::GlobalKind {
-        T::from_global_raw(global_ref)
+    unsafe fn global_kind_from_raw(global_ref: jobject) -> Self::GlobalKind {
+        T::global_kind_from_raw(global_ref)
     }
 }

--- a/src/refs/weak.rs
+++ b/src/refs/weak.rs
@@ -302,12 +302,12 @@ where
         T::lookup_class(env, loader_context)
     }
 
-    unsafe fn from_raw<'env>(local_ref: jobject) -> Self::Kind<'env> {
-        T::from_raw(local_ref)
+    unsafe fn kind_from_raw<'env>(local_ref: jobject) -> Self::Kind<'env> {
+        T::kind_from_raw(local_ref)
     }
 
-    unsafe fn from_global_raw(global_ref: jobject) -> Self::GlobalKind {
-        T::from_global_raw(global_ref)
+    unsafe fn global_kind_from_raw(global_ref: jobject) -> Self::GlobalKind {
+        T::global_kind_from_raw(global_ref)
     }
 }
 


### PR DESCRIPTION
The renames `Reference::from_raw` to `kind_from_raw` to avoid being confused for a method that will return a `Self` for some raw JNI reference.

NB: For generic wrappers like `Global<T>`, `Weak<T>`, `Auto<T>` and `Cast<T>`, the associated `Kind` type that `Reference::from_raw` constructs is actually for the inner `<T>`, not for `Self`.

For consistency this also renames `from_global_raw` to `global_kind_from_raw`.

Fixes: #661
