### PR TITLE
Reference: have `lookup_class` take a `LoaderContext` reference

### DIFF
--- a/src/env.rs
+++ b/src/env.rs
@@ -703,13 +703,13 @@ See the jni-rs Env documentation for more details.
 
     /// Checks if an object can be cast to a specific reference type.
     pub(crate) fn is_instance_of_cast_type<To: Reference>(&self, obj: &JObject) -> Result<bool> {
-        let class = match To::lookup_class(self, LoaderContext::FromObject(obj)) {
+        let class = match To::lookup_class(self, &LoaderContext::FromObject(obj)) {
             Ok(class) => class,
             Err(Error::ClassNotFound { name: _ }) => return Ok(false),
             Err(e) => return Err(e),
         };
 
-        let class: &JClass = class.as_ref();
+        let class: &JClass = &class;
         self.is_instance_of_class(obj, class)
     }
 
@@ -839,8 +839,8 @@ See the jni-rs Env documentation for more details.
     // FIXME: this API shouldn't need a `&mut self` reference since it doesn't return a local reference
     // (currently it just needs the `&mut self` for the sake of `Desc<JClass>::lookup`)
     fn throw_new_optional(&self, class: &JClass, msg: Option<&JNIStr>) -> Result<()> {
-        let throwable_class = JThrowable::lookup_class(self, LoaderContext::None)?;
-        let throwable_class: &JClass = throwable_class.as_ref();
+        let throwable_class = JThrowable::lookup_class(self, &LoaderContext::None)?;
+        let throwable_class: &JClass = &throwable_class;
 
         if !self.is_assignable_from_class(class.as_ref(), throwable_class)? {
             return Err(Error::WrongObjectType);
@@ -2905,7 +2905,7 @@ See the jni-rs Env documentation for more details.
         // Runtime check that the 'local reference lifetime will be tied to
         // Env lifetime for the top JNI stack frame
         self.assert_top();
-        let class = E::lookup_class(self, LoaderContext::None)?;
+        let class = E::lookup_class(self, &LoaderContext::None)?;
 
         let array = unsafe {
             jni_call_check_ex_and_null_ret!(

--- a/src/objects/jbytebuffer.rs
+++ b/src/objects/jbytebuffer.rs
@@ -132,9 +132,9 @@ unsafe impl Reference for JByteBuffer<'_> {
 
     fn lookup_class<'caller>(
         env: &Env<'_>,
-        loader_context: LoaderContext,
+        loader_context: &LoaderContext,
     ) -> crate::errors::Result<impl Deref<Target = Global<JClass<'static>>> + 'caller> {
-        let api = JByteBufferAPI::get(env, &loader_context)?;
+        let api = JByteBufferAPI::get(env, loader_context)?;
         Ok(&api.class)
     }
     unsafe fn kind_from_raw<'env>(local_ref: jobject) -> Self::Kind<'env> {

--- a/src/objects/jclass.rs
+++ b/src/objects/jclass.rs
@@ -261,7 +261,7 @@ unsafe impl Reference for JClass<'_> {
 
     fn lookup_class<'caller>(
         env: &Env<'_>,
-        _loader_context: LoaderContext,
+        _loader_context: &LoaderContext,
     ) -> crate::errors::Result<impl Deref<Target = Global<JClass<'static>>> + 'caller> {
         // As a special-case; we ignore loader_context just to be clear that there's no risk of
         // recursion. (`LoaderContext::load_class` depends on the `JClassAPI`)

--- a/src/objects/jclass_loader.rs
+++ b/src/objects/jclass_loader.rs
@@ -176,7 +176,7 @@ unsafe impl Reference for JClassLoader<'_> {
 
     fn lookup_class<'caller>(
         env: &Env<'_>,
-        _loader_context: LoaderContext,
+        _loader_context: &LoaderContext,
     ) -> crate::errors::Result<impl Deref<Target = Global<JClass<'static>>> + 'caller> {
         // As a special-case; we ignore loader_context just to be clear that there's no risk of
         // recursion. (`LoaderContext::load_class` depends on the `JClassLoaderAPI`)

--- a/src/objects/jcollection.rs
+++ b/src/objects/jcollection.rs
@@ -299,9 +299,9 @@ unsafe impl Reference for JCollection<'_> {
 
     fn lookup_class<'caller>(
         env: &Env<'_>,
-        loader_context: LoaderContext,
+        loader_context: &LoaderContext,
     ) -> crate::errors::Result<impl Deref<Target = Global<JClass<'static>>> + 'caller> {
-        let api = JCollectionAPI::get(env, &loader_context)?;
+        let api = JCollectionAPI::get(env, loader_context)?;
         Ok(&api.class)
     }
 

--- a/src/objects/jiterator.rs
+++ b/src/objects/jiterator.rs
@@ -221,9 +221,9 @@ unsafe impl Reference for JIterator<'_> {
     }
     fn lookup_class<'caller>(
         env: &Env<'_>,
-        loader_context: LoaderContext,
+        loader_context: &LoaderContext,
     ) -> crate::errors::Result<impl Deref<Target = Global<JClass<'static>>> + 'caller> {
-        let api = JIteratorAPI::get(env, &loader_context)?;
+        let api = JIteratorAPI::get(env, loader_context)?;
         Ok(&api.class)
     }
 

--- a/src/objects/jlist.rs
+++ b/src/objects/jlist.rs
@@ -344,9 +344,9 @@ unsafe impl Reference for JList<'_> {
 
     fn lookup_class<'caller>(
         env: &Env<'_>,
-        loader_context: LoaderContext,
+        loader_context: &LoaderContext,
     ) -> crate::errors::Result<impl Deref<Target = Global<JClass<'static>>> + 'caller> {
-        let api = JListAPI::get(env, &loader_context)?;
+        let api = JListAPI::get(env, loader_context)?;
         Ok(&api.class)
     }
 

--- a/src/objects/jmap.rs
+++ b/src/objects/jmap.rs
@@ -312,9 +312,9 @@ unsafe impl Reference for JMap<'_> {
 
     fn lookup_class<'caller>(
         env: &Env<'_>,
-        loader_context: LoaderContext,
+        loader_context: &LoaderContext,
     ) -> crate::errors::Result<impl Deref<Target = Global<JClass<'static>>> + 'caller> {
-        let api = JMapAPI::get(env, &loader_context)?;
+        let api = JMapAPI::get(env, loader_context)?;
         Ok(&api.class)
     }
 
