### PR TITLE
Add `MethodSignature` and `FieldSignature` types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `Env::throw_new_void` provides an easy way to throw an exception that's constructed with no message argument
 - `Env::new_object_type_array<E>` lets you you instantiate a `JObjectArray` with a given element type like `new_object_type_array::<JString>`
 - `Env::load_class` supports class lookups via the current `Thread` context class loader, with `FindClass` fallback. ([#674](https://github.com/jni-rs/jni-rs/pull/674))
+- `MethodSignature` and `FieldSignature` types have been added for compile-time parsed JNI method and field signatures
 
 #### Native Method APIs
 


### PR DESCRIPTION
These structs represent parsed JNI method or field signatures respectively.

Although these types are not yet used, the plan is to implement a `jni_sig!()` proc macro that can parse and validate JNI signatures at compile time and use these structs to output a MUTF-8 encoded signature literal as well as JavaTypes for method arguments, return values and field types.

Once we have the macro, then we can update the Env APIs for method calls and getting/setting fields to expect these types.

Right now there is a big trade off between the safe vs `_unchecked` APIs for making JNI method calls since the safe APIs are forced to do so much in order to guarantee safety. It would be nice if we could at least remove the need for re-parsing signatures at runtime every time a method call is made (and avoid heap allocating the JavaTypes for arguments every call).

### Definition of Done

- [x] There are no TODOs left in the code
- [ ] Change is covered by [automated tests](https://github.com/jni-rs/jni-rs/blob/master/CONTRIBUTING.md#tests)
- [x] The [coding guidelines](https://github.com/jni-rs/jni-rs/blob/master/CONTRIBUTING.md#the-code-style) are followed
- [x] Public API has documentation
- [x] User-visible changes are mentioned in the Changelog
- [ ] The continuous integration build passes
