### PR TITLE
clippy fix: use `.to_bytes()` for comparison in `PartialEq<JNIString> for &JNIStr`

### DIFF
--- a/src/strings/ffi_str.rs
+++ b/src/strings/ffi_str.rs
@@ -92,7 +92,10 @@ impl AsRef<JNIStr> for CStr {
 impl PartialEq<JNIString> for &JNIStr {
     #[inline]
     fn eq(&self, other: &JNIString) -> bool {
-        &self.internal == other.internal.as_c_str()
+        // PartialEq<&CStr> was only added in Rust 1.90 which is currently higher
+        // than our MSRV, so we compare by bytes to also avoid clippy warnings
+        // with newer Rust versions.
+        self.internal.to_bytes() == other.internal.to_bytes()
     }
 }
 


### PR DESCRIPTION
`PartialEq<&CStr>` for `CStr` was only added in 1.90 and so we use `.to_bytes()` to compare since that works with our MSRV (1.77) and also avoids a clippy warning from relying on `PartialEq<CStr>`.