@@ -519,9 +519,9 @@ unsafe impl Reference for JMapEntry<'_> {
 
     fn lookup_class<'caller>(
         env: &Env<'_>,
-        loader_context: LoaderContext,
+        loader_context: &LoaderContext,
     ) -> crate::errors::Result<impl Deref<Target = Global<JClass<'static>>> + 'caller> {
-        let api = JMapEntryAPI::get(env, &loader_context)?;
+        let api = JMapEntryAPI::get(env, loader_context)?;
         Ok(&api.class)
     }
 

--- a/src/objects/jobject.rs
+++ b/src/objects/jobject.rs
@@ -160,7 +160,7 @@ unsafe impl Reference for JObject<'_> {
 
     fn lookup_class<'caller>(
         env: &Env<'_>,
-        _loader_context: LoaderContext,
+        _loader_context: &LoaderContext,
     ) -> crate::errors::Result<impl Deref<Target = Global<JClass<'static>>> + 'caller> {
         // As a special-case; we ignore loader_context just to be clear that there's no risk of
         // recursion. (`LoaderContext::load_class` depends on the `JObjectAPI`)

--- a/src/objects/jobject_array.rs
+++ b/src/objects/jobject_array.rs
@@ -270,9 +270,9 @@ unsafe impl<'local, E: Reference + 'local> Reference for JObjectArray<'local, E>
 
     fn lookup_class<'caller>(
         env: &Env<'_>,
-        loader_context: LoaderContext,
+        loader_context: &LoaderContext,
     ) -> crate::errors::Result<impl Deref<Target = Global<JClass<'static>>> + 'caller> {
-        let api = JObjectArrayAPI::<E::GlobalKind>::get(env, &loader_context)?;
+        let api = JObjectArrayAPI::<E::GlobalKind>::get(env, loader_context)?;
         Ok(&api.class)
     }
 

--- a/src/objects/jprimitive_array.rs
+++ b/src/objects/jprimitive_array.rs
@@ -424,7 +424,7 @@ macro_rules! impl_ref_for_jprimitive_array {
 
                 fn lookup_class<'caller>(
                     env: &Env<'_>,
-                    loader_context: LoaderContext,
+                    loader_context: &LoaderContext,
                 ) -> crate::errors::Result<impl Deref<Target = Global<JClass<'static>>> + 'caller> {
                     let api = [<JPrimitiveArrayAPI _ $type>]::get(env, &loader_context)?;
                     Ok(&api.class)

--- a/src/objects/jset.rs
+++ b/src/objects/jset.rs
@@ -225,9 +225,9 @@ unsafe impl Reference for JSet<'_> {
 
     fn lookup_class<'caller>(
         env: &Env<'_>,
-        loader_context: LoaderContext,
+        loader_context: &LoaderContext,
     ) -> crate::errors::Result<impl Deref<Target = Global<JClass<'static>>> + 'caller> {
-        let api = JSetAPI::get(env, &loader_context)?;
+        let api = JSetAPI::get(env, loader_context)?;
         Ok(&api.class)
     }
 

--- a/src/objects/jstack_trace_element.rs
+++ b/src/objects/jstack_trace_element.rs
@@ -270,9 +270,9 @@ unsafe impl Reference for JStackTraceElement<'_> {
 
     fn lookup_class<'caller>(
         env: &Env<'_>,
-        loader_context: LoaderContext,
+        loader_context: &LoaderContext,
     ) -> crate::errors::Result<impl Deref<Target = Global<JClass<'static>>> + 'caller> {
-        let api = JStackTraceElementAPI::get(env, &loader_context)?;
+        let api = JStackTraceElementAPI::get(env, loader_context)?;
         Ok(&api.class)
     }
 

