### PR TITLE
jni_mangle: name + sig args + camelCase convert + export_name + `#[unsafe()]`

### DIFF
--- a/jni-macros/Cargo.toml
+++ b/jni-macros/Cargo.toml
@@ -7,10 +7,19 @@ categories = ["api-bindings", "development-tools::procedural-macro-helpers"]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/jni-rs/jni-rs"
 edition = "2024"
-include = ["../LICENSE-APACHE", "../LICENSE-MIT", "src/**", "examples/**"]
+include = [
+    "../LICENSE-APACHE",
+    "../LICENSE-MIT",
+    "build.rs",
+    "src/**",
+    "examples/**",
+]
 
 [lib]
 proc-macro = true
+
+[build-dependencies]
+rustc_version = "0.4"
 
 [dependencies]
 syn = { version = "2.0", features = ["full"] }

--- a/jni-macros/build.rs
+++ b/jni-macros/build.rs
@@ -1,0 +1,16 @@
+use rustc_version::{Version, version};
+
+// Even though the `#[unsafe(no_mangle)]` syntax is required with the 2024 edition,
+// the syntax itself was only added in 1.82.
+//
+// Since there are still projects that need to support older versions of Rust that
+// means we need to gate the usage of this syntax behind a cfg flag.
+fn main() {
+    println!("cargo::rustc-check-cfg=cfg(has_unsafe_attr)");
+
+    let v = version().expect("query rustc version");
+    // Unsafe-attribute syntax is available since 1.82
+    if v >= Version::new(1, 82, 0) {
+        println!("cargo:rustc-cfg=has_unsafe_attr");
+    }
+}

--- a/jni-macros/src/lib.rs
+++ b/jni-macros/src/lib.rs
@@ -1,29 +1,102 @@
-use crate::mangle::jni_mangle2;
-
 mod mangle;
 
-/// Annotate a function with this procedural macro attribute to expose it over the JNI.
+/// Export a Rust function with a JNI-compatible, mangled method name.
 ///
-/// This attribute takes a single string literal as an argument, specifying the package namespace
-/// this function should be placed under.
+/// This adds an appropriate `#[export_name = "..."]` attribute and `extern
+/// "system"` ABI to the function, to allow it to be resolved by a JVM when
+/// calling an associated native method.
 ///
+/// This attribute takes one to three string literal arguments:
+/// 1. Package namespace (required)
+/// 2. Method name (optional)
+/// 3. JNI signature (optional)
+///
+/// If two arguments are given, the second is inferred to be a method name if it
+/// doesn't contain '(', otherwise it's treated as a signature.
+///
+/// The name is mangled according to the JNI Specification, under "Design" ->
+/// "Resolving Native Method Names"
+///
+/// <https://docs.oracle.com/en/java/javase/11/docs/specs/jni/design.html#resolving-native-method-names>
+///
+/// ## Method Name Generation
+///
+/// If no method name is provided, the Rust function name is converted from
+/// `snake_case` to `lowerCamelCase`.
+///
+/// If the Rust function name is not entirely lowercase with underscores (i.e.
+/// it contains any uppercase letters), the name is used directly without
+/// transformation.
+///
+/// ## `snake_case` to `lowerCamelCase` Conversion Rules
+///
+/// If the input contains any uppercase letters, it's returned unchanged to
+/// preserve intentional casing.
+///
+/// Leading underscores are preserved except for one underscore that is removed.
+///
+/// Trailing underscores are preserved.
+///
+/// When capitalizing segments after underscores, the first non-numeric
+/// character is capitalized. This ensures that segments with numeric prefixes
+/// are properly capitalized.
+///
+/// Examples:
+/// - `"say_hello"` -> `"sayHello"`
+/// - `"get_user_name"` -> `"getUserName"`
+/// - `"_private_method"` -> `"privateMethod"` (one leading underscore removed)
+/// - `"__dunder__"` -> `"_dunder__"` (one leading underscore removed)
+/// - `"___priv"` -> `"__priv"` (one leading underscore removed)
+/// - `"trailing_"` -> `"trailing_"`
+/// - `"sayHello"` -> `"sayHello"` (unchanged)
+/// - `"getUserName"` -> `"getUserName"` (unchanged)
+/// - `"Foo_Bar"` -> `"Foo_Bar"` (unchanged - contains uppercase)
+/// - `"XMLParser"` -> `"XMLParser"` (unchanged - contains uppercase)
+/// - `"init"` -> `"init"` (unchanged - no underscores)
+/// - `"test_αλφα"` -> `"testΑλφα"` (Unicode-aware)
+/// - `"array_2d_foo"` -> `"array2DFoo"` (capitalizes first char after digits)
+/// - `"test_3d"` -> `"test3D"` (capitalizes first char after digits)
+///
+/// ## ABI Handling
+///
+/// The macro requires the ABI to be `extern "system"` (required for JNI).
+/// - If no ABI is specified, it will automatically be set to `extern "system"`
+/// - If `extern "system"` is already specified, it will be preserved
+/// - If any other ABI (e.g., `extern "C"`) is specified, a compile error will
+///   be generated
+///
+/// ## Examples
+///
+/// Basic usage with just namespace (function name converted to lowerCamelCase):
 /// ```
