### PR TITLE
Address inconsistencies with 'env' argument position

### DIFF
--- a/src/descriptors/class_desc.rs
+++ b/src/descriptors/class_desc.rs
@@ -14,7 +14,7 @@ where
 
     fn lookup(self, env: &mut Env<'local>) -> Result<Self::Output> {
         Ok(LoaderContext::None
-            .find_class(self.as_ref(), false, env)?
+            .find_class(env, self.as_ref(), false)?
             .auto())
     }
 }

--- a/src/env.rs
+++ b/src/env.rs
@@ -681,7 +681,7 @@ See the jni-rs Env documentation for more details.
         S: AsRef<JNIStr>,
     {
         let name = name.as_ref();
-        LoaderContext::None.load_class(name, false, self)
+        LoaderContext::None.load_class(self, name, false)
     }
 
     /// Returns the superclass for a particular class. Returns None for `java.lang.Object` or
@@ -2970,7 +2970,7 @@ See the jni-rs Env documentation for more details.
         array: impl AsRef<JObjectArray<'other_local, E>>,
         index: usize,
     ) -> Result<E::Kind<'local>> {
-        array.as_ref().get_element(index, self)
+        array.as_ref().get_element(self, index)
     }
 
     /// Sets an element of the [`JObjectArray`] `array`.
@@ -2984,7 +2984,7 @@ See the jni-rs Env documentation for more details.
         index: usize,
         value: impl AsRef<E::Kind<'any_local_2>>,
     ) -> Result<()> {
-        array.as_ref().set_element(index, value, self)
+        array.as_ref().set_element(self, index, value)
     }
 
     /// Create a new java byte array from a rust byte slice.

