### PR TITLE
Add `JObjectArray::new` and `JPrimitiveArray::new` constructor methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,7 +90,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `JList::clear` allows a list to be cleared.
 - `JList::is_empty` checks if a list is empty.
 - `JList::as_collection` casts a list into a `JCollection`
+- `JObjectArray::new` lets you construct a `JObjectArray<E>` with strong element type parameterization, instead of `Env::new_object_array`
 - `JObjectArray::get/set_element` let you get and set array elements as methods on the array.
+- `JPrimitiveArray::new` lets you construct a `JPrimitiveArray<E>`, consistent with `JObjectArray::new`
 - `JThrowable::get_message` is a binding for `getMessage()` and gives easy access to an exception message
 - `JThrowable::get_stack_trace` is a binding for `getStackTrace()`, returning a `JObjectArray<JStackTraceElement>`
 - `JStackTraceElement` gives access to stack frame info within a stack trace, like filename, line number etc
@@ -171,6 +173,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `Env::get_*_array_region` and `Env::set_*_array_region` are deprecated in favor of `JPrimitiveArray::get/set_region`
 - `Env::get_array_length` is deprecated in favor of `JPrimitiveArray::len` and `JObjectArray::len`
 - `Env::get/set_object_array_element` are deprecated in favor of `JObjectArray::get/set_element`
+- `Env::new_*_array` methods for primitive array types (like `JByteArray`) take a `&mut Env` and a `usize` len, and the docs recommend using `J<Type>Array::new()` instead.
 - `Env::new_object_unchecked` now takes a `Desc<JMethodID>` for consistency/flexibility instead of directly taking a `JMethodID`
 - `JObjectArray` supports generic element types like `JObjectArray<JString>`
 - `AutoLocal` has been renamed to `Auto` with a deprecated type alias for `AutoLocal` to sign post the rename.

