### PR TITLE
Consistent `from_raw`, `cast_local` and `null` methods for `Reference` types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `Env::as_cast_unchecked` returns a `Cast<To>` like `as_cast()` but without a runtime `IsInstanceOf` check ([#669](https://github.com/jni-rs/jni-rs/pull/669))
 - `Env::as_cast_raw` or `Cast::from_raw` borrows a raw `jobject` reference and returns a `Cast<To>` that will Deref into `&To`
 - `Cast::new_unchecked` and `Cast::from_raw_unchecked` let you borrow a reference with an (`unsafe`) type cast, with no runtime check
+- `::cast_local()` methods as a convenience for all reference types, such as `let s = JString::cast_local(obj)`
+- `const` `null()` methods for all reference types.
 
 #### JNI Environment APIs
 
@@ -125,7 +127,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `JavaVM::get_java_vm_pointer` has been renamed `JavaVM::get_raw` for consistency.
 - `JavaVM::new` and `JavaVM::with_libjvm` now prevent libjvm from being unloaded. This isn't necessary for HotSpot, but other JVMs could crash if we don't do this. ([#554](https://github.com/jni-rs/jni-rs/pull/554))
 - `JValueGen` has been removed. `JValue` and `JValueOwned` are now separate, unrelated, non-generic types. ([#429](https://github.com/jni-rs/jni-rs/pull/429))
-- Make most `from_raw()`, `get_raw()` and `into_raw()` methods `const fn`. ([#453](https://github.com/jni-rs/jni-rs/pull/453))
+- Make `from_raw()`, `into_raw()` and `null()` methods `const fn`. ([#453](https://github.com/jni-rs/jni-rs/pull/453))
+- Make `from_raw()` require an `Env` reference so the returned wrapper is guaranteed to have a local reference frame lifetime ([#670](https://github.com/jni-rs/jni-rs/pull/670))
 - `get_object_class` borrows the `Env` mutably because it creates a new local reference. ([#456](https://github.com/jni-rs/jni-rs/pull/456))
 - `get/set_*_field_unchecked` have been marked as unsafe since they can lead to undefined behaviour if the given types don't match the field type ([#457](https://github.com/jni-rs/jni-rs/pull/457) + [#629](https://github.com/jni-rs/jni-rs/pull/629))
 - `set_static_field` takes a field name and signature as strings so the ID is looked up internally to ensure it's valid. ([#629](https://github.com/jni-rs/jni-rs/pull/629))

--- a/src/refs/cast.rs
+++ b/src/refs/cast.rs
@@ -92,7 +92,7 @@ impl<'any, 'from, To: Reference> Cast<'any, 'from, To> {
     where
         'any: 'from,
     {
-        let from = JObject::from_raw(*from);
+        let from = JObject::from_raw(env, *from);
         let from = &from; // make it clear, we don't own `from`
 
         // Note we can't just chain up to Cast::new since the from lifetime would be incorrect.
@@ -131,7 +131,7 @@ impl<'any, 'from, To: Reference> Cast<'any, 'from, To> {
     ///
     /// # Safety
     ///
-    /// The caller must ensure that `from` is an instance of `To`.
+    /// The caller must ensure that `from` is an instance of `To`, or null.
     pub unsafe fn new_unchecked<From: Reference + AsRef<JObject<'any>>>(from: &'from From) -> Self
     where
         'any: 'from,

--- a/src/refs/reference.rs
+++ b/src/refs/reference.rs
@@ -115,6 +115,13 @@ pub unsafe trait Reference: Sized {
     /// Returns a new reference type based on [`Self::Kind`] for the given `reference` that is tied
     /// to the specified lifetime.
     ///
+    /// This method in generally only expected to be used internally or when implementing your own
+    /// reference wrapper types.
+    ///
+    /// You should always prefer to use wrapper-provided `::from_raw()` methods (Such as
+    /// `JString::from_raw()`) for wrapping raw local references because those will guarantee that
+    /// the returned reference has a lifetime that's tied to a valid local reference frame.
+    ///
     /// # Safety
     ///
     /// There must not be no other owning wrapper for the given `reference` (unless it is `null`)
@@ -125,8 +132,8 @@ pub unsafe trait Reference: Sized {
     /// limits them to a single JNI stack frame.
     ///
     /// This can also be used to create a borrowed view of a global reference (e.g. as part of a
-    /// type cast), which may be associated with a `'static` lifetime only so long as the lifetime of
-    /// the view is limited by borrowing from the original global wrapper.
+    /// type cast), which may be associated with a `'static` lifetime only so long as the lifetime
+    /// of the view is limited by borrowing from the original global wrapper.
     ///
     /// You are responsible to knowing that `Self::Kind` is a suitable wrapper type for the given
     /// `reference`. E.g. because the `reference` came from an `into_raw` call from the same type.

--- a/tests/jni_api.rs
+++ b/tests/jni_api.rs
@@ -1228,8 +1228,8 @@ pub fn get_direct_buffer_capacity_ok() {
 #[test]
 pub fn get_direct_buffer_capacity_wrong_arg() {
     attach_current_thread(|env| {
-        let wrong_obj =
-            unsafe { JByteBuffer::from_raw(env.new_string(c"wrong").unwrap().into_raw()) };
+        let wrong_type = env.new_string(c"wrong").unwrap();
+        let wrong_obj = unsafe { JByteBuffer::from_raw(env, wrong_type.into_raw()) };
         let capacity = env.get_direct_buffer_capacity(&wrong_obj);
         assert!(capacity.is_err());
 
@@ -1276,7 +1276,7 @@ pub fn get_direct_buffer_address_wrong_arg() {
 
         // SAFETY: This is not a valid cast and not generally safe but `GetDirectBufferAddress` is
         // documented to return a null pointer in case the "given object is not a direct java.nio.Buffer".
-        let wrong_obj = unsafe { JByteBuffer::from_raw(wrong_obj.into_raw()) };
+        let wrong_obj = unsafe { JByteBuffer::from_raw(env, wrong_obj.into_raw()) };
         let result = env.get_direct_buffer_address(&wrong_obj);
         assert!(result.is_err());
 
@@ -1694,7 +1694,7 @@ fn test_jstring_conversion() {
     //
     // Alternatively the only other way we could test this case would be with a
     // native method callback which is hard to reproduce here.
-    let invalid = unsafe { JString::from_raw(1 as _) };
+    let invalid = unsafe { JString::kind_from_raw(1 as _) };
     assert_eq!(invalid.to_string(), "<JNI Not Initialized>");
 
     attach_current_thread(|env| {
@@ -1712,7 +1712,7 @@ fn test_jstring_conversion() {
 #[test]
 pub fn test_null_string_mutf8_chars() {
     attach_current_thread(|env| {
-        let s = unsafe { JString::from_raw(std::ptr::null_mut() as _) };
+        let s = unsafe { JString::from_raw(env, std::ptr::null_mut() as _) };
         let ret = s.mutf8_chars(env);
         assert!(ret.is_err());
 


### PR DESCRIPTION
This does a pass over all reference types to ensure they have consistent `from_raw`, `cast_local` and `null` methods.

The `from_raw` methods now all require an `env: Env<'local>` argument so we can guarantee that the returned wrapper is tied to a valid local reference frame. This ensures the API is only used with valid local references and can't be used to create wrappers that have a `'static` lifetime. (`Env::global_from_raw` can instead be used for global references that need a `'static` lifetime).

Requiring an `env` argument for `from_raw` methods is also important for being able to assume that if code ever observes a `Reference` type with a `'local` lifetime then that should be enough to prove that 1) JavaVM::singleton() is initialized and 2) the current thread must be attached to the JVM.

Even though there is a `Reference::null()` method, we add an explicit `null()` method for each reference type that is `const`.

The descriptions for all reference types are now also consistent and refer to the `java.*` type that they wrap.