--- a/src/objects/jbytebuffer.rs
+++ b/src/objects/jbytebuffer.rs
@@ -60,7 +60,7 @@ impl JByteBufferAPI {
         static JBYTEBUFFER_API: OnceCell<JByteBufferAPI> = OnceCell::new();
         JBYTEBUFFER_API.get_or_try_init(|| {
             env.with_local_frame(DEFAULT_LOCAL_FRAME_CAPACITY, |env| {
-                let class = loader_context.load_class_for_type::<JByteBuffer>(false, env)?;
+                let class = loader_context.load_class_for_type::<JByteBuffer>(env, false)?;
                 let class = env.new_global_ref(&class).unwrap();
                 Ok(Self { class })
             })

--- a/src/objects/jcollection.rs
+++ b/src/objects/jcollection.rs
@@ -71,7 +71,7 @@ impl JCollectionAPI {
         static JCOLLECTION_API: OnceCell<JCollectionAPI> = OnceCell::new();
         JCOLLECTION_API.get_or_try_init(|| {
             env.with_local_frame(DEFAULT_LOCAL_FRAME_CAPACITY, |env| {
-                let class = loader_context.load_class_for_type::<JCollection>(true, env)?;
+                let class = loader_context.load_class_for_type::<JCollection>(env, true)?;
                 let class = env.new_global_ref(&class).unwrap();
 
                 let add_method = env.get_method_id(&class, c"add", c"(Ljava/lang/Object;)Z")?;

--- a/src/objects/jiterator.rs
+++ b/src/objects/jiterator.rs
@@ -64,7 +64,7 @@ impl JIteratorAPI {
         static JITERATOR_API: OnceCell<JIteratorAPI> = OnceCell::new();
         JITERATOR_API.get_or_try_init(|| {
             env.with_local_frame(DEFAULT_LOCAL_FRAME_CAPACITY, |env| {
-                let class = loader_context.load_class_for_type::<JIterator>(true, env)?;
+                let class = loader_context.load_class_for_type::<JIterator>(env, true)?;
                 let class = env.new_global_ref(&class).unwrap();
 
                 let has_next_method = env.get_method_id(&class, c"hasNext", c"()Z")?;

--- a/src/objects/jlist.rs
+++ b/src/objects/jlist.rs
@@ -72,7 +72,7 @@ impl JListAPI {
         static JLIST_API: OnceCell<JListAPI> = OnceCell::new();
         JLIST_API.get_or_try_init(|| {
             env.with_local_frame(DEFAULT_LOCAL_FRAME_CAPACITY, |env| {
-                let class = loader_context.load_class_for_type::<JList>(true, env)?;
+                let class = loader_context.load_class_for_type::<JList>(env, true)?;
                 let class = env.new_global_ref(&class).unwrap();
 
                 let get_method = env.get_method_id(&class, c"get", c"(I)Ljava/lang/Object;")?;

--- a/src/objects/jmap.rs
+++ b/src/objects/jmap.rs
@@ -64,7 +64,7 @@ impl JMapAPI {
         static JMAP_API: OnceCell<JMapAPI> = OnceCell::new();
         JMAP_API.get_or_try_init(|| {
             env.with_local_frame(DEFAULT_LOCAL_FRAME_CAPACITY, |env| {
-                let class = loader_context.load_class_for_type::<JMap>(true, env)?;
+                let class = loader_context.load_class_for_type::<JMap>(env, true)?;
                 let class = env.new_global_ref(&class).unwrap();
 
                 let get_method =
@@ -377,7 +377,7 @@ impl JMapEntryAPI {
         static JMAPENTRY_API: OnceCell<JMapEntryAPI> = OnceCell::new();
         JMAPENTRY_API.get_or_try_init(|| {
             env.with_local_frame(DEFAULT_LOCAL_FRAME_CAPACITY, |env| {
-                let class = loader_context.load_class_for_type::<JMapEntry>(true, env)?;
+                let class = loader_context.load_class_for_type::<JMapEntry>(env, true)?;
                 let class = env.new_global_ref(&class).unwrap();
 
                 let get_key_method =

--- a/src/objects/jobject_array.rs
+++ b/src/objects/jobject_array.rs
@@ -94,7 +94,7 @@ impl<E: Reference + Send + Sync> JObjectArrayAPI<E> {
 
         let created: JObjectArrayAPI<E> = {
             env.with_local_frame(DEFAULT_LOCAL_FRAME_CAPACITY, |env| -> Result<_> {
-                let class = loader_context.load_class_for_type::<JObjectArray<E>>(false, env)?;
+                let class = loader_context.load_class_for_type::<JObjectArray<E>>(env, false)?;
                 let class = env.new_global_ref(&class)?;
                 Ok(JObjectArrayAPI {
                     class,
@@ -204,8 +204,8 @@ impl<'local, E: Reference + 'local> JObjectArray<'local, E> {
     ///
     /// Returns [Error::WrongObjectType] if the `IsInstanceOf` check fails.
     pub fn cast_local<'any_local, O: Reference + 'static>(
-        obj: impl Reference + Into<JObject<'any_local>> + AsRef<JObject<'any_local>>,
         env: &mut Env<'_>,
+        obj: impl Reference + Into<JObject<'any_local>> + AsRef<JObject<'any_local>>,
     ) -> Result<<JObjectArray<'any_local, O> as Reference>::Kind<'any_local>> {
         env.cast_local::<JObjectArray<'any_local, O>>(obj)
     }
@@ -223,8 +223,8 @@ impl<'local, E: Reference + 'local> JObjectArray<'local, E> {
     /// Returns a local reference to an element of the [`JObjectArray`] `array`.
     pub fn get_element<'env_local>(
         &self,
-        index: usize,
         env: &mut Env<'env_local>,
+        index: usize,
     ) -> Result<E::Kind<'env_local>> {
         // Runtime check that the 'local reference lifetime will be tied to
         // Env lifetime for the top JNI stack frame
@@ -247,9 +247,9 @@ impl<'local, E: Reference + 'local> JObjectArray<'local, E> {
     /// Sets an element of the [`JObjectArray`] `array`.
     pub fn set_element<'any_local>(
         &self,
+        env: &Env<'_>,
         index: usize,
         value: impl AsRef<E::Kind<'any_local>>,
-        env: &Env<'_>,
     ) -> Result<()> {
         let array = null_check!(
             self.as_raw() as jobjectArray,

--- a/src/objects/jprimitive_array.rs
+++ b/src/objects/jprimitive_array.rs
@@ -401,7 +401,7 @@ macro_rules! impl_ref_for_jprimitive_array {
 
                     let api = env.with_local_frame(4, |env| -> Result<_> {
                         let class =
-                            loader_context.load_class_for_type::<JPrimitiveArray::<crate::sys::$type>>(false, env)?;
+                            loader_context.load_class_for_type::<JPrimitiveArray::<crate::sys::$type>>(env, false)?;
                         let class = env.new_global_ref(&class).unwrap();
                         Ok(Self {
                             class,
@@ -428,8 +428,8 @@ macro_rules! impl_ref_for_jprimitive_array {
                 ///
                 /// Returns [Error::WrongObjectType] if the `IsInstanceOf` check fails.
                 pub fn cast_local<'any_local>(
-                    obj: impl Reference + Into<JObject<'any_local>> + AsRef<JObject<'any_local>>,
                     env: &mut Env<'_>,
+                    obj: impl Reference + Into<JObject<'any_local>> + AsRef<JObject<'any_local>>,
                 ) -> Result<<JPrimitiveArray<'any_local, crate::sys::$type> as Reference>::Kind<'any_local>> {
                     env.cast_local::<JPrimitiveArray<crate::sys::$type>>(obj)
                 }

--- a/src/objects/jset.rs
+++ b/src/objects/jset.rs
@@ -70,7 +70,7 @@ impl JSetAPI {
         static JSET_API: OnceCell<JSetAPI> = OnceCell::new();
         JSET_API.get_or_try_init(|| {
             env.with_local_frame(DEFAULT_LOCAL_FRAME_CAPACITY, |env| {
-                let class = loader_context.load_class_for_type::<JSet>(true, env)?;
+                let class = loader_context.load_class_for_type::<JSet>(env, true)?;
                 let class = env.new_global_ref(&class).unwrap();
 
                 Ok(Self { class })

--- a/src/objects/jstack_trace_element.rs
+++ b/src/objects/jstack_trace_element.rs
@@ -64,7 +64,7 @@ impl JStackTraceElementAPI {
         static JSTACK_TRACE_ELEMENT_API: OnceCell<JStackTraceElementAPI> = OnceCell::new();
         JSTACK_TRACE_ELEMENT_API.get_or_try_init(|| {
             env.with_local_frame(DEFAULT_LOCAL_FRAME_CAPACITY, |env| {
-                let class = loader_context.load_class_for_type::<JStackTraceElement>(false, env)?;
+                let class = loader_context.load_class_for_type::<JStackTraceElement>(env, false)?;
                 let class = env.new_global_ref(&class).unwrap();
 
                 let get_class_name_method = env

--- a/src/objects/jstring.rs
+++ b/src/objects/jstring.rs
@@ -141,7 +141,7 @@ impl JStringAPI {
         static JSTRING_API: OnceCell<JStringAPI> = OnceCell::new();
         JSTRING_API.get_or_try_init(|| {
             env.with_local_frame(DEFAULT_LOCAL_FRAME_CAPACITY, |env| {
-                let class = loader_context.load_class_for_type::<JString>(true, env)?;
+                let class = loader_context.load_class_for_type::<JString>(env, true)?;
                 let class = env.new_global_ref(&class).unwrap();
                 let intern_method = env
                     .get_method_id(&class, c"intern", c"()Ljava/lang/String;")

--- a/src/objects/jthrowable.rs
+++ b/src/objects/jthrowable.rs
@@ -68,7 +68,7 @@ impl JThrowableAPI {
         static JTHROWABLE_API: OnceCell<JThrowableAPI> = OnceCell::new();
         JTHROWABLE_API.get_or_try_init(|| {
             env.with_local_frame(DEFAULT_LOCAL_FRAME_CAPACITY, |env| {
-                let class = loader_context.load_class_for_type::<JThrowable>(true, env)?;
+                let class = loader_context.load_class_for_type::<JThrowable>(env, true)?;
                 let class = env.new_global_ref(&class).unwrap();
                 let get_message_method = env
                     .get_method_id(&class, c"getMessage", c"()Ljava/lang/String;")

--- a/tests/jni_api.rs
+++ b/tests/jni_api.rs
@@ -1609,10 +1609,10 @@ fn get_object_array_element() {
             .unwrap();
 
         assert!(!array.is_null());
-        assert!(array.get_element(0, env).unwrap().is_null());
+        assert!(array.get_element(env, 0).unwrap().is_null());
         let test_str = env.new_string(c"test").unwrap();
-        array.set_element(0, test_str, env).unwrap();
-        assert!(!array.get_element(0, env).unwrap().is_null());
+        array.set_element(env, 0, test_str).unwrap();
+        assert!(!array.get_element(env, 0).unwrap().is_null());
 
         Ok(())
     })
@@ -1936,7 +1936,7 @@ fn test_throwable_get_stack_trace() {
         assert_eq!(len, 0);
 
         for i in 0..len {
-            let element = stack_trace.get_element(i, env).unwrap();
+            let element = stack_trace.get_element(env, i).unwrap();
             let _class_name = element.get_class_name(env).unwrap();
             let _method_name = element.get_method_name(env).unwrap();
             let _file_name = element.get_file_name(env).unwrap();


### PR DESCRIPTION
This tries to ensure we consistently pass the `env: &Env` reference as the first argument to methods that need it.

This is effectively back tracking on starting to pass it as the last argument as a kind of borrow checker workaround that lets you access the env while filling in arguments for a method.

Since methods that return new object references require a `&mut Env` reference, it's sometimes a little awkward when making method calls that take other object references because you need to have those other references ready before you give away your only `&mut Env` reference.

We had started to suggest that APIs can avoid this paper cut by instead designing APIs that take the `env` argument last - so that it remains available to derive the value of other arguments.

Having started trying to do this in various places though I'm now thinking that actually this is just going to lead to more confusion.

In practice it feels unintuitive (to me) to have the `env` argument come last and at least currently it's very awkward not being able to assume / guess where the `env` argument will go because for some existing APIs it comes first but other new APIs it comes last.

Theoretically the `env` argument can come first for any API that only takes a shared `&Env` reference but that would add to the inconsistency / confusion.

I guess the main concern here is consistency and it could be _OK_ perhaps if everything put the `env` argument last, but if the  choices are:

1. always first
2. `¯\_(ツ)_/¯`
3. always last

...then I definitely think 1) is the more practical choice that's going to better align with expectations (even though it has the disadvantage that you're forced to derive object reference arguments before making a method call)

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Change is covered by [automated tests](https://github.com/jni-rs/jni-rs/blob/master/CONTRIBUTING.md#tests)
- [x] The [coding guidelines](https://github.com/jni-rs/jni-rs/blob/master/CONTRIBUTING.md#the-code-style) are followed
- [x] Public API has documentation
- [x] User-visible changes are mentioned in the Changelog
- [x] The continuous integration build passes