--- a/src/objects/type_array.rs
+++ b/src/objects/type_array.rs
@@ -19,6 +19,9 @@ pub(crate) mod type_array_sealed {
     ///
     /// The `release` method must not invalidate the `ptr` if the `mode` is [`sys::JNI_COMMIT`].
     pub unsafe trait TypeArraySealed: Copy + Send + Sync {
+        /// Creates a new array of this type with the given length.
+        unsafe fn new_array(env: &mut Env, length: jsize) -> Result<jarray>;
+
         /// getter
         ///
         /// # Safety
@@ -84,8 +87,15 @@ pub(crate) mod type_array_sealed {
     macro_rules! type_array {
         ( $jni_type:ty, $jni_type_name:ident) => {
             paste! {
+
                 /// $jni_type array access/release impl
                 unsafe impl TypeArraySealed for $jni_type {
+                    /// Create new Java $jni_type array
+                    unsafe fn new_array(env: &mut Env, length: jsize) -> Result<jarray> {
+                        let raw_array = jni_call_check_ex_and_null_ret!(env, v1_1, [< New $jni_type_name Array>], length)?;
+                        Ok(raw_array)
+                    }
+
                     /// Get Java $jni_type array
                     unsafe fn get_elements(
                         env: &Env,

--- a/tests/jni_api.rs
+++ b/tests/jni_api.rs
@@ -13,7 +13,7 @@ use jni::{
     refs::Reference,
     signature::{JavaType, Primitive, ReturnType},
     strings::{JNIStr, JNIString},
-    sys::{jboolean, jbyte, jchar, jdouble, jfloat, jint, jlong, jobject, jshort, jsize},
+    sys::{jboolean, jbyte, jchar, jdouble, jfloat, jint, jlong, jshort},
     Env,
 };
 
@@ -1346,7 +1346,7 @@ pub fn get_direct_buffer_address_null_arg() {
 #[test]
 pub fn new_primitive_array_ok() {
     attach_current_thread(|env| {
-        const SIZE: jsize = 16;
+        const SIZE: usize = 16;
 
         let result = env.new_boolean_array(SIZE);
         assert!(result.is_ok());
@@ -1387,41 +1387,33 @@ pub fn new_primitive_array_ok() {
 
 // Group test for testing the family of new_PRIMITIVE_array functions with wrong arguments
 #[test]
-pub fn new_primitive_array_wrong() {
+pub fn new_primitive_array_bad_size() {
     attach_current_thread(|env| {
-        const WRONG_SIZE: jsize = -1;
+        const BAD_SIZE: usize = usize::MAX;
 
-        let result = env.new_boolean_array(WRONG_SIZE).map(|arr| arr.as_raw());
-        assert_exception(&result, "Env#new_boolean_array should throw exception");
-        assert_pending_java_exception(env);
+        let result = env.new_boolean_array(BAD_SIZE).map(|arr| arr.as_raw());
+        assert!(result.is_err());
 
-        let result = env.new_byte_array(WRONG_SIZE).map(|arr| arr.as_raw());
-        assert_exception(&result, "Env#new_byte_array should throw exception");
-        assert_pending_java_exception(env);
+        let result = env.new_byte_array(BAD_SIZE).map(|arr| arr.as_raw());
+        assert!(result.is_err());
 
-        let result = env.new_char_array(WRONG_SIZE).map(|arr| arr.as_raw());
-        assert_exception(&result, "Env#new_char_array should throw exception");
-        assert_pending_java_exception(env);
+        let result = env.new_char_array(BAD_SIZE).map(|arr| arr.as_raw());
+        assert!(result.is_err());
 
-        let result = env.new_short_array(WRONG_SIZE).map(|arr| arr.as_raw());
-        assert_exception(&result, "Env#new_short_array should throw exception");
-        assert_pending_java_exception(env);
+        let result = env.new_short_array(BAD_SIZE).map(|arr| arr.as_raw());
+        assert!(result.is_err());
 
-        let result = env.new_int_array(WRONG_SIZE).map(|arr| arr.as_raw());
-        assert_exception(&result, "Env#new_int_array should throw exception");
-        assert_pending_java_exception(env);
+        let result = env.new_int_array(BAD_SIZE).map(|arr| arr.as_raw());
+        assert!(result.is_err());
 
-        let result = env.new_long_array(WRONG_SIZE).map(|arr| arr.as_raw());
-        assert_exception(&result, "Env#new_long_array should throw exception");
-        assert_pending_java_exception(env);
+        let result = env.new_long_array(BAD_SIZE).map(|arr| arr.as_raw());
+        assert!(result.is_err());
 
-        let result = env.new_float_array(WRONG_SIZE).map(|arr| arr.as_raw());
-        assert_exception(&result, "Env#new_float_array should throw exception");
-        assert_pending_java_exception(env);
+        let result = env.new_float_array(BAD_SIZE).map(|arr| arr.as_raw());
+        assert!(result.is_err());
 
-        let result = env.new_double_array(WRONG_SIZE).map(|arr| arr.as_raw());
-        assert_exception(&result, "Env#new_double_array should throw exception");
-        assert_pending_java_exception(env);
+        let result = env.new_double_array(BAD_SIZE).map(|arr| arr.as_raw());
+        assert!(result.is_err());
 
         Ok(())
     })
@@ -1778,15 +1770,6 @@ where
 
     assert_exception_type(env, exception, RUNTIME_EXCEPTION_CLASS);
     assert_exception_message(env, exception, TEST_EXCEPTION_MESSAGE);
-}
-
-// Helper method that asserts that result is Error and the cause is JavaException.
-fn assert_exception(res: &Result<jobject, Error>, expect_message: &str) {
-    assert!(res.is_err());
-    assert!(res
-        .as_ref()
-        .map_err(|error| matches!(error, Error::JavaException))
-        .expect_err(expect_message));
 }
 
 // Shortcut to `assert_pending_java_exception_detailed()` without checking for expected  type and


### PR DESCRIPTION
Although the `Env::new_XYZ_array` methods have been kept for anyone that's familiar with the JNI C API naming conventions, the idea here is to also provide `::new()` constructor methods as a more natural API for constructing these object references (purely from a Rust API style pov).

Currently there is a _lot_ of `Env` API which can make it hard to find things.

Intuitively I think someone who's not intimately familiar with the underlying C API is more likely to look a the object type APIs when looking for a way to construct these objects instead of looking for an `Env` method.

It's also not a generally scalable pattern for all object constructor methods to be `Env` methods so I think it's better to establish constructor methods for the various object APIs.

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Change is covered by [automated tests](https://github.com/jni-rs/jni-rs/blob/master/CONTRIBUTING.md#tests)
- [x] The [coding guidelines](https://github.com/jni-rs/jni-rs/blob/master/CONTRIBUTING.md#the-code-style) are followed
- [x] Public API has documentation
- [x] User-visible changes are mentioned in the Changelog
- [x] The continuous integration build passes
