### PR TITLE
Use rust 2024 edition's `crate-type`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -86,7 +86,7 @@
 //! need to make a couple of changes to `Cargo.toml` before we do anything else.
 //!
 //! * Under `[dependencies]`, add `jni = "0.22"`
-//! * Add a new `[lib]` section and under it, `crate_type = ["cdylib"]`.
+//! * Add a new `[lib]` section and under it, `crate-type = ["cdylib"]`.
 //!
 //! Now, if you run `cargo build` from inside the crate directory, you should
 //! see a `libmylib.so` (if you're on Linux) or a `libmylib.dylib` (if you are


### PR DESCRIPTION
## Overview

The docs state to use `crate_type` in `Cargo.toml`,  but this isn't correct for the 2024 edition:

```
$ cargo build
error: failed to parse manifest at `/home/maarten/code/rules-engine/Cargo.toml`

Caused by:
  `crate_type` is unsupported as of the 2024 edition; instead use `crate-type`
  (in the `rules_engine` library target)
```

### Definition of Done

- [ ] There are no TODOs left in the code
- [ ] Change is covered by [automated tests](https://github.com/jni-rs/jni-rs/blob/master/CONTRIBUTING.md#tests)
- [ ] The [coding guidelines](https://github.com/jni-rs/jni-rs/blob/master/CONTRIBUTING.md#the-code-style) are followed
- [ ] Public API has documentation
- [ ] User-visible changes are mentioned in the Changelog
- [ ] The continuous integration build passes