-/// use jni::{ EnvUnowned, objects::{ JClass, JString }, sys::jstring };
-/// use jni_macros::jni_mangle;
+/// # use jni::{ EnvUnowned, objects::{ JObject, JString } };
+/// # use jni_macros::jni_mangle;
 ///
+/// // Rust function in snake_case
 /// #[jni_mangle("com.example.RustBindings")]
-/// pub fn sayHello<'local>(mut unowned_env: EnvUnowned<'local>, _: JClass<'local>, name: JString<'local>) -> JString<'local> {
-///     unowned_env.with_env(|env| {
-///         let name = name.to_string();
-///
-///         env.new_string(format!("Hello, {}!", name))
-///     }).resolve::<jni::errors::ThrowRuntimeExAndDefault>()
+/// pub fn say_hello<'local>(mut env: EnvUnowned<'local>, _: JObject<'local>, name: JString<'local>) -> JString<'local> {
+///     // ...
+/// #     unimplemented!()
 /// }
+/// // Generates: Java_com_example_RustBindings_sayHello
 /// ```
 ///
-/// The `sayHello` function will automatically be expanded to have the correct ABI specification
-/// and the appropriate JNI-compatible name, i.e. in this case -
-/// `Java_com_example_RustBindings_sayHello`.
+/// Or already in lowerCamelCase (idempotent):
+/// ```
+/// # use jni::{ EnvUnowned, objects::{ JObject, JString } };
+/// # use jni_macros::jni_mangle;
+/// #[allow(non_snake_case)]
+/// #[jni_mangle("com.example.RustBindings")]
+/// pub fn sayHello<'local>(mut env: EnvUnowned<'local>, _: JObject<'local>, name: JString<'local>) -> JString<'local> {
+///     // ...
+/// #     unimplemented!()
+/// }
+/// // Generates: Java_com_example_RustBindings_sayHello
+/// ```
+///
+/// The `sayHello` function will automatically be expanded to have the correct
+/// ABI specification and the appropriate JNI-compatible name, i.e. in this case
+/// - `Java_com_example_RustBindings_sayHello`.
 ///
 /// Then it can be accessed by, for example, Kotlin code as follows:
 /// ```kotlin
@@ -37,10 +110,48 @@ mod mangle;
 ///     }
 /// }
 /// ```
+///
+/// With custom method name:
+/// ```
+/// # use jni::{ EnvUnowned, objects::JObject };
+/// # use jni_macros::jni_mangle;
+/// #[jni_mangle("com.example.RustBindings", "customMethodName")]
+/// pub fn some_rust_function<'local>(env: EnvUnowned<'local>, _: JObject<'local>) { }
+/// // Generates: Java_com_example_RustBindings_customMethodName
+/// ```
+///
+/// With signature only (overloaded method):
+/// ```
+/// # use jni::{ EnvUnowned, objects::JObject };
+/// # use jni_macros::jni_mangle;
+/// #[jni_mangle("com.example.RustBindings", "(I)Z")]
+/// pub fn boolean_method<'local>(env: EnvUnowned<'local>, _: JObject<'local>) { }
+/// // Generates: Java_com_example_RustBindings_booleanMethod__I
+/// // Note: Only argument types are encoded (I), return type (Z) is ignored
+/// ```
+///
+/// With method name and signature:
+/// ```
+/// # use jni::{ EnvUnowned, objects::JObject };
+/// # use jni_macros::jni_mangle;
+/// #[jni_mangle("com.example.RustBindings", "customName", "(Ljava/lang/String;)V")]
+/// pub fn another_function<'local>(env: EnvUnowned<'local>, _: JObject<'local>) { }
+/// // Generates: Java_com_example_RustBindings_customName__Ljava_lang_String_2
+/// // Note: Only argument types are encoded, return type (V) is ignored
+/// ```
+///
+/// Pre-existing "system" ABI is preserved:
+/// ```
+/// # use jni::{ EnvUnowned, objects::JObject };
+/// # use jni_macros::jni_mangle;
+/// #[jni_mangle("com.example.RustBindings")]
+/// pub extern "system" fn my_function<'local>(env: EnvUnowned<'local>, _: JObject<'local>) { }
+/// // The ABI will be set to "system" but you can also set it explicitly
+/// ```
 #[proc_macro_attribute]
 pub fn jni_mangle(
     attr: proc_macro::TokenStream,
     item: proc_macro::TokenStream,
 ) -> proc_macro::TokenStream {
-    jni_mangle2(attr.into(), item.into()).into()
+    mangle::jni_mangle2(attr.into(), item.into()).into()
 }

--- a/jni-macros/src/mangle.rs
+++ b/jni-macros/src/mangle.rs
@@ -31,10 +31,28 @@ pub fn jni_mangle2(attr: TokenStream, item: TokenStream) -> TokenStream {
         }
     };
 
