### PR TITLE
make env::NativeMethod transparent JNINativeMethod wrapper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -176,6 +176,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `Desc<JClass>::lookup()` is now based on `LoaderContext::load_class` (instead of `Env::find_class`), which checks for a thread context class loader by default.
 - `AutoElements[Critical]::discard()` now takes ownership of the elements and drops them to release the pointer after setting the mode to `NoCopyBack` ([#645](https://github.com/jni-rs/jni-rs/pull/645))
 - Mark `MonitorGuard` with `#[must_use]` to warn when the guard is dropped accidentally ([#676](https://github.com/jni-rs/jni-rs/pull/676))
+- `NativeMethod` (used with `Env::register_native_methods`) is a now a transparent `jni::sys::JNINativeWrapper` wrapper with an `unsafe` `::from_raw_parts` constructor.
 
 ### Fixed
 - `Env::get_string` no longer leaks local references. ([#528](https://github.com/jni-rs/jni-rs/pull/528), [#557](https://github.com/jni-rs/jni-rs/pull/557))


### PR DESCRIPTION
This makes `env::NativeMethod` a transparent wrapper for `JNINativeMethod` with an `unsafe` `::from_raw_parts()` constructor.

This makes it clearer what the safety concerns are with constructing a `NativeMethod` descriptor and also avoids the need to allocate an intermediate `Vec` within `Env::register_native_methods()`

There is also a plan to implement a `native_method!()` macro that can safely construct a `NativeMethod` by guaranteeing that the function matches the given JNI signature.

Even with `::from_raw_parts()` being `unsafe` we still _also_ keep `register_native_methods()` as `unsafe` due to the risk of muddling up the signature for static vs instance methods, which won't be something that can verified at compile time just via a `native_method!` macro.

### Definition of Done

- [x] There are no TODOs left in the code
- [ ] Change is covered by [automated tests](https://github.com/jni-rs/jni-rs/blob/master/CONTRIBUTING.md#tests)
- [x] The [coding guidelines](https://github.com/jni-rs/jni-rs/blob/master/CONTRIBUTING.md#the-code-style) are followed
- [x] Public API has documentation
- [x] User-visible changes are mentioned in the Changelog
- [x] The continuous integration build passes