--- a/src/objects/jstring.rs
+++ b/src/objects/jstring.rs
@@ -311,9 +311,9 @@ unsafe impl Reference for JString<'_> {
 
     fn lookup_class<'caller>(
         env: &Env<'_>,
-        loader_context: LoaderContext,
+        loader_context: &LoaderContext,
     ) -> crate::errors::Result<impl Deref<Target = Global<JClass<'static>>> + 'caller> {
-        let api = JStringAPI::get(env, &loader_context)?;
+        let api = JStringAPI::get(env, loader_context)?;
         Ok(&api.class)
     }
 

--- a/src/objects/jthread.rs
+++ b/src/objects/jthread.rs
@@ -306,7 +306,7 @@ unsafe impl Reference for JThread<'_> {
 
     fn lookup_class<'caller>(
         env: &Env<'_>,
-        _loader_context: LoaderContext,
+        _loader_context: &LoaderContext,
     ) -> crate::errors::Result<impl Deref<Target = Global<JClass<'static>>> + 'caller> {
         // As a special-case; we ignore loader_context just to be clear that there's no risk of
         // recursion. (`LoaderContext::load_class` depends on the `JThreadAPI`)

--- a/src/objects/jthrowable.rs
+++ b/src/objects/jthrowable.rs
@@ -228,9 +228,9 @@ unsafe impl Reference for JThrowable<'_> {
 
     fn lookup_class<'caller>(
         env: &Env<'_>,
-        loader_context: LoaderContext,
+        loader_context: &LoaderContext,
     ) -> crate::errors::Result<impl Deref<Target = Global<JClass<'static>>> + 'caller> {
-        let api = JThrowableAPI::get(env, &loader_context)?;
+        let api = JThrowableAPI::get(env, loader_context)?;
         Ok(&api.class)
     }
 

--- a/src/refs/auto.rs
+++ b/src/refs/auto.rs
@@ -285,7 +285,7 @@ where
 
     fn lookup_class<'caller>(
         env: &Env<'_>,
-        loader_context: LoaderContext,
+        loader_context: &LoaderContext,
     ) -> crate::errors::Result<impl Deref<Target = Global<JClass<'static>>> + 'caller> {
         T::lookup_class(env, loader_context)
     }

--- a/src/refs/cast.rs
+++ b/src/refs/cast.rs
@@ -213,7 +213,7 @@ unsafe impl<'any, 'from, To: Reference> Reference for Cast<'any, 'from, To> {
 
     fn lookup_class<'caller>(
         env: &Env<'_>,
-        loader_context: LoaderContext,
+        loader_context: &LoaderContext,
     ) -> crate::errors::Result<impl Deref<Target = Global<JClass<'static>>> + 'caller> {
         To::lookup_class(env, loader_context)
     }

--- a/src/refs/global.rs
+++ b/src/refs/global.rs
@@ -308,7 +308,7 @@ where
 
     fn lookup_class<'caller>(
         env: &Env<'_>,
-        loader_context: LoaderContext,
+        loader_context: &LoaderContext,
     ) -> crate::errors::Result<impl Deref<Target = Global<JClass<'static>>> + 'caller> {
         T::lookup_class(env, loader_context)
     }

--- a/src/refs/reference.rs
+++ b/src/refs/reference.rs
@@ -118,7 +118,7 @@ pub unsafe trait Reference: Sized {
     /// #
     /// # fn example<'local>(env: &mut Env<'local>) -> Result<()> {
     /// use jni::objects::{JString, Reference as _, LoaderContext};
-    /// let string_class = JString::lookup_class(env, LoaderContext::None)?;
+    /// let string_class = JString::lookup_class(env, &LoaderContext::None)?;
     /// let string_class_ref: &JClass = string_class.as_ref();
     /// # Ok(())
     /// # }
@@ -140,7 +140,7 @@ pub unsafe trait Reference: Sized {
     ///
     fn lookup_class<'caller>(
         env: &Env<'_>,
-        loader_context: LoaderContext,
+        loader_context: &LoaderContext,
     ) -> crate::errors::Result<impl Deref<Target = Global<JClass<'static>>> + 'caller>;
 
     /// Returns a new reference type based on [`Self::Kind`] for the given `reference` that is tied
@@ -422,7 +422,7 @@ where
 
     fn lookup_class<'caller>(
         env: &Env<'_>,
-        loader_context: LoaderContext,
+        loader_context: &LoaderContext,
     ) -> crate::errors::Result<impl Deref<Target = Global<JClass<'static>>> + 'caller> {
         T::lookup_class(env, loader_context)
     }

--- a/src/refs/weak.rs
+++ b/src/refs/weak.rs
@@ -297,7 +297,7 @@ where
 
     fn lookup_class<'caller>(
         env: &Env<'_>,
-        loader_context: LoaderContext,
+        loader_context: &LoaderContext,
     ) -> crate::errors::Result<impl Deref<Target = Global<JClass<'static>>> + 'caller> {
         T::lookup_class(env, loader_context)
     }


### PR DESCRIPTION
It was a mistake for the `LoaderContext` to be passed to `Reference::lookup_class` by value instead of by reference, while code that's given a `LoaderContext` might need to make multiple different lookups with the same context.