-    let namespace = match syn::parse2::<syn::LitStr>(attr) {
-        Ok(n) => n,
-        Err(_e) => return syn::Error::new(attr_span, "The `jni_mangle` attribute must have a single string literal supplied to specify the namespace").to_compile_error(),
-    }.value();
+    // Parse the attribute arguments
+    let args: syn::punctuated::Punctuated<syn::LitStr, syn::Token![,]> =
+        match syn::parse::Parser::parse2(syn::punctuated::Punctuated::parse_terminated, attr) {
+            Ok(args) => args,
+            Err(_e) => {
+                return syn::Error::new(
+                    attr_span,
+                    "The `jni_mangle` attribute must have string literal arguments",
+                )
+                .to_compile_error();
+            }
+        };
+
+    if args.is_empty() || args.len() > 3 {
+        return syn::Error::new(
+            attr_span,
+            "The `jni_mangle` attribute must have 1-3 string literal arguments",
+        )
+        .to_compile_error();
+    }
+
+    let namespace = args[0].value();
 
     if !valid_namespace(&namespace) {
         return syn::Error::new(
@@ -46,23 +64,83 @@ pub fn jni_mangle2(attr: TokenStream, item: TokenStream) -> TokenStream {
 
     let orig_fn_name = function.sig.ident.to_string();
 
-    function.sig.ident = syn::Ident::new(
-        &create_jni_fn_name(&namespace, &orig_fn_name),
-        function.sig.ident.span(),
-    );
+    // Parse optional method name and signature
+    let (method_name, signature) = match args.len() {
+        1 => {
+            // Just namespace - derive lowerCamelCase from Rust function name
+            (snake_case_to_lower_camel_case(&orig_fn_name), None)
+        }
+        2 => {
+            // Namespace + either method name or signature
+            let second_arg = args[1].value();
+            if second_arg.contains('(') {
+                // It's a signature - derive method name from Rust function name
+                (
+                    snake_case_to_lower_camel_case(&orig_fn_name),
+                    Some(second_arg),
+                )
+            } else {
+                // It's a method name
+                (second_arg, None)
+            }
+        }
+        3 => {
+            // Namespace + method name + signature
+            (args[1].value(), Some(args[2].value()))
+        }
+        _ => unreachable!(),
+    };
 
-    function.attrs.extend([
-        parse_quote!(#[unsafe(no_mangle)]),
-        parse_quote!(#[allow(non_snake_case)]),
-    ]);
+    let mangled_jni_name = create_jni_fn_name(&namespace, &method_name, signature.as_deref());
 
-    if function.sig.abi.is_some() {
-        return syn::Error::new(function.sig.abi.span(), "Don't specify an ABI for `jni_mangle` attributed functions - the correct ABI will be added automatically").to_compile_error();
+    // Specify the name of the exported function symbol
+    //
+    // Note: we don't change `function.sig.ident` and use `#[no_mangle]` so that the function can also
+    // continue to be referenced by its Rust name within the crate.
+    if cfg!(has_unsafe_attr) {
+        // Add attributes for Rust 1.82+
+        function
+            .attrs
+            .extend([parse_quote!(#[unsafe(export_name = #mangled_jni_name)])]);
+    } else {
+        // Add attributes for older Rust versions
+        function
+            .attrs
+            .extend([parse_quote!(#[export_name = #mangled_jni_name])]);
     }
-    function.sig.abi = Some(syn::Abi {
-        extern_token: Default::default(),
-        name: Some(syn::LitStr::new("system", function.sig.ident.span())),
-    });
+
+    function
+        .attrs
+        .extend([parse_quote!(#[allow(non_snake_case)])]);
+
+    // Check ABI - must be "system" or unspecified
+    if let Some(ref abi) = function.sig.abi {
+        if let Some(ref name) = abi.name {
+            if name.value() != "system" {
+                return syn::Error::new(
+                    name.span(),
+                    format!(
+                        "`jni_mangle` attributed functions must use `extern \"system\"` ABI, found `extern \"{}\"`",
+                        name.value()
+                    ),
+                )
+                .to_compile_error();
+            }
+            // ABI is already "system", keep it as is
+        } else {
+            // extern with no explicit ABI string - set to "system"
+            function.sig.abi = Some(syn::Abi {
+                extern_token: abi.extern_token,
+                name: Some(syn::LitStr::new("system", function.sig.ident.span())),
+            });
+        }
+    } else {
+        // No ABI specified - set to "system"
+        function.sig.abi = Some(syn::Abi {
+            extern_token: Default::default(),
+            name: Some(syn::LitStr::new("system", function.sig.ident.span())),
+        });
+    }
 
     if !matches!(function.vis, syn::Visibility::Public(_)) {
         return syn::Error::new(
@@ -99,6 +177,16 @@ fn valid_namespace(namespace: &str) -> bool {
         }
     }
 
+    // Check for leading or trailing dots
+    if namespace.starts_with('.') || namespace.ends_with('.') {
+        return false;
+    }
+
+    // Check for consecutive dots (which would create empty identifiers)
+    if namespace.contains("..") {
+        return false;
+    }
+
     fn is_valid_ident(ident: &str) -> bool {
         /// These shouldn't occur as the first character of an identifier.
         const FORBIDDEN_START_CHARS: &[char] = &['0', '1', '2', '3', '4', '5', '6', '7', '8', '9'];
@@ -125,20 +213,164 @@ fn valid_namespace(namespace: &str) -> bool {
     true
 }
 
-/// Creates a JNI-compatible function name from the given namespace and function name.
+/// Converts a snake_case identifier to lowerCamelCase.
+/// This transformation is idempotent - if the input is already in lowerCamelCase, it returns unchanged.
+/// If the input contains any uppercase letters, it's returned unchanged to preserve intentional casing.
+/// Leading underscores are preserved except for one underscore that is removed.
+/// Trailing underscores are preserved.
+///
+/// When capitalizing segments after underscores, the first non-numeric character is capitalized.
+/// This ensures that segments with numeric prefixes are properly capitalized.
+///
+/// Examples:
+/// - "say_hello" -> "sayHello"
+/// - "get_user_name" -> "getUserName"
+/// - "_private_method" -> "privateMethod" (one leading underscore removed)
+/// - "__dunder__" -> "_dunder__" (one leading underscore removed)
+/// - "___priv" -> "__priv" (one leading underscore removed)
+/// - "trailing_" -> "trailing_"
+/// - "sayHello" -> "sayHello" (unchanged)
+/// - "getUserName" -> "getUserName" (unchanged)
+/// - "Foo_Bar" -> "Foo_Bar" (unchanged - contains uppercase)
+/// - "XMLParser" -> "XMLParser" (unchanged - contains uppercase)
+/// - "init" -> "init" (unchanged - no underscores)
+/// - "test_αλφα" -> "testΑλφα" (Unicode-aware)
+/// - "array_2d_foo" -> "array2DFoo" (capitalizes first char after digits)
+/// - "test_3d" -> "test3D" (capitalizes first char after digits)
+pub fn snake_case_to_lower_camel_case(s: &str) -> String {
+    // If the string contains any uppercase letters, assume it's intentionally cased
+    // and return it unchanged
+    if s.chars().any(|c| c.is_uppercase()) {
+        return s.to_string();
+    }
+
+    // Find leading underscores
+    let leading_underscores = s.chars().take_while(|&c| c == '_').count();
+
+    // Find trailing underscores
+    let trailing_underscores = s.chars().rev().take_while(|&c| c == '_').count();
+
+    // If the entire string is underscores, return as-is
+    if leading_underscores + trailing_underscores >= s.len() {
+        return s.to_string();
+    }
+
+    // Extract the middle part (without leading/trailing underscores)
+    let middle = &s[leading_underscores..s.len() - trailing_underscores];
+
+    // Convert the middle part
+    let mut result = String::new();
+    let mut capitalize_next = false;
+
+    for c in middle.chars() {
+        if c == '_' {
+            capitalize_next = true;
+        } else if capitalize_next {
+            // If this is a digit, just add it and keep looking for the first non-digit to capitalize
+            if c.is_ascii_digit() {
+                result.push(c);
+            } else {
+                // Use Unicode-aware uppercase conversion on the first non-digit character
+                for upper_c in c.to_uppercase() {
+                    result.push(upper_c);
+                }
+                capitalize_next = false;
+            }
+        } else {
+            result.push(c);
+        }
+    }
+
+    // Reconstruct with leading and trailing underscores
+    // Remove one leading underscore (if any exist)
+    let adjusted_leading_underscores = if leading_underscores > 0 {
+        leading_underscores - 1
+    } else {
+        0
+    };
+
+    let mut final_result = String::with_capacity(s.len());
+    for _ in 0..adjusted_leading_underscores {
+        final_result.push('_');
+    }
+    final_result.push_str(&result);
+    for _ in 0..trailing_underscores {
+        final_result.push('_');
+    }
+
+    final_result
+}
+
+/// Creates a JNI-compatible function name from the given namespace, function name, and optional signature.
 /// This does _not_ transform the provided function name into `snakeCase` if it's not already; but
 /// `#[allow(non_snake_case)]` should be added to prevent errors.
 ///
 /// Any underscores in the original namespace or function name need to be replaced by "_1", and
-/// then dot separators need to be turned into underscores. Scala may use dollar signs in class
-/// names; those also need to be converted to `_00024`.
-fn create_jni_fn_name(namespace: &str, fn_name: &str) -> String {
-    let namespace_underscored = namespace
-        .replace('_', "_1")
-        .replace('.', "_")
-        .replace('$', "_00024");
-    let fn_name_underscored = fn_name.replace('_', "_1");
-    format!("Java_{}_{}", namespace_underscored, fn_name_underscored)
+/// then dot separators need to be turned into underscores.
+///
+/// For signatures (if provided), only the argument types (between parentheses) are encoded:
+/// - '_' -> "_1"
+/// - ';' -> "_2"
+/// - '[' -> "_3"
+/// - '/' -> "_"
+/// - Non-ASCII characters (including '$') -> "_0xxxx" where xxxx is the lowercase hex Unicode codepoint
+///
+/// The return type is ignored, and parentheses are not included in the mangled name.
+pub fn create_jni_fn_name(namespace: &str, fn_name: &str, signature: Option<&str>) -> String {
+    fn mangle_identifier(s: &str) -> String {
+        let mut result = String::new();
+        for c in s.chars() {
+            match c {
+                '_' => result.push_str("_1"),
+                '.' => result.push('_'),
+                // Handle ASCII alphanumeric and safe characters
+                _ if c.is_ascii_alphanumeric() => result.push(c),
+                // Everything else (including '$' and non-ASCII) gets encoded
+                _ => result.push_str(&format!("_0{:04x}", c as u32)),
+            }
+        }
+        result
+    }
+
+    fn mangle_signature_args(s: &str) -> String {
+        let mut result = String::new();
+        for c in s.chars() {
+            match c {
+                '_' => result.push_str("_1"),
+                ';' => result.push_str("_2"),
+                '[' => result.push_str("_3"),
+                '/' => result.push('_'),
+                _ if c.is_ascii_alphanumeric() => result.push(c),
+                _ => {
+                    // Non-ASCII character or other special chars - encode as _0xxxx
+                    result.push_str(&format!("_0{:04x}", c as u32));
+                }
+            }
+        }
+        result
+    }
+
+    let namespace_underscored = mangle_identifier(namespace);
+    let fn_name_underscored = mangle_identifier(fn_name);
+
+    let mut result = format!("Java_{}_{}", namespace_underscored, fn_name_underscored);
+
+    if let Some(sig) = signature {
+        // Extract only the argument types (between parentheses), ignoring return type
+        #[allow(clippy::collapsible_if)]
+        if let Some(start) = sig.find('(') {
+            if let Some(end) = sig.find(')') {
+                let args = &sig[start + 1..end];
+                // Always add __ when signature is provided (indicates overloaded method)
+                result.push_str("__");
+                if !args.is_empty() {
+                    result.push_str(&mangle_signature_args(args));
+                }
+            }
+        }
+    }
+
+    result
 }
 
 #[cfg(test)]
@@ -147,42 +379,86 @@ mod tests {
 
     #[test]
     fn test_create_jni_fn_name() {
+        // Basic namespace and function name tests
         assert_eq!(
-            create_jni_fn_name("com.example.Foo", "init"),
+            create_jni_fn_name("com.example.Foo", "init", None),
             "Java_com_example_Foo_init"
         );
         assert_eq!(
-            create_jni_fn_name("com.example.Bar", "closeIt"),
+            create_jni_fn_name("com.example.Bar", "closeIt", None),
             "Java_com_example_Bar_closeIt"
         );
         assert_eq!(
-            create_jni_fn_name("com.example.Bar", "close_it"),
+            create_jni_fn_name("com.example.Bar", "close_it", None),
             "Java_com_example_Bar_close_1it"
         );
         assert_eq!(
             create_jni_fn_name(
                 "org.signal.client.internal.Native",
-                "IdentityKeyPair_Deserialize"
+                "IdentityKeyPair_Deserialize",
+                None
             ),
             "Java_org_signal_client_internal_Native_IdentityKeyPair_1Deserialize"
         );
         assert_eq!(
-            create_jni_fn_name("a.b.c.Test$", "show"),
+            create_jni_fn_name("a.b.c.Test$", "show", None),
             "Java_a_b_c_Test_00024_show"
+        );
+
+        // Tests with signatures - only argument types are encoded, no parens or return type
+        assert_eq!(
+            create_jni_fn_name("com.example.Foo", "method", Some("(I)Z")),
+            "Java_com_example_Foo_method__I"
+        );
+        assert_eq!(
+            create_jni_fn_name("com.example.Bar", "test", Some("(Ljava/lang/String;)V")),
+            "Java_com_example_Bar_test__Ljava_lang_String_2"
+        );
+        assert_eq!(
+            create_jni_fn_name("a.b.Test", "arrayMethod", Some("([I)[Ljava/lang/Object;")),
+            "Java_a_b_Test_arrayMethod___3I"
+        );
+        assert_eq!(
+            create_jni_fn_name(
+                "com.example.Test",
+                "complex_method",
+                Some("([[Ljava/lang/String;I)[[I")
+            ),
+            "Java_com_example_Test_complex_1method___3_3Ljava_lang_String_2I"
+        );
+        // Test with no arguments (empty parentheses) - should still have __ suffix
+        assert_eq!(
+            create_jni_fn_name("com.example.Foo", "noArgs", Some("()V")),
+            "Java_com_example_Foo_noArgs__"
         );
     }
 
     #[test]
     fn test_valid_namespace() {
+        // Valid namespaces
         assert!(valid_namespace("com.example.Foo"));
         assert!(valid_namespace("com.antonok.kb"));
         assert!(valid_namespace("org.signal.client.internal.Native"));
         assert!(valid_namespace("net.under_score"));
         assert!(valid_namespace("a.b.c.Test$"));
+
+        // Invalid namespaces - spaces and special characters
         assert!(!valid_namespace("com example Foo"));
         assert!(!valid_namespace(" com.example.Foo"));
         assert!(!valid_namespace("com.example.Foo "));
         assert!(!valid_namespace("com.example.1Foo"));
+
+        // Invalid namespaces - leading dots
+        assert!(!valid_namespace(".com.example.Foo"));
+        assert!(!valid_namespace("."));
+
+        // Invalid namespaces - trailing dots
+        assert!(!valid_namespace("com.example.Foo."));
+
+        // Invalid namespaces - consecutive dots
+        assert!(!valid_namespace("com..example.Foo"));
+        assert!(!valid_namespace("com...example.Foo"));
+        assert!(!valid_namespace("com.example..Foo"));
     }
 
     #[test]
@@ -198,14 +474,15 @@ mod tests {
 
         let expanded = jni_mangle2(attr, source);
 
+        // Note: close_it becomes closeIt (lowerCamelCase)
         assert_eq!(
             format!("{}", expanded),
             format!(
                 "{}",
                 quote::quote! {
-                    #[unsafe(no_mangle)]
+                    #[unsafe(export_name = "Java_com_example_Bar_closeIt")]
                     #[allow(non_snake_case)]
-                    pub extern "system" fn Java_com_example_Bar_close_1it (env: JNIEnv, _: JClass, filename: JString) -> jboolean {
+                    pub extern "system" fn close_it(env: JNIEnv, _: JClass, filename: JString) -> jboolean {
                         unimplemented!()
                     }
                 }
@@ -226,14 +503,15 @@ mod tests {
 
         let expanded = jni_mangle2(attr, source);
 
+        // Note: close_it becomes closeIt (lowerCamelCase)
         assert_eq!(
             format!("{}", expanded),
             format!(
                 "{}",
                 quote::quote! {
-                    #[unsafe(no_mangle)]
+                    #[unsafe(export_name = "Java_com_example_Bar_closeIt")]
                     #[allow(non_snake_case)]
-                    pub unsafe extern "system" fn Java_com_example_Bar_close_1it (env: JNIEnv, _: JClass, filename: JString) -> jboolean {
+                    pub unsafe extern "system" fn close_it(env: JNIEnv, _: JClass, filename: JString) -> jboolean {
                         unimplemented!()
                     }
                 }
@@ -280,7 +558,7 @@ mod tests {
             format!(
                 "{}",
                 quote::quote! {
-                    ::core::compile_error! { "The `jni_mangle` attribute must have a single string literal supplied to specify the namespace" }
+                    ::core::compile_error! { "The `jni_mangle` attribute must have 1-3 string literal arguments" }
                 }
             )
         );
@@ -309,22 +587,45 @@ mod tests {
     }
 
     #[test]
-    fn test_specified_abi() {
+    fn test_wrong_abi_generates_error() {
         let attr = quote::quote! { "com.example.Foo" };
         let source = quote::quote! {
-            pub extern "C" fn close_it(env: JNIEnv, _: JClass, filename: JString) -> jboolean {
+            pub extern "C" fn closeIt(env: JNIEnv, _: JClass, filename: JString) -> jboolean {
                 unimplemented!()
             }
         };
 
         let expanded = jni_mangle2(attr, source);
 
+        // Should generate an error for non-system ABI
+        let expanded_str = format!("{}", expanded);
+        assert!(expanded_str.contains("compile_error"));
+        assert!(expanded_str.contains("must use `extern \\\"system\\\"` ABI"));
+        assert!(expanded_str.contains("found `extern \\\"C\\\"`"));
+    }
+
+    #[test]
+    fn test_system_abi_is_preserved() {
+        let attr = quote::quote! { "com.example.Foo" };
+        let source = quote::quote! {
+            pub extern "system" fn closeIt(env: JNIEnv, _: JClass, filename: JString) -> jboolean {
+                unimplemented!()
+            }
+        };
+
+        let expanded = jni_mangle2(attr, source);
+
+        // The "system" ABI should be preserved
         assert_eq!(
             format!("{}", expanded),
             format!(
                 "{}",
                 quote::quote! {
-                    ::core::compile_error! { "Don't specify an ABI for `jni_mangle` attributed functions - the correct ABI will be added automatically" }
+                    #[unsafe(export_name = "Java_com_example_Foo_closeIt")]
+                    #[allow(non_snake_case)]
+                    pub extern "system" fn closeIt (env: JNIEnv, _: JClass, filename: JString) -> jboolean {
+                        unimplemented!()
+                    }
                 }
             )
         );
@@ -347,6 +648,277 @@ mod tests {
                 "{}",
                 quote::quote! {
                     ::core::compile_error! { "`jni_mangle` attributed functions must have public visibility (`pub`)" }
+                }
+            )
+        );
+    }
+
+    #[test]
+    fn test_with_method_name() {
+        let attr = quote::quote! {
+            "com.example.Bar", "customMethod"
+        };
+        let source = quote::quote! {
+            pub fn rust_function(env: JNIEnv, _: JClass) -> jboolean {
+                unimplemented!()
+            }
+        };
+
+        let expanded = jni_mangle2(attr, source);
+
+        assert_eq!(
+            format!("{}", expanded),
+            format!(
+                "{}",
+                quote::quote! {
+                    #[unsafe(export_name = "Java_com_example_Bar_customMethod")]
+                    #[allow(non_snake_case)]
+                    pub extern "system" fn rust_function (env: JNIEnv, _: JClass) -> jboolean {
+                        unimplemented!()
+                    }
+                }
+            )
+        );
+    }
+
+    #[test]
+    fn test_with_signature_only() {
+        let attr = quote::quote! {
+            "com.example.Bar", "(I)Z"
+        };
+        let source = quote::quote! {
+            pub fn boolMethod(env: JNIEnv, _: JClass) -> jboolean {
+                unimplemented!()
+            }
+        };
+
+        let expanded = jni_mangle2(attr, source);
+
+        assert_eq!(
+            format!("{}", expanded),
+            format!(
+                "{}",
+                quote::quote! {
+                    #[unsafe(export_name = "Java_com_example_Bar_boolMethod__I")]
+                    #[allow(non_snake_case)]
+                    pub extern "system" fn boolMethod (env: JNIEnv, _: JClass) -> jboolean {
+                        unimplemented!()
+                    }
+                }
+            )
+        );
+    }
+
+    #[test]
+    fn test_with_method_name_and_signature() {
+        let attr = quote::quote! {
+            "com.example.Bar", "testMethod", "(Ljava/lang/String;)V"
+        };
+        let source = quote::quote! {
+            pub fn rust_func(env: JNIEnv, _: JClass) {
+                unimplemented!()
+            }
+        };
+
+        let expanded = jni_mangle2(attr, source);
+
+        assert_eq!(
+            format!("{}", expanded),
+            format!(
+                "{}",
+                quote::quote! {
+                    #[unsafe(export_name = "Java_com_example_Bar_testMethod__Ljava_lang_String_2")]
+                    #[allow(non_snake_case)]
+                    pub extern "system" fn rust_func (env: JNIEnv, _: JClass) {
+                        unimplemented!()
+                    }
+                }
+            )
+        );
+    }
+
+    #[test]
+    fn test_snake_case_to_lower_camel_case() {
+        // Basic conversions
+        assert_eq!(snake_case_to_lower_camel_case("say_hello"), "sayHello");
+        assert_eq!(
+            snake_case_to_lower_camel_case("get_user_name"),
+            "getUserName"
+        );
+        assert_eq!(snake_case_to_lower_camel_case("init"), "init");
+        assert_eq!(snake_case_to_lower_camel_case("close_it"), "closeIt");
+
+        // Idempotent - already lowerCamelCase
+        assert_eq!(snake_case_to_lower_camel_case("sayHello"), "sayHello");
+        assert_eq!(snake_case_to_lower_camel_case("getUserName"), "getUserName");
+        assert_eq!(snake_case_to_lower_camel_case("closeIt"), "closeIt");
+
+        // Mixed case - preserved unchanged
+        assert_eq!(snake_case_to_lower_camel_case("Foo_Bar"), "Foo_Bar");
+        assert_eq!(snake_case_to_lower_camel_case("XMLParser"), "XMLParser");
+        assert_eq!(snake_case_to_lower_camel_case("IOError"), "IOError");
+        assert_eq!(snake_case_to_lower_camel_case("HTML_Parser"), "HTML_Parser");
+
+        // Unicode support
+        assert_eq!(snake_case_to_lower_camel_case("café_résumé"), "caféRésumé");
+        assert_eq!(snake_case_to_lower_camel_case("ß_test"), "ßTest");
+        assert_eq!(snake_case_to_lower_camel_case("test_αλφα"), "testΑλφα");
+        assert_eq!(
+            snake_case_to_lower_camel_case("method_привет"),
+            "methodПривет"
+        );
+
+        // Leading underscores - one is removed
+        assert_eq!(
+            snake_case_to_lower_camel_case("_private_method"),
+            "privateMethod"
+        );
+        assert_eq!(snake_case_to_lower_camel_case("__dunder__"), "_dunder__");
+        assert_eq!(snake_case_to_lower_camel_case("_leading"), "leading");
+        assert_eq!(
+            snake_case_to_lower_camel_case("__leading_multiple"),
+            "_leadingMultiple"
+        );
+        assert_eq!(snake_case_to_lower_camel_case("___priv"), "__priv");
+        assert_eq!(snake_case_to_lower_camel_case("_priv_name"), "privName");
+        assert_eq!(snake_case_to_lower_camel_case("__priv_name"), "_privName");
+
+        // Trailing underscores preserved
+        assert_eq!(snake_case_to_lower_camel_case("trailing_"), "trailing_");
+        assert_eq!(
+            snake_case_to_lower_camel_case("trailing_multiple__"),
+            "trailingMultiple__"
+        );
+        assert_eq!(snake_case_to_lower_camel_case("_a_"), "a_");
+        assert_eq!(snake_case_to_lower_camel_case("_foo_bar_"), "fooBar_");
+
+        // All underscores
+        assert_eq!(snake_case_to_lower_camel_case("___"), "___");
+
+        // Edge cases
+        assert_eq!(snake_case_to_lower_camel_case("a_b_c"), "aBC");
+
+        // Numeric prefixes - capitalize first non-digit character
+        assert_eq!(snake_case_to_lower_camel_case("array_2d_foo"), "array2DFoo");
+        assert_eq!(snake_case_to_lower_camel_case("test_3d"), "test3D");
+        assert_eq!(snake_case_to_lower_camel_case("foo_123bar"), "foo123Bar");
+        assert_eq!(snake_case_to_lower_camel_case("get_2d_array"), "get2DArray");
+        assert_eq!(snake_case_to_lower_camel_case("test_42"), "test42");
+        assert_eq!(snake_case_to_lower_camel_case("a_1_b"), "a1B");
+    }
+
+    #[test]
+    fn test_snake_case_function_name_conversion() {
+        // Test that snake_case function names are automatically converted to lowerCamelCase
+        let attr = quote::quote! {
+            "com.example.Bar"
+        };
+        let source = quote::quote! {
+            pub fn say_hello_world(env: JNIEnv, _: JClass) {
+                unimplemented!()
+            }
+        };
+
+        let expanded = jni_mangle2(attr, source);
+
+        assert_eq!(
+            format!("{}", expanded),
+            format!(
+                "{}",
+                quote::quote! {
+                    #[unsafe(export_name = "Java_com_example_Bar_sayHelloWorld")]
+                    #[allow(non_snake_case)]
+                    pub extern "system" fn say_hello_world (env: JNIEnv, _: JClass) {
+                        unimplemented!()
+                    }
+                }
+            )
+        );
+    }
+
+    #[test]
+    fn test_camel_case_function_name_unchanged() {
+        // Test that lowerCamelCase function names remain unchanged (idempotent)
+        let attr = quote::quote! {
+            "com.example.Bar"
+        };
+        let source = quote::quote! {
+            pub fn sayHelloWorld(env: JNIEnv, _: JClass) {
+                unimplemented!()
+            }
+        };
+
+        let expanded = jni_mangle2(attr, source);
+
+        assert_eq!(
+            format!("{}", expanded),
+            format!(
+                "{}",
+                quote::quote! {
+                    #[unsafe(export_name = "Java_com_example_Bar_sayHelloWorld")]
+                    #[allow(non_snake_case)]
+                    pub extern "system" fn sayHelloWorld (env: JNIEnv, _: JClass) {
+                        unimplemented!()
+                    }
+                }
+            )
+        );
+    }
+
+    #[test]
+    fn test_snake_case_with_signature() {
+        // Test that snake_case function names are converted even when signature is present
+        let attr = quote::quote! {
+            "com.example.Bar", "(I)Z"
+        };
+        let source = quote::quote! {
+            pub fn check_valid(env: JNIEnv, _: JClass) -> jboolean {
+                unimplemented!()
+            }
+        };
+
+        let expanded = jni_mangle2(attr, source);
+
+        assert_eq!(
+            format!("{}", expanded),
+            format!(
+                "{}",
+                quote::quote! {
+                    #[unsafe(export_name = "Java_com_example_Bar_checkValid__I")]
+                    #[allow(non_snake_case)]
+                    pub extern "system" fn check_valid (env: JNIEnv, _: JClass) -> jboolean {
+                        unimplemented!()
+                    }
+                }
+            )
+        );
+    }
+
+    #[test]
+    fn test_signature_with_no_args() {
+        // Test that signatures with no arguments still add __ suffix (for overloaded methods)
+        let attr = quote::quote! {
+            "com.example.Bar", "()V"
+        };
+        let source = quote::quote! {
+            pub fn noArgs(env: JNIEnv, _: JClass) {
+                unimplemented!()
+            }
+        };
+
+        let expanded = jni_mangle2(attr, source);
+
+        // Should have __ even with no arguments (indicates overloaded method)
+        assert_eq!(
+            format!("{}", expanded),
+            format!(
+                "{}",
+                quote::quote! {
+                    #[unsafe(export_name = "Java_com_example_Bar_noArgs__")]
+                    #[allow(non_snake_case)]
+                    pub extern "system" fn noArgs (env: JNIEnv, _: JClass) {
+                        unimplemented!()
+                    }
                 }
             )
         );


### PR DESCRIPTION
This makes a number of changes to the jni_mangle macro...

The macro now accept three arguments:
1. The package name (required / as before)
2. The method name (optional)
3. The method JNI signature (optional)

If two args are given then if the second arg contains brackets it will be treated as a signature.

# Use 'export_name' attribute

The macro now emits an `#[export_name = "Java_..."]` attribute instead of renaming the Rust function itself and adding `#[no_mangle]`. This way the function can continue to be referenced from the Rust crate.

# `#[unsafe()]`

With Rust >= 1.82 we wrap the `export_name` with `#[unsafe()]` for compatibility with newer Rust editions.

# Supports names that can't be represented as a Rust ident

The method name argument allows the macro to mangle names that aren't valid Rust function names (such as `fooBar$Baz`)

# Supports overloaded methods + unicode

The JNI signature argument allows the macro to encode a fully-qualified name that also allows native method overloads.

Instead of having one special-case for encoding the '$' character, this also implements general support for encoding any non-ascii characters in the form `_0xxxx` where `xxxx` is the unicode codepoint in lower-case hex.

This also makes sure to encode `;` and `[` as `_2` and `_3` respectively (when encoding the arguments of a JNI signature).

# Error for non-"system" ABI

The macro allows for the initial function to already have the "system" ABI be specified - but any other explicit ABI will still trigger an error.

# snake_case to lowerCamelCase

If no method name is explicitly specified then instead of directly taking the Rust function name as the name, the macro will first convert a lower_snake_case name to camelCase, preserving any leading or trailing underscores, except for one leading underscore.

Note: no camelCase transform is done if the Rust function has any upper-case characters, so a name like `fooBar_Baz` would be used as-is, and for anything extra-weird the name can be given to the macro as a string literal.

When validating the package name the macro will now throw an error if the package name starts with a '.' or contains any double dots.


### Definition of Done

- [x] There are no TODOs left in the code
- [x] Change is covered by [automated tests](https://github.com/jni-rs/jni-rs/blob/master/CONTRIBUTING.md#tests)
- [x] The [coding guidelines](https://github.com/jni-rs/jni-rs/blob/master/CONTRIBUTING.md#the-code-style) are followed
- [x] Public API has documentation
- [x] User-visible changes are mentioned in the Changelog
- [x] The continuous integration build passes
