### PR TITLE
Add `JString::new/from_str/from_jni_str` constructor methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,7 +83,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 #### java.lang APIs
 
-- `JThread` as a `Reference` wrapper for `java.lang.Thread` references ([#612](https://github.com/jni-rs/jni-rs/pull/612))
 - `JClassLoader` as a `Reference` wrapper for `java.lang.ClassLoader` references ([#612](https://github.com/jni-rs/jni-rs/pull/612))
 - `JCollection`, `JSet` and `JIterator` reference wrappers for `java.util.Collection`, `java.util.Set` and `java.util.Iterator` interfaces.
 - `JList::remove_item` for removing a given value, by-reference, from the list (instead of by index).
@@ -93,9 +92,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `JObjectArray::new` lets you construct a `JObjectArray<E>` with strong element type parameterization, instead of `Env::new_object_array`
 - `JObjectArray::get/set_element` let you get and set array elements as methods on the array.
 - `JPrimitiveArray::new` lets you construct a `JPrimitiveArray<E>`, consistent with `JObjectArray::new`
+- `JStackTraceElement` gives access to stack frame info within a stack trace, like filename, line number etc
+- `JString` now has `::new()`, `::from_str` and `::from_jni_str` constructor methods ([#960](https://github.com/jni-rs/jni-rs/pull/690))
+- `JThread` as a `Reference` wrapper for `java.lang.Thread` references ([#612](https://github.com/jni-rs/jni-rs/pull/612))
 - `JThrowable::get_message` is a binding for `getMessage()` and gives easy access to an exception message
 - `JThrowable::get_stack_trace` is a binding for `getStackTrace()`, returning a `JObjectArray<JStackTraceElement>`
-- `JStackTraceElement` gives access to stack frame info within a stack trace, like filename, line number etc
 
 
 ### Changed

--- a/benches/api_calls.rs
+++ b/benches/api_calls.rs
@@ -1,6 +1,6 @@
 #![cfg(feature = "invocation")]
 
-use jni::strings::{JNIStr, JNIString};
+use jni::strings::JNIStr;
 use jni_sys::jvalue;
 use lazy_static::lazy_static;
 
@@ -231,7 +231,7 @@ fn jni_call_static_date_time_method_unchecked_jclass(c: &mut Criterion) {
 
 fn jni_call_object_hash_method_safe(c: &mut Criterion) {
     VM.attach_current_thread_for_scope(|env| -> jni::errors::Result<()> {
-        let s = env.new_string(c"").unwrap();
+        let s = env.new_string("").unwrap();
         let obj = black_box(JObject::from(s));
 
         c.bench_function("jni_call_object_hash_method_safe", |b| {
@@ -244,7 +244,7 @@ fn jni_call_object_hash_method_safe(c: &mut Criterion) {
 
 fn jni_call_object_hash_method_unchecked(c: &mut Criterion) {
     VM.attach_current_thread_for_scope(|env| -> jni::errors::Result<()> {
-        let s = env.new_string(c"").unwrap();
+        let s = env.new_string("").unwrap();
         let obj = black_box(JObject::from(s));
         let obj_class = env.get_object_class(&obj).unwrap();
         let method_id = env
@@ -368,9 +368,7 @@ fn jni_get_java_vm(c: &mut Criterion) {
 
 fn jni_get_string(c: &mut Criterion) {
     VM.attach_current_thread_for_scope(|env| -> jni::errors::Result<()> {
-        let string = env
-            .new_string(JNIString::from(TEST_STRING_UNICODE))
-            .unwrap();
+        let string = env.new_string(TEST_STRING_UNICODE).unwrap();
 
         c.bench_function("jni_get_string", |b| {
             b.iter(|| {
@@ -385,9 +383,7 @@ fn jni_get_string(c: &mut Criterion) {
 
 fn jni_get_string_unchecked(c: &mut Criterion) {
     VM.attach_current_thread_for_scope(|env| -> jni::errors::Result<()> {
-        let string = env
-            .new_string(JNIString::from(TEST_STRING_UNICODE))
-            .unwrap();
+        let string = env.new_string(TEST_STRING_UNICODE).unwrap();
 
         c.bench_function("jni_get_string_unchecked", |b| {
             b.iter(|| {
@@ -476,7 +472,7 @@ fn jni_new_string_within_single_thread_attachment(c: &mut Criterion) {
     VM.attach_current_thread_for_scope(|env| -> jni::errors::Result<()> {
         c.bench_function("jni_new_string_within_single_thread_attachment", |b| {
             b.iter(|| {
-                black_box(env.new_string(c"Test").unwrap().auto());
+                black_box(env.new_string("Test").unwrap().auto());
             })
         });
         Ok(())
@@ -491,7 +487,7 @@ fn jni_new_string_with_repeat_scoped_thread_attachments(c: &mut Criterion) {
         |b| {
             b.iter(|| {
                 VM.attach_current_thread_for_scope(|env| -> jni::errors::Result<()> {
-                    black_box(env.new_string(c"Test").unwrap().auto());
+                    black_box(env.new_string("Test").unwrap().auto());
                     Ok(())
                 })
                 .unwrap();
@@ -514,7 +510,7 @@ fn jni_new_string_with_repeat_permanent_thread_attachments(c: &mut Criterion) {
         |b| {
             b.iter(|| {
                 VM.attach_current_thread(|env| -> jni::errors::Result<()> {
-                    black_box(env.new_string(c"Test").unwrap().auto());
+                    black_box(env.new_string("Test").unwrap().auto());
                     Ok(())
                 })
                 .unwrap();

--- a/src/descriptors/exception_desc.rs
+++ b/src/descriptors/exception_desc.rs
@@ -2,7 +2,7 @@ use crate::{
     descriptors::Desc,
     env::Env,
     errors::*,
-    objects::{Auto, IntoAuto as _, JClass, JObject, JThrowable, JValue},
+    objects::{Auto, IntoAuto as _, JClass, JObject, JString, JThrowable, JValue},
     strings::{JNIStr, JNIString},
 };
 
@@ -16,7 +16,7 @@ where
     type Output = Auto<'local, JThrowable<'local>>;
 
     fn lookup(self, env: &mut Env<'local>) -> Result<Self::Output> {
-        let jmsg = env.new_string(self.1.as_ref())?.auto();
+        let jmsg = JString::from_jni_str(env, self.1.as_ref())?.auto();
         let obj: JObject =
             env.new_object(self.0, c"(Ljava/lang/String;)V", &[JValue::from(&jmsg)])?;
         let throwable = env.cast_local::<JThrowable>(obj)?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -158,7 +158,7 @@
 //!         let input: String = input.to_string();
 //!         // Then we have to create a new Java string to return. Again, more info
 //!         // in the `strings` module.
-//!         env.new_string(JNIString::from(format!("Hello, {}!", input)))
+//!         JString::from_str(env, format!("Hello, {}!", input))
 //!     });
 //!
 //!    // Finally, we have to resolve the `EnvOutcome` into a concrete return value.

--- a/src/objects/jclass.rs
+++ b/src/objects/jclass.rs
@@ -5,7 +5,9 @@ use once_cell::sync::OnceCell;
 use crate::{
     env::Env,
     errors::Result,
-    objects::{Global, JClassLoader, JMethodID, JObject, JStaticMethodID, JValue, LoaderContext},
+    objects::{
+        Global, JClassLoader, JMethodID, JObject, JStaticMethodID, JString, JValue, LoaderContext,
+    },
     signature::JavaType,
     strings::JNIStr,
     sys::{jclass, jobject},
@@ -178,7 +180,7 @@ impl JClass<'_> {
     {
         let api = JClassAPI::get(env)?;
 
-        let class_name = env.new_string(class_name)?;
+        let class_name = JString::from_jni_str(env, class_name.as_ref())?;
 
         // Safety: We know that `forName` is a valid static method on `java/lang/Class` that takes
         // a String and returns a valid `Class` instance.
@@ -223,7 +225,7 @@ impl JClass<'_> {
     {
         let api = JClassAPI::get(env)?;
 
-        let class_name = env.new_string(class_name)?;
+        let class_name = JString::from_jni_str(env, class_name.as_ref())?;
 
         // Safety: We know that `forName` is a valid static method on `java/lang/Class` that takes
         // a String, initializer boolean and a ClassLoader and returns a valid `Class` instance.

--- a/src/objects/jclass_loader.rs
+++ b/src/objects/jclass_loader.rs
@@ -6,7 +6,7 @@ use crate::{
     env::Env,
     errors::Result,
     ids::JStaticMethodID,
-    objects::{Global, JClass, JMethodID, JObject, JValue, LoaderContext},
+    objects::{Global, JClass, JMethodID, JObject, JString, JValue, LoaderContext},
     signature::JavaType,
     strings::JNIStr,
     sys::{jclass, jobject},
@@ -178,7 +178,7 @@ impl JClassLoader<'_> {
     ) -> Result<JClass<'local>> {
         let api = JClassLoaderAPI::get(env)?;
 
-        let name = env.new_string(name)?;
+        let name = JString::from_jni_str(env, name)?;
 
         // SAFETY:
         // - we know that `self` is a valid `JClassLoader` reference and `load_class_method` is a valid method ID.

--- a/src/refs/auto.rs
+++ b/src/refs/auto.rs
@@ -64,7 +64,7 @@ use super::Reference;
 /// for i in 0..1000 {
 ///     // Ensure we aren't left with a new local for each iteration by
 ///     // wrapping the reference in an `Auto` wrapper.
-///     let auto_delete_string = env.new_string(c"Hello, world!")?.auto();
+///     let auto_delete_string = env.new_string("Hello, world!")?.auto();
 /// }
 /// # Ok(())
 /// # }

--- a/src/strings/mutf8_chars.rs
+++ b/src/strings/mutf8_chars.rs
@@ -32,7 +32,7 @@ use ::{
 /// # use jni::{errors::Result, Env, objects::*};
 /// #
 /// # fn f(env: &mut Env) -> Result<()> {
-/// let string = env.new_string(c"Hello, world!")?;
+/// let string = JString::from_str(env, "Hello, world!")?;
 /// let rust_utf8_string = string.mutf8_chars(env)?.to_string();
 /// # Ok(())
 /// # }
@@ -173,10 +173,10 @@ where
     ///
     /// # Example
     /// ```rust,no_run
-    /// # use jni::{errors::Result, Env, strings::MUTF8Chars};
+    /// # use jni::{errors::Result, Env, objects::JString, strings::MUTF8Chars};
     /// #
     /// # fn example(env: &mut Env) -> Result<()> {
-    /// let jstring = env.new_string(c"foo")?;
+    /// let jstring = JString::from_str(env, "foo")?;
     /// let chars = jstring.mutf8_chars(env)?;
     ///
     /// let (ptr, is_copy) = chars.into_raw();

--- a/tests/get_rust_field_ergonomics.rs
+++ b/tests/get_rust_field_ergonomics.rs
@@ -32,7 +32,7 @@ pub extern "system" fn Java_Renderer_render<'local>(
             renderer.render(&surface);
 
             // Check we can still call something requiring `&mut Env` after locking multiple fields
-            let _s = env.new_string(c"hello")?;
+            let _s = env.new_string("hello")?;
 
             Ok(())
         })

--- a/tests/invocation_character_encoding.rs
+++ b/tests/invocation_character_encoding.rs
@@ -24,7 +24,7 @@ fn invocation_character_encoding() {
 
     jvm.attach_current_thread(|env| -> jni::errors::Result<()> {
         println!("creating new_string, env = {:?}", env.get_raw());
-        let prop_name = env.new_string(c"nbsp").unwrap();
+        let prop_name = env.new_string("nbsp").unwrap();
 
         println!("calling getProperty");
         let prop_value = env

--- a/tests/jlist.rs
+++ b/tests/jlist.rs
@@ -27,7 +27,7 @@ pub fn jlist_push_and_iterate() {
         // Add all strings to the list
         unwrap(
             data.iter().try_for_each(|s| {
-                let string = env.new_string(s)?;
+                let string = JString::from_jni_str(env, s)?;
                 let added = list.add(env, &string)?;
                 assert!(added);
                 Ok(())
@@ -68,8 +68,8 @@ pub fn jlist_get_and_set() {
         let list = unwrap(JList::cast_local(list_object, env), env);
 
         // Add some initial elements
-        let hello_str = unwrap(env.new_string(c"hello"), env);
-        let world_str = unwrap(env.new_string(c"world"), env);
+        let hello_str = unwrap(JString::from_str(env, "hello"), env);
+        let world_str = unwrap(JString::from_str(env, "world"), env);
 
         unwrap(list.add(env, &hello_str.into()), env);
         unwrap(list.add(env, &world_str.into()), env);
@@ -106,14 +106,14 @@ pub fn jlist_insert_and_remove() {
         let list = unwrap(JList::cast_local(list_object, env), env);
 
         // Add initial elements
-        let first_str = unwrap(env.new_string(c"first"), env);
-        let third_str = unwrap(env.new_string(c"third"), env);
+        let first_str = unwrap(JString::from_str(env, "first"), env);
+        let third_str = unwrap(JString::from_str(env, "third"), env);
 
         unwrap(list.add(env, &first_str.into()), env);
         unwrap(list.add(env, &third_str.into()), env);
 
         // Insert in the middle
-        let second_str = unwrap(env.new_string(c"second"), env);
+        let second_str = unwrap(JString::from_str(env, "second"), env);
         unwrap(list.insert(env, 1, &second_str.into()), env);
 
         // Verify the size is now 3
@@ -169,9 +169,9 @@ pub fn jlist_size_and_remove() {
         assert_eq!(size, 0);
 
         // Add some elements
-        let first_str = unwrap(env.new_string(c"first"), env);
-        let second_str = unwrap(env.new_string(c"second"), env);
-        let third_str = unwrap(env.new_string(c"third"), env);
+        let first_str = unwrap(env.new_string("first"), env);
+        let second_str = unwrap(env.new_string("second"), env);
+        let third_str = unwrap(env.new_string("third"), env);
 
         unwrap(list.add(env, &first_str), env);
         unwrap(list.add(env, &second_str), env);
@@ -259,7 +259,7 @@ pub fn jlist_iterator_with_auto() {
         // Add all strings to the list
         unwrap(
             data.iter().try_for_each(|s| {
-                let string = env.new_string(s)?;
+                let string = JString::from_jni_str(env, s)?;
                 let added = list.add(env, &string)?;
                 assert!(added);
                 Ok(())

--- a/tests/jmap.rs
+++ b/tests/jmap.rs
@@ -25,7 +25,7 @@ pub fn jmap_push_and_iterate() {
         // Push all strings
         unwrap(
             data.iter().try_for_each(|s| {
-                env.new_string(s)
+                JString::from_jni_str(env, s)
                     .map(JObject::from)
                     .and_then(|s| map.put(env, &s, &s).map(|_| ()))
             }),

--- a/tests/ui/fail/with-local-frame-borrow-mut-env.rs
+++ b/tests/ui/fail/with-local-frame-borrow-mut-env.rs
@@ -2,12 +2,13 @@
 mod util;
 use util::attach_current_thread;
 
+use jni::objects::JString;
 use jni::Env;
 
 pub fn main() {
     attach_current_thread(|env0: &mut Env| {
         env0.with_local_frame(10, |_env1: &mut Env| -> jni::errors::Result<_> {
-            let _s = env0.new_string(c"hello").unwrap();
+            let _s = JString::from_str(env0, "hello").unwrap();
             eprintln!("BUG: this shouldn't compile since env0 shouldn't be mutable and new_string requires a mutable Env");
             Ok(())
         })

--- a/tests/ui/fail/with-local-frame-borrow-mut-env.stderr
+++ b/tests/ui/fail/with-local-frame-borrow-mut-env.stderr
@@ -1,10 +1,10 @@
 error[E0500]: closure requires unique access to `*env0` but it is already borrowed
-  --> tests/ui/fail/with-local-frame-borrow-mut-env.rs:9:35
+  --> tests/ui/fail/with-local-frame-borrow-mut-env.rs:10:35
    |
- 9 |         env0.with_local_frame(10, |_env1: &mut Env| -> jni::errors::Result<_> {
+10 |         env0.with_local_frame(10, |_env1: &mut Env| -> jni::errors::Result<_> {
    |         ---- ----------------     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ closure construction occurs here
    |         |    |
    |         |    first borrow later used by call
    |         borrow occurs here
-10 |             let _s = env0.new_string(c"hello").unwrap();
-   |                      ---- second borrow occurs due to use of `*env0` in closure
+11 |             let _s = JString::from_str(env0, "hello").unwrap();
+   |                                        ---- second borrow occurs due to use of `*env0` in closure


### PR DESCRIPTION
Similar to https://github.com/jni-rs/jni-rs/pull/688, this adds constructor methods for `JString` that should hopefully be more discoverable for anyone that's not intimately familiar with the underlying C API.

The plan is that the various `Reference` type API bindings should consistently expose their Java constructor bindings as Rust constructor methods, so this is applying that idea to `JString`.

This also reverts `Env::new_string` to taking an `AsRef<str>` instead of `AsRef<JNIStr>` as the more practical choice for allocating `java.lang.String` objects from Rust strings, even though it involves copying the input and encoding to MUTF-8 at runtime.

For anyone wanting to optimize how they allocate a `java.lang.String` from a `&'static JNIStr` (that's already MUTF-8 encoded) they can now use `JString::from_jni_str()`

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Change is covered by [automated tests](https://github.com/jni-rs/jni-rs/blob/master/CONTRIBUTING.md#tests)
- [x] The [coding guidelines](https://github.com/jni-rs/jni-rs/blob/master/CONTRIBUTING.md#the-code-style) are followed
- [x] Public API has documentation
- [x] User-visible changes are mentioned in the Changelog
- [x] The continuous integration build passes
