### PR TITLE
Add Env::as_cast_unchecked for unsafe downcasts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `Env::new_cast_local_ref` acts like `new_local_ref` with a type cast ([#612](https://github.com/jni-rs/jni-rs/pull/612))
 - `Env::cast_local` takes an owned local reference and returns a new type-cast wrapper (owned) ([#612](https://github.com/jni-rs/jni-rs/pull/612))
 - `Env::as_cast` or `Cast::new` borrows any `From: Reference` (global or local) reference and returns  a `Cast<To>` that will Deref into `&To` ([#612](https://github.com/jni-rs/jni-rs/pull/612))
+- `Env::as_cast_unchecked` returns a `Cast<To>` like `as_cast()` but without a runtime `IsInstanceOf` check ([#669](https://github.com/jni-rs/jni-rs/pull/669))
 - `Env::as_cast_raw` or `Cast::from_raw` borrows a raw `jobject` reference and returns a `Cast<To>` that will Deref into `&To`
 - `Cast::new_unchecked` and `Cast::from_raw_unchecked` let you borrow a reference with an (`unsafe`) type cast, with no runtime check
 

--- a/src/env.rs
+++ b/src/env.rs
@@ -1545,6 +1545,41 @@ impl<'local> Env<'local> {
         Cast::new(self, obj)
     }
 
+    /// Cast a reference (local or global) to a different type without consuming
+    /// it and without any runtime checks.
+    ///
+    /// This method borrows the input reference and returns a wrapper that
+    /// derefs to the target type. The original reference remains valid and can
+    /// be used after the cast operation.
+    ///
+    /// # Example
+    /// ```rust,no_run
+    /// # use jni::{errors::Result, Env, objects::*};
+    /// #
+    /// # fn example(env: &mut Env) -> Result<()> {
+    /// let obj: JObject = env.new_object(c"java/lang/String", c"()V", &[])?;
+    /// let string_ref = unsafe { env.as_cast_unchecked::<JString>(&obj) };
+    /// // obj is still valid here
+    /// let empty_string_contents = string_ref.to_string();
+    /// # Ok(())
+    /// # }
+    /// ```
+    ///
+    /// # Safety
+    ///
+    /// The caller must ensure that `obj` is a valid instance of `To`, or
+    /// `null`.
+    pub unsafe fn as_cast_unchecked<'from, 'any, To>(
+        &self,
+        obj: &'from (impl Reference + AsRef<JObject<'any>>),
+    ) -> Cast<'from, 'any, To>
+    where
+        To: Reference,
+        'any: 'from,
+    {
+        Cast::new_unchecked(obj)
+    }
+
     /// Attempts to cast a raw [`jobject`] reference without taking ownership.
     ///
     /// This method borrows the input reference and returns a wrapper that


### PR DESCRIPTION
`Env::as_cast_unchecked` returns a `Cast<To>` like `as_cast()` but without a runtime `IsInstanceOf` check