### PR TITLE
import jni_fn as jni_mangle macro

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -98,6 +98,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `JThrowable::get_message` is a binding for `getMessage()` and gives easy access to an exception message
 - `JThrowable::get_stack_trace` is a binding for `getStackTrace()`, returning a `JObjectArray<JStackTraceElement>`
 
+#### Macros
+
+- The `#[jni_mangle()]` attribute proc macro can export an `extern "system"` native method with a mangled name like "Java_com_example_myMethod" so it can be automatically resolved within a shared library by the JVM ([#693](https://github.com/jni-rs/jni-rs/pull/693))
 
 ### Changed
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ name = "api_calls"
 harness = false
 
 [dependencies]
+jni-macros = { path = "jni-macros", version = "0.1.0" }
 cfg-if = "1.0.0"
 cesu8 = "1.1.0"
 combine = "4.1.0"
@@ -62,4 +63,4 @@ default = []
 features = ["invocation"]
 
 [workspace]
-members = ["javac"]
+members = ["javac", "jni-macros"]

--- a/javac/Cargo.toml
+++ b/javac/Cargo.toml
@@ -12,7 +12,7 @@ license = "MIT OR Apache-2.0"
 repository = "https://github.com/jni-rs/jni-rs"
 version = "0.1.0"
 edition = "2024"
-include = ["../LICENSE-APACHE", "../LICENSE-MIT", "**/*.rs"]
+include = ["../LICENSE-APACHE", "../LICENSE-MIT", "src/**/*.rs"]
 
 [dependencies]
 which = "8"

--- a/jni-macros/Cargo.toml
+++ b/jni-macros/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "jni-macros"
+version = "0.1.0"
+description = "Procedural macros for the jni crate"
+keywords = ["jni", "java", "jvm", "android", "ndk"]
+categories = ["api-bindings", "development-tools::procedural-macro-helpers"]
+license = "MIT OR Apache-2.0"
+repository = "https://github.com/jni-rs/jni-rs"
+edition = "2024"
+include = ["../LICENSE-APACHE", "../LICENSE-MIT", "src/**", "examples/**"]
+
+[lib]
+proc-macro = true
+
+[dependencies]
+syn = { version = "2.0", features = ["full"] }
+quote = "1.0"
+proc-macro2 = "1.0"
+
+[dev-dependencies]
+jni = { path = "../", version = "0.21.0", features = ["invocation"] }

--- a/jni-macros/README.md
+++ b/jni-macros/README.md
@@ -1,0 +1,21 @@
+Proc macros for the [jni](https://crates.io/crates/jni) crate.
+
+See the [jni docs](https://docs.rs/jni/latest/jni/) for more details, since
+these macros are re-exported by the `jni` crate.
+
+## License
+
+This project is licensed under either of
+
+ * Apache License, Version 2.0, ([LICENSE-APACHE](../LICENSE-APACHE) or
+   https://www.apache.org/licenses/LICENSE-2.0)
+ * MIT license ([LICENSE-MIT](../LICENSE-MIT) or
+   https://opensource.org/licenses/MIT)
+
+at your option.
+
+### Contribution
+
+Unless you explicitly state otherwise, any contribution intentionally submitted
+for inclusion in this project by you, as defined in the Apache-2.0 license, shall be
+dual licensed as above, without any additional terms or conditions.

--- a/jni-macros/src/lib.rs
+++ b/jni-macros/src/lib.rs
@@ -1,0 +1,46 @@
+use crate::mangle::jni_mangle2;
+
+mod mangle;
+
+/// Annotate a function with this procedural macro attribute to expose it over the JNI.
+///
+/// This attribute takes a single string literal as an argument, specifying the package namespace
+/// this function should be placed under.
+///
+/// ```
+/// use jni::{ EnvUnowned, objects::{ JClass, JString }, sys::jstring };
+/// use jni_macros::jni_mangle;
+///
+/// #[jni_mangle("com.example.RustBindings")]
+/// pub fn sayHello<'local>(mut unowned_env: EnvUnowned<'local>, _: JClass<'local>, name: JString<'local>) -> JString<'local> {
+///     unowned_env.with_env(|env| {
+///         let name = name.to_string();
+///
+///         env.new_string(format!("Hello, {}!", name))
+///     }).resolve::<jni::errors::ThrowRuntimeExAndDefault>()
+/// }
+/// ```
+///
+/// The `sayHello` function will automatically be expanded to have the correct ABI specification
+/// and the appropriate JNI-compatible name, i.e. in this case -
+/// `Java_com_example_RustBindings_sayHello`.
+///
+/// Then it can be accessed by, for example, Kotlin code as follows:
+/// ```kotlin
+/// package com.example.RustBindings
+///
+/// class RustBindings {
+///     private external fun sayHello(name: String): String
+///
+///     fun greetWorld() {
+///         println(sayHello("world"))
+///     }
+/// }
+/// ```
+#[proc_macro_attribute]
+pub fn jni_mangle(
+    attr: proc_macro::TokenStream,
+    item: proc_macro::TokenStream,
+) -> proc_macro::TokenStream {
+    jni_mangle2(attr.into(), item.into()).into()
+}

--- a/jni-macros/src/mangle.rs
+++ b/jni-macros/src/mangle.rs
@@ -1,0 +1,354 @@
+//! JNI-compatible method signature generator for Rust libraries.
+//!
+//! This crate was designed for use with the [`jni`](https://crates.io/crates/jni) crate, which
+//! exposes JNI-compatible type bindings. Although it's possible to use `jni` without `jni_fn`, the
+//! procedural macro defined here will make it easier to write the method signatures correctly.
+//!
+//! See the `jni_fn` attribute macro documentation below for more info and usage examples.
+
+#![deny(missing_docs)]
+#![deny(unsafe_code)]
+
+use proc_macro2::TokenStream;
+use quote::ToTokens;
+use syn::parse_quote;
+use syn::spanned::Spanned;
+
+/// Deals exclusively with `proc_macro2::TokenStream` instead of `proc_macro::TokenStream`,
+/// allowing it and all interior functionality to be unit tested.
+pub fn jni_mangle2(attr: TokenStream, item: TokenStream) -> TokenStream {
+    let attr_span = attr.span();
+    let item_span = item.span();
+
+    let mut function: syn::ItemFn = match syn::parse2(item) {
+        Ok(f) => f,
+        Err(_e) => {
+            return syn::Error::new(
+                item_span,
+                "The `jni_mangle` attribute can only be applied to `fn` items",
+            )
+            .to_compile_error();
+        }
+    };
+
+    let namespace = match syn::parse2::<syn::LitStr>(attr) {
+        Ok(n) => n,
+        Err(_e) => return syn::Error::new(attr_span, "The `jni_mangle` attribute must have a single string literal supplied to specify the namespace").to_compile_error(),
+    }.value();
+
+    if !valid_namespace(&namespace) {
+        return syn::Error::new(
+            attr_span,
+            "Invalid package namespace supplied to `jni_mangle` attribute",
+        )
+        .to_compile_error();
+    }
+
+    let orig_fn_name = function.sig.ident.to_string();
+
+    function.sig.ident = syn::Ident::new(
+        &create_jni_fn_name(&namespace, &orig_fn_name),
+        function.sig.ident.span(),
+    );
+
+    function.attrs.extend([
+        parse_quote!(#[unsafe(no_mangle)]),
+        parse_quote!(#[allow(non_snake_case)]),
+    ]);
+
+    if function.sig.abi.is_some() {
+        return syn::Error::new(function.sig.abi.span(), "Don't specify an ABI for `jni_mangle` attributed functions - the correct ABI will be added automatically").to_compile_error();
+    }
+    function.sig.abi = Some(syn::Abi {
+        extern_token: Default::default(),
+        name: Some(syn::LitStr::new("system", function.sig.ident.span())),
+    });
+
+    if !matches!(function.vis, syn::Visibility::Public(_)) {
+        return syn::Error::new(
+            function.vis.span(),
+            "`jni_mangle` attributed functions must have public visibility (`pub`)",
+        )
+        .to_compile_error();
+    }
+
+    function.into_token_stream()
+}
+
+/// Ensures that `namespace` appears roughly like a valid package name.
+///
+/// A package name is a '.'-separated identifier list.
+///
+/// Identifiers are described in section 3.8 of the Java language specification, although some
+/// JVM-compatible languages have slightly different restrictions on what is considered a valid
+/// identifier. This function attempts to catch obviously incorrect strings.
+///
+/// Please submit an issue report or patch to make this more permissive if it's required for
+/// valid JVM code! Otherwise, making it more restrictive is appreciated as long as it's confirmed
+/// to work with multiple JVM-compatible languages.
+fn valid_namespace(namespace: &str) -> bool {
+    /// These shouldn't occur _anywhere_ in the package name.
+    const FORBIDDEN_CHARS: &[char] = &[
+        ' ', ',', ':', ';', '|', '\\', '/', '!', '@', '#', '%', '^', '&', '*', '(', ')', '{', '}',
+        '[', ']', '-', '`', '~', '\t', '\n', '\r',
+    ];
+
+    for c in FORBIDDEN_CHARS {
+        if namespace.contains(*c) {
+            return false;
+        }
+    }
+
+    fn is_valid_ident(ident: &str) -> bool {
+        /// These shouldn't occur as the first character of an identifier.
+        const FORBIDDEN_START_CHARS: &[char] = &['0', '1', '2', '3', '4', '5', '6', '7', '8', '9'];
+
+        if ident.is_empty() {
+            return false;
+        }
+
+        for c in FORBIDDEN_START_CHARS {
+            if ident.starts_with(*c) {
+                return false;
+            }
+        }
+
+        true
+    }
+
+    for ident in namespace.split('.') {
+        if !is_valid_ident(ident) {
+            return false;
+        }
+    }
+
+    true
+}
+
+/// Creates a JNI-compatible function name from the given namespace and function name.
+/// This does _not_ transform the provided function name into `snakeCase` if it's not already; but
+/// `#[allow(non_snake_case)]` should be added to prevent errors.
+///
+/// Any underscores in the original namespace or function name need to be replaced by "_1", and
+/// then dot separators need to be turned into underscores. Scala may use dollar signs in class
+/// names; those also need to be converted to `_00024`.
+fn create_jni_fn_name(namespace: &str, fn_name: &str) -> String {
+    let namespace_underscored = namespace
+        .replace('_', "_1")
+        .replace('.', "_")
+        .replace('$', "_00024");
+    let fn_name_underscored = fn_name.replace('_', "_1");
+    format!("Java_{}_{}", namespace_underscored, fn_name_underscored)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_create_jni_fn_name() {
+        assert_eq!(
+            create_jni_fn_name("com.example.Foo", "init"),
+            "Java_com_example_Foo_init"
+        );
+        assert_eq!(
+            create_jni_fn_name("com.example.Bar", "closeIt"),
+            "Java_com_example_Bar_closeIt"
+        );
+        assert_eq!(
+            create_jni_fn_name("com.example.Bar", "close_it"),
+            "Java_com_example_Bar_close_1it"
+        );
+        assert_eq!(
+            create_jni_fn_name(
+                "org.signal.client.internal.Native",
+                "IdentityKeyPair_Deserialize"
+            ),
+            "Java_org_signal_client_internal_Native_IdentityKeyPair_1Deserialize"
+        );
+        assert_eq!(
+            create_jni_fn_name("a.b.c.Test$", "show"),
+            "Java_a_b_c_Test_00024_show"
+        );
+    }
+
+    #[test]
+    fn test_valid_namespace() {
+        assert!(valid_namespace("com.example.Foo"));
+        assert!(valid_namespace("com.antonok.kb"));
+        assert!(valid_namespace("org.signal.client.internal.Native"));
+        assert!(valid_namespace("net.under_score"));
+        assert!(valid_namespace("a.b.c.Test$"));
+        assert!(!valid_namespace("com example Foo"));
+        assert!(!valid_namespace(" com.example.Foo"));
+        assert!(!valid_namespace("com.example.Foo "));
+        assert!(!valid_namespace("com.example.1Foo"));
+    }
+
+    #[test]
+    fn test_code_generation() {
+        let attr = quote::quote! {
+            "com.example.Bar"
+        };
+        let source = quote::quote! {
+            pub fn close_it(env: JNIEnv, _: JClass, filename: JString) -> jboolean {
+                unimplemented!()
+            }
+        };
+
+        let expanded = jni_mangle2(attr, source);
+
+        assert_eq!(
+            format!("{}", expanded),
+            format!(
+                "{}",
+                quote::quote! {
+                    #[unsafe(no_mangle)]
+                    #[allow(non_snake_case)]
+                    pub extern "system" fn Java_com_example_Bar_close_1it (env: JNIEnv, _: JClass, filename: JString) -> jboolean {
+                        unimplemented!()
+                    }
+                }
+            )
+        );
+    }
+
+    #[test]
+    fn test_unsafe_fn() {
+        let attr = quote::quote! {
+            "com.example.Bar"
+        };
+        let source = quote::quote! {
+            pub unsafe fn close_it(env: JNIEnv, _: JClass, filename: JString) -> jboolean {
+                unimplemented!()
+            }
+        };
+
+        let expanded = jni_mangle2(attr, source);
+
+        assert_eq!(
+            format!("{}", expanded),
+            format!(
+                "{}",
+                quote::quote! {
+                    #[unsafe(no_mangle)]
+                    #[allow(non_snake_case)]
+                    pub unsafe extern "system" fn Java_com_example_Bar_close_1it (env: JNIEnv, _: JClass, filename: JString) -> jboolean {
+                        unimplemented!()
+                    }
+                }
+            )
+        );
+    }
+
+    #[test]
+    fn test_non_function() {
+        let attr = quote::quote! { "com.example.Foo" };
+        let source = quote::quote! {
+            enum NotAFunction {
+                Variant1,
+                Variant2(u8),
+            }
+        };
+
+        let expanded = jni_mangle2(attr, source);
+
+        assert_eq!(
+            format!("{}", expanded),
+            format!(
+                "{}",
+                quote::quote! {
+                    ::core::compile_error! { "The `jni_mangle` attribute can only be applied to `fn` items" }
+                }
+            )
+        );
+    }
+
+    #[test]
+    fn test_empty_attribute() {
+        let attr = quote::quote! {};
+        let source = quote::quote! {
+            pub fn close_it(env: JNIEnv, _: JClass, filename: JString) -> jboolean {
+                unimplemented!()
+            }
+        };
+
+        let expanded = jni_mangle2(attr, source);
+
+        assert_eq!(
+            format!("{}", expanded),
+            format!(
+                "{}",
+                quote::quote! {
+                    ::core::compile_error! { "The `jni_mangle` attribute must have a single string literal supplied to specify the namespace" }
+                }
+            )
+        );
+    }
+
+    #[test]
+    fn test_invalid_namespace() {
+        let attr = quote::quote! { "." };
+        let source = quote::quote! {
+            pub fn close_it(env: JNIEnv, _: JClass, filename: JString) -> jboolean {
+                unimplemented!()
+            }
+        };
+
+        let expanded = jni_mangle2(attr, source);
+
+        assert_eq!(
+            format!("{}", expanded),
+            format!(
+                "{}",
+                quote::quote! {
+                    ::core::compile_error! { "Invalid package namespace supplied to `jni_mangle` attribute" }
+                }
+            )
+        );
+    }
+
+    #[test]
+    fn test_specified_abi() {
+        let attr = quote::quote! { "com.example.Foo" };
+        let source = quote::quote! {
+            pub extern "C" fn close_it(env: JNIEnv, _: JClass, filename: JString) -> jboolean {
+                unimplemented!()
+            }
+        };
+
+        let expanded = jni_mangle2(attr, source);
+
+        assert_eq!(
+            format!("{}", expanded),
+            format!(
+                "{}",
+                quote::quote! {
+                    ::core::compile_error! { "Don't specify an ABI for `jni_mangle` attributed functions - the correct ABI will be added automatically" }
+                }
+            )
+        );
+    }
+
+    #[test]
+    fn test_wrong_visibility() {
+        let attr = quote::quote! { "com.example.Foo" };
+        let source = quote::quote! {
+            fn close_it(env: JNIEnv, _: JClass, filename: JString) -> jboolean {
+                unimplemented!()
+            }
+        };
+
+        let expanded = jni_mangle2(attr, source);
+
+        assert_eq!(
+            format!("{}", expanded),
+            format!(
+                "{}",
+                quote::quote! {
+                    ::core::compile_error! { "`jni_mangle` attributed functions must have public visibility (`pub`)" }
+                }
+            )
+        );
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -338,3 +338,5 @@ pub mod vm;
     note = "Please use `jni::vm::JavaVM` instead of `jni::JavaVM`."
 )]
 pub use self::vm::*;
+
+pub use jni_macros::jni_mangle;


### PR DESCRIPTION
This imports the `jni_fn` macro from https://gitlab.com/antonok/jni_fn/ renamed to `jni_mangle`.

The plan is to use this internally within a `bind_java_type!{}` macro but we need to make some tweaks to the interface.

The plan is to accept the function name and signature as optional second and third arguments like:

`#[jni_mangle("foo.Bar", "nativeMethod", "(I)V")`

This ensures the macro can handle any valid Java method name (not just names that are valid as Rust identifiers).

Accepting the signature also ensures it's able to mangle overloaded methods.

The plan is to also use `export_name` instead of `no_mangle` so that the non-mangled function name remains usable from the Rust crate.

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Change is covered by [automated tests](https://github.com/jni-rs/jni-rs/blob/master/CONTRIBUTING.md#tests)
- [x] The [coding guidelines](https://github.com/jni-rs/jni-rs/blob/master/CONTRIBUTING.md#the-code-style) are followed
- [x] Public API has documentation
- [x] User-visible changes are mentioned in the Changelog
- [x] The continuous integration build passes
