### PR TITLE
jni-macros: add jni_str + jni_cstr macros

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -101,6 +101,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 #### Macros
 
 - The `#[jni_mangle()]` attribute proc macro can export an `extern "system"` native method with a mangled name like "Java_com_example_myMethod" so it can be automatically resolved within a shared library by the JVM ([#693](https://github.com/jni-rs/jni-rs/pull/693))
+- The `jni_str!` and `jni_cstr!` macros can encode a MUTF-8 `&'static JNIStr` or `&' static CStr` at compile time with full unicode support.
 
 ### Changed
 

--- a/jni-macros/Cargo.toml
+++ b/jni-macros/Cargo.toml
@@ -25,6 +25,8 @@ rustc_version = "0.4"
 syn = { version = "2.0", features = ["full"] }
 quote = "1.0"
 proc-macro2 = "1.0"
+proc-macro-crate = "3"
+cesu8 = "1.1.0"
 
 [dev-dependencies]
 jni = { path = "../", version = "0.21.0", features = ["invocation"] }

--- a/jni-macros/examples/jni_str.rs
+++ b/jni-macros/examples/jni_str.rs
@@ -1,0 +1,44 @@
+//! Example demonstrating the jni_str! macro
+//!
+//! This macro converts UTF-8 string literals to MUTF-8 encoded literals at compile time.
+//! MUTF-8 is Java's modified UTF-8 encoding used for JNI string operations.
+
+use jni::strings::JNIStr;
+use jni_macros::jni_str;
+
+#[allow(unused)]
+fn main() {
+    // Basic usage - creates &'static JNIStr with MUTF-8 encoding
+    const CLASS_NAME: &JNIStr = jni_str!("java.lang.String");
+    const PACKAGE: &JNIStr = jni_str!("com.example.myapp");
+
+    // Concatenating multiple literals
+    const FULL_CLASS: &JNIStr = jni_str!("java.lang.", "String");
+    const VERSION: &JNIStr = jni_str!("Version ", 1, '.', 0);
+
+    // Common JNI use cases
+    const ARRAY_LIST: &JNIStr = jni_str!("java.util.ArrayList");
+    const HASH_MAP: &JNIStr = jni_str!("java.util.HashMap");
+    const TO_STRING: &JNIStr = jni_str!("toString");
+    const GET_VALUE: &JNIStr = jni_str!("getValue");
+    const VALUE_FIELD: &JNIStr = jni_str!("value");
+    const COUNT_FIELD: &JNIStr = jni_str!("count");
+
+    // Inner classes (using $ separator)
+    const OUTER_INNER: &JNIStr = jni_str!("com.example.Outer$Inner");
+    const MAP_ENTRY: &JNIStr = jni_str!("java.util.Map$Entry");
+
+    // Unicode support - Japanese characters
+    const JP_CLASS: &JNIStr = jni_str!("jp.こんにちは.App");
+
+    // Emoji (encoded as MUTF-8 surrogate pairs)
+    // Note: High Unicode chars (U+10000+) are encoded as 6-byte surrogate pairs
+    const EMOJI_CLASS: &JNIStr = jni_str!("emoji.MyApp😀");
+
+    // Using in const fn
+    const fn get_class() -> &'static JNIStr {
+        jni_str!("com.example.MyClass")
+    }
+
+    const MY_CLASS: &JNIStr = get_class();
+}

--- a/jni-macros/src/lib.rs
+++ b/jni-macros/src/lib.rs
@@ -1,4 +1,77 @@
 mod mangle;
+mod str;
+mod utils;
+
+/// Converts UTF-8 string literals to a MUTF-8 encoded `&'static JNIStr`.
+///
+/// This macro takes one or more literals and encodes them using Java's Modified UTF-8
+/// (MUTF-8) format, returning a `&'static JNIStr`.
+///
+/// Like the `concat!` macro, multiple literals can be provided and will be converted to
+/// strings and concatenated before encoding.
+///
+/// Supported literal types:
+/// - String literals (`"..."`)
+/// - Character literals (`'c'`)
+/// - Integer literals (`42`, `-10`)
+/// - Float literals (`3.14`, `1.0`)
+/// - Boolean literals (`true`, `false`)
+/// - Byte literals (`b'A'` - formatted as numeric value)
+/// - C-string literals (`c"..."` - must be valid UTF-8)
+///
+/// MUTF-8 is Java's variant of UTF-8 that:
+/// - Encodes the null character (U+0000) as `0xC0 0x80` instead of `0x00`
+/// - Encodes Unicode characters above U+FFFF using CESU-8 (surrogate pairs)
+///
+/// This is the most type-safe way to create JNI string literals, as it returns a
+/// `JNIStr` which is directly compatible with the jni crate's API.
+///
+/// # Syntax
+///
+/// ```
+/// # use jni::jni_str;
+/// # extern crate jni as jni2;
+/// jni_str!("string literal");
+/// jni_str!("part1", "part2", "part3");  // Concatenates before encoding
+/// jni_str!("value: ", 42);               // Mix different literal types
+/// jni_str!(jni = jni2, "string literal");  // Override jni crate path (must be first)
+/// ```
+///
+/// # Examples
+///
+/// ```
+/// use jni::{jni_str, strings::JNIStr};
+///
+/// const CLASS_NAME: &JNIStr = jni_str!("java.lang.String");
+/// // Result: &'static JNIStr for "java.lang.String" (MUTF-8 encoded)
+///
+/// const EMOJI_CLASS: &JNIStr = jni_str!("unicode.Type😀");
+/// // Result: &'static JNIStr with emoji encoded as surrogate pair
+///
+/// const PACKAGE_CLASS: &JNIStr = jni_str!("java.lang.", "String");
+/// // Result: &'static JNIStr for "java.lang.String" (concatenated then MUTF-8 encoded)
+///
+/// const PORT: &JNIStr = jni_str!("localhost:", 8080);
+/// // Result: &'static JNIStr for "localhost:8080" (mixed literal types concatenated)
+/// ```
+#[proc_macro]
+pub fn jni_str(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
+    str::jni_str_impl(input.into())
+        .unwrap_or_else(|e| e.to_compile_error())
+        .into()
+}
+
+/// Converts UTF-8 string literals to a MUTF-8 encoded CStr literal.
+///
+/// This macro is equivalent to [`jni_str!`] but returns a `&CStr` instead of a `&'static JNIStr`.
+///
+/// See the [`jni_str!`] macro documentation for detailed syntax and examples.
+#[proc_macro]
+pub fn jni_cstr(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
+    str::jni_cstr_impl(input.into())
+        .unwrap_or_else(|e| e.to_compile_error())
+        .into()
+}
 
 /// Export a Rust function with a JNI-compatible, mangled method name.
 ///

--- a/jni-macros/src/str.rs
+++ b/jni-macros/src/str.rs
@@ -1,0 +1,381 @@
+//! String utilities for JNI signature and class name handling
+//!
+//! This module provides utilities for encoding strings to Java's Modified UTF-8 (MUTF-8)
+//! format and creating CStr and JNIStr literals for use in procedural macros.
+
+use proc_macro2::Span;
+use syn::LitCStr;
+
+/// Encode a UTF-8 string as MUTF-8 (Java's modified UTF-8)
+///
+/// Java uses a modified version of UTF-8 that:
+/// - Encodes the null character (U+0000) as `0xC0 0x80` instead of `0x00`
+/// - Encodes Unicode characters above U+FFFF using CESU-8 (surrogate pairs)
+///
+/// # Examples
+///
+/// ```ignore
+/// let mutf8_bytes = encode_mutf8("Hello");
+/// // Basic ASCII is unchanged
+///
+/// let mutf8_emoji = encode_mutf8("😀");
+/// // Emoji encoded as surrogate pairs in MUTF-8
+/// ```
+pub fn encode_mutf8(s: &str) -> Vec<u8> {
+    cesu8::to_java_cesu8(s).into_owned()
+}
+
+/// Create a LitCStr from a string with MUTF-8 encoding
+///
+/// This function takes a UTF-8 string, encodes it to MUTF-8, and creates
+/// a `syn::LitCStr` for use in procedural macros.
+///
+/// # Safety
+///
+/// MUTF-8 encoded strings should not contain NUL bytes (except encoded as \xC0\x80).
+/// The function uses `CString::from_vec_unchecked` which is safe for MUTF-8 encoded data.
+///
+/// # Examples
+///
+/// ```ignore
+/// let cstr = lit_cstr_mutf8("java.lang.String");
+/// // Creates c"java.lang.String" with MUTF-8 encoding
+/// ```
+pub fn lit_cstr_mutf8(s: &str) -> LitCStr {
+    let mutf8 = encode_mutf8(s);
+    // Safety: MUTF-8 encoded strings should not contain NUL bytes (except encoded as \xC0\x80)
+    let c = unsafe { std::ffi::CString::from_vec_unchecked(mutf8) };
+    LitCStr::new(&c, Span::call_site())
+}
+
+use proc_macro2::TokenStream;
+use quote::quote;
+use syn::{Lit, Result, Token, parse::Parse};
+
+/// Convert a literal to a string value for concatenation
+fn literal_to_string(lit: &Lit) -> Result<String> {
+    match lit {
+        Lit::Str(s) => Ok(s.value()),
+        Lit::Char(c) => Ok(c.value().to_string()),
+        Lit::Int(i) => Ok(i.base10_digits().to_string()),
+        Lit::Float(f) => Ok(f.base10_digits().to_string()),
+        Lit::Bool(b) => Ok(b.value.to_string()),
+        Lit::Byte(b) => {
+            // Bytes are formatted as their numeric value
+            Ok(b.value().to_string())
+        }
+        Lit::CStr(c) => {
+            // CStr must be valid UTF-8 for our purposes
+            let cstr = c.value();
+            cstr.to_str().map(|s| s.to_string()).map_err(|e| {
+                syn::Error::new_spanned(c, format!("CStr literal must contain valid UTF-8: {}", e))
+            })
+        }
+        Lit::ByteStr(_) => Err(syn::Error::new_spanned(
+            lit,
+            "byte string literals are not supported in jni_str!/jni_cstr! macros",
+        )),
+        Lit::Verbatim(_) => Err(syn::Error::new_spanned(
+            lit,
+            "verbatim literals are not supported in jni_str!/jni_cstr! macros",
+        )),
+        // Lit is marked as non_exhaustive, so we need a wildcard pattern
+        _ => Err(syn::Error::new_spanned(
+            lit,
+            "unsupported literal type in jni_str!/jni_cstr! macros",
+        )),
+    }
+}
+
+/// Input for jni_cstr! and jni_str! macros
+/// Supports:
+/// - Multiple comma-separated literals (like concat!)
+/// - Optional `jni = <path>` as the first argument
+struct JniStrInput {
+    jni_crate: syn::Path,
+    string: String,
+}
+
+impl Parse for JniStrInput {
+    fn parse(input: syn::parse::ParseStream) -> Result<Self> {
+        let jni_crate = crate::utils::parse_jni_crate_override(&input)?;
+
+        // Parse comma-separated literals (like concat!)
+        let mut concatenated = String::new();
+
+        if input.is_empty() {
+            return Err(syn::Error::new(
+                input.span(),
+                "expected at least one literal",
+            ));
+        }
+
+        loop {
+            let lit = input.parse::<Lit>()?;
+            let value = literal_to_string(&lit)?;
+            concatenated.push_str(&value);
+
+            if input.is_empty() {
+                break;
+            }
+
+            input.parse::<Token![,]>()?;
+
+            if input.is_empty() {
+                break;
+            }
+        }
+
+        Ok(JniStrInput {
+            jni_crate,
+            string: concatenated,
+        })
+    }
+}
+
+/// Implementation for jni_cstr! macro
+/// Takes UTF-8 string literals and returns a MUTF-8 encoded CStr literal
+/// Supports:
+/// - Multiple comma-separated string literals (like concat!)
+/// - Optional `jni = <path>` as the first argument
+pub fn jni_cstr_impl(input: TokenStream) -> Result<TokenStream> {
+    let JniStrInput { string, .. } = syn::parse2(input)?;
+
+    // Create a C string literal with MUTF-8 encoding
+    let cstr = lit_cstr_mutf8(&string);
+
+    Ok(quote! {
+        #cstr
+    })
+}
+
+/// Implementation for jni_str! macro
+/// Takes UTF-8 string literals and returns a MUTF-8 encoded &'static JNIStr
+/// Supports:
+/// - Multiple comma-separated string literals (like concat!)
+/// - Optional `jni = <path>` as the first argument
+pub fn jni_str_impl(input: TokenStream) -> Result<TokenStream> {
+    let JniStrInput { jni_crate, string } = syn::parse2(input)?;
+
+    // Create a C string literal with MUTF-8 encoding
+    let cstr = lit_cstr_mutf8(&string);
+
+    Ok(quote! {
+        {
+            // Safety: The string was encoded to MUTF-8 at compile-time
+            unsafe {
+                #jni_crate::strings::JNIStr::from_cstr_unchecked(#cstr)
+            }
+        }
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use quote::quote;
+
+    #[test]
+    fn test_jni_cstr_single_literal() {
+        let input = quote! { "hello" };
+        let result = jni_cstr_impl(input).unwrap();
+        let result_str = result.to_string();
+
+        // Should produce a CStr literal
+        assert!(result_str.contains("c\"hello\"") || result_str.contains("\"hello\""));
+    }
+
+    #[test]
+    fn test_jni_cstr_multiple_literals() {
+        let input = quote! { "hello", " ", "world" };
+        let result = jni_cstr_impl(input).unwrap();
+        let result_str = result.to_string();
+
+        // Should concatenate to "hello world"
+        assert!(result_str.contains("hello world"));
+    }
+
+    #[test]
+    fn test_jni_cstr_with_jni_override() {
+        let input = quote! { jni = crate::my_jni, "test" };
+        let result = jni_cstr_impl(input).unwrap();
+        let result_str = result.to_string();
+
+        // Should produce a CStr literal (jni override doesn't affect jni_cstr! output)
+        assert!(result_str.contains("test"));
+    }
+
+    #[test]
+    fn test_jni_str_single_literal() {
+        let input = quote! { "hello" };
+        let result = jni_str_impl(input).unwrap();
+        let result_str = result.to_string();
+
+        // Should produce JNIStr::from_cstr_unchecked call
+        assert!(result_str.contains("JNIStr"));
+        assert!(result_str.contains("from_cstr_unchecked"));
+        assert!(result_str.contains("hello"));
+    }
+
+    #[test]
+    fn test_jni_str_multiple_literals() {
+        let input = quote! { "java.lang.", "String" };
+        let result = jni_str_impl(input).unwrap();
+        let result_str = result.to_string();
+
+        // Should concatenate to "java.lang.String"
+        assert!(result_str.contains("java.lang.String"));
+    }
+
+    #[test]
+    fn test_jni_str_with_jni_override() {
+        let input = quote! { jni = ::my_custom_jni, "test" };
+        let result = jni_str_impl(input).unwrap();
+        let result_str = result.to_string();
+
+        // Should use the custom jni crate path
+        assert!(result_str.contains(":: my_custom_jni :: strings :: JNIStr"));
+        assert!(result_str.contains("test"));
+    }
+
+    #[test]
+    fn test_jni_str_with_jni_override_and_multiple_literals() {
+        let input = quote! { jni = crate, "part1", "part2" };
+        let result = jni_str_impl(input).unwrap();
+        let result_str = result.to_string();
+
+        // Should use crate:: and concatenate literals
+        assert!(result_str.contains("crate :: strings :: JNIStr"));
+        assert!(result_str.contains("part1part2"));
+    }
+
+    #[test]
+    fn test_jni_cstr_empty_input_fails() {
+        let input = quote! {};
+        let result = jni_cstr_impl(input);
+        assert!(result.is_err());
+
+        let err = result.unwrap_err();
+        assert!(err.to_string().contains("expected at least one literal"));
+    }
+
+    #[test]
+    fn test_jni_cstr_trailing_comma() {
+        let input = quote! { "hello", "world", };
+        let result = jni_cstr_impl(input).unwrap();
+        let result_str = result.to_string();
+
+        // Should handle trailing comma and concatenate
+        assert!(result_str.contains("helloworld"));
+    }
+
+    #[test]
+    fn test_jni_str_jni_property_must_be_first() {
+        // jni property after string literal should fail during parsing
+        // because it will try to parse "test" as a string literal, then fail on the identifier "jni"
+        let input = quote! { "test", jni = crate };
+        let result = jni_str_impl(input);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_mutf8_encoding() {
+        // Test that emoji is properly encoded using MUTF-8
+        let input = quote! { "😀" };
+        let result = jni_cstr_impl(input).unwrap();
+        let result_str = result.to_string();
+
+        // Emoji should be encoded as surrogate pairs in MUTF-8
+        // The exact encoding will be in the c"..." literal
+        assert!(result_str.contains("c\"") || result_str.contains("\""));
+    }
+
+    #[test]
+    fn test_literal_char() {
+        let input = quote! { 'a' };
+        let result = jni_cstr_impl(input).unwrap();
+        let result_str = result.to_string();
+        assert!(result_str.contains("a"));
+    }
+
+    #[test]
+    fn test_literal_int() {
+        let input = quote! { 42 };
+        let result = jni_cstr_impl(input).unwrap();
+        let result_str = result.to_string();
+        assert!(result_str.contains("42"));
+    }
+
+    #[test]
+    fn test_literal_float() {
+        let input = quote! { 3.14 };
+        let result = jni_cstr_impl(input).unwrap();
+        let result_str = result.to_string();
+        assert!(result_str.contains("3.14"));
+    }
+
+    #[test]
+    fn test_literal_bool() {
+        let input = quote! { true };
+        let result = jni_cstr_impl(input).unwrap();
+        let result_str = result.to_string();
+        assert!(result_str.contains("true"));
+
+        let input = quote! { false };
+        let result = jni_cstr_impl(input).unwrap();
+        let result_str = result.to_string();
+        assert!(result_str.contains("false"));
+    }
+
+    #[test]
+    fn test_literal_byte() {
+        let input = quote! { b'A' };
+        let result = jni_cstr_impl(input).unwrap();
+        let result_str = result.to_string();
+        // Byte literals are formatted as their numeric value
+        assert!(result_str.contains("65")); // ASCII value of 'A'
+    }
+
+    #[test]
+    fn test_literal_cstr_valid_utf8() {
+        let input = quote! { c"hello" };
+        let result = jni_cstr_impl(input).unwrap();
+        let result_str = result.to_string();
+        assert!(result_str.contains("hello"));
+    }
+
+    #[test]
+    fn test_mixed_literals() {
+        let input = quote! { "Port: ", 8080 };
+        let result = jni_cstr_impl(input).unwrap();
+        let result_str = result.to_string();
+        assert!(result_str.contains("Port: 8080") || result_str.contains("Port : 8080"));
+    }
+
+    #[test]
+    fn test_mixed_literals_with_char() {
+        let input = quote! { "Version ", 1, '.', 2 };
+        let result = jni_cstr_impl(input).unwrap();
+        let result_str = result.to_string();
+        assert!(result_str.contains("Version 1.2") || result_str.contains("Version 1 . 2"));
+    }
+
+    #[test]
+    fn test_jni_str_mixed_literals() {
+        let input = quote! { "localhost:", 8080 };
+        let result = jni_str_impl(input).unwrap();
+        let result_str = result.to_string();
+        assert!(result_str.contains("localhost:8080") || result_str.contains("localhost : 8080"));
+        assert!(result_str.contains("JNIStr"));
+    }
+
+    #[test]
+    fn test_literal_byte_str_fails() {
+        // Byte string literals should not be supported
+        let input = quote! { b"hello" };
+        let result = jni_cstr_impl(input);
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        assert!(err.to_string().contains("byte string"));
+    }
+}

--- a/jni-macros/src/utils.rs
+++ b/jni-macros/src/utils.rs
@@ -1,0 +1,54 @@
+use syn::{Ident, Token};
+
+/// Helper function to resolve the jni crate path using proc_macro_crate
+fn resolve_jni_crate() -> syn::Path {
+    let Ok(found_crate) = proc_macro_crate::crate_name("jni") else {
+        return syn::parse_quote!(::jni);
+    };
+
+    match found_crate {
+        // Note: if we map `Itself` to `crate` then that won't work with doc tests
+        //
+        // It's kind of a pain but we instead use `extern crate self as jni;` whenever we use
+        // `jni-macros` in the `jni` crate itself.
+        //
+        // See: <https://github.com/bkchr/proc-macro-crate/issues/11>
+        proc_macro_crate::FoundCrate::Itself => syn::parse_quote!(::jni),
+        proc_macro_crate::FoundCrate::Name(name) => {
+            let ident = syn::Ident::new(&name, proc_macro2::Span::call_site());
+            syn::parse_quote!( ::#ident )
+        }
+    }
+}
+
+pub fn parse_jni_crate_override(input: &syn::parse::ParseStream) -> Result<syn::Path, syn::Error> {
+    let mut jni_path: Option<syn::Path> = None;
+
+    // First check for a special-case `jni = path` property for overriding the jni crate path
+    if !input.is_empty() {
+        let lookahead = input.lookahead1();
+        if lookahead.peek(Ident) {
+            // Peek at the first property name
+            let fork = input.fork();
+            let first_property: Ident = fork.parse()?;
+
+            #[allow(clippy::cmp_owned)]
+            if first_property.to_string() == "jni" {
+                // Check if it's followed by '='
+                if fork.peek(Token![=]) {
+                    // Parse the jni property
+                    let _property_name: Ident = input.parse()?;
+                    input.parse::<Token![=]>()?;
+                    jni_path = Some(input.parse()?);
+
+                    // Skip comma after jni property
+                    if input.peek(Token![,]) {
+                        input.parse::<Token![,]>()?;
+                    }
+                }
+            }
+        }
+    }
+
+    Ok(jni_path.unwrap_or_else(resolve_jni_crate))
+}

--- a/jni-macros/tests/string.rs
+++ b/jni-macros/tests/string.rs
@@ -1,0 +1,309 @@
+//! Tests for jni_str! and jni_cstr! macros
+//!
+//! These tests verify the macros properly:
+//! - Encode strings to MUTF-8 format
+//! - Support concatenation of multiple literals
+//! - Support different literal types
+//! - Handle Unicode correctly (including surrogate pairs)
+//! - Roundtrip encode/decode correctly
+//! - Work in const contexts
+
+use jni::strings::JNIStr;
+use jni_macros::{jni_cstr, jni_str};
+use std::ffi::CStr;
+
+// Helper function to verify MUTF-8 roundtrip encoding
+fn verify_roundtrip(original: &str, mutf8_bytes: &[u8]) {
+    match cesu8::from_java_cesu8(mutf8_bytes) {
+        Ok(decoded) => {
+            assert_eq!(
+                decoded, original,
+                "Roundtrip failed: decoded '{}' != original '{}'",
+                decoded, original
+            );
+        }
+        Err(e) => {
+            panic!("Failed to decode MUTF-8: {:?}", e);
+        }
+    }
+}
+
+#[test]
+fn test_jni_cstr_basic_ascii() {
+    const CLASS: &CStr = jni_cstr!("java.lang.String");
+
+    assert_eq!(CLASS.to_str().unwrap(), "java.lang.String");
+    verify_roundtrip("java.lang.String", CLASS.to_bytes());
+}
+
+#[test]
+fn test_jni_str_basic_ascii() {
+    const CLASS: &JNIStr = jni_str!("java.lang.String");
+
+    let bytes = CLASS.to_bytes();
+    assert_eq!(bytes, b"java.lang.String");
+    verify_roundtrip("java.lang.String", bytes);
+}
+
+#[test]
+fn test_jni_cstr_and_jni_str_produce_same_bytes() {
+    const CSTR: &CStr = jni_cstr!("com.example.TestClass");
+    const JSTR: &JNIStr = jni_str!("com.example.TestClass");
+
+    assert_eq!(CSTR.to_bytes(), JSTR.to_bytes());
+}
+
+#[test]
+fn test_concatenation_multiple_strings() {
+    const PACKAGE: &CStr = jni_cstr!("com.example.", "MyClass");
+    const JPACKAGE: &JNIStr = jni_str!("com.example.", "MyClass");
+
+    assert_eq!(PACKAGE.to_str().unwrap(), "com.example.MyClass");
+    assert_eq!(PACKAGE.to_bytes(), JPACKAGE.to_bytes());
+    verify_roundtrip("com.example.MyClass", PACKAGE.to_bytes());
+}
+
+#[test]
+fn test_concatenation_three_strings() {
+    const PATH: &CStr = jni_cstr!("java", ".", "lang", ".", "Object");
+
+    assert_eq!(PATH.to_str().unwrap(), "java.lang.Object");
+    verify_roundtrip("java.lang.Object", PATH.to_bytes());
+}
+
+#[test]
+fn test_mixed_literal_types_string_and_int() {
+    const PORT: &CStr = jni_cstr!("Port: ", 8080);
+    const JPORT: &JNIStr = jni_str!("Port: ", 8080);
+
+    assert_eq!(PORT.to_str().unwrap(), "Port: 8080");
+    assert_eq!(PORT.to_bytes(), JPORT.to_bytes());
+    verify_roundtrip("Port: 8080", PORT.to_bytes());
+}
+
+#[test]
+fn test_mixed_literal_types_with_char() {
+    const VERSION: &CStr = jni_cstr!("Version ", 1, '.', 2);
+
+    assert_eq!(VERSION.to_str().unwrap(), "Version 1.2");
+    verify_roundtrip("Version 1.2", VERSION.to_bytes());
+}
+
+#[test]
+fn test_boolean_literal() {
+    const ENABLED: &CStr = jni_cstr!("enabled=", true);
+    const DISABLED: &CStr = jni_cstr!("disabled=", false);
+
+    assert_eq!(ENABLED.to_str().unwrap(), "enabled=true");
+    assert_eq!(DISABLED.to_str().unwrap(), "disabled=false");
+}
+
+#[test]
+fn test_float_literal() {
+    const PI: &CStr = jni_cstr!("pi=", 3.14);
+
+    assert_eq!(PI.to_str().unwrap(), "pi=3.14");
+}
+
+#[test]
+fn test_char_literal() {
+    const SEPARATOR: &CStr = jni_cstr!("separator", '=', "value");
+
+    assert_eq!(SEPARATOR.to_str().unwrap(), "separator=value");
+}
+
+#[test]
+fn test_byte_literal() {
+    // Byte literals are converted to their numeric value
+    const BYTE_VAL: &CStr = jni_cstr!("byte=", b'A');
+
+    assert_eq!(BYTE_VAL.to_str().unwrap(), "byte=65"); // ASCII value of 'A'
+}
+
+#[test]
+fn test_cstr_literal() {
+    const FROM_CSTR: &CStr = jni_cstr!(c"hello");
+
+    assert_eq!(FROM_CSTR.to_str().unwrap(), "hello");
+}
+
+#[test]
+fn test_unicode_emoji_surrogate_pairs() {
+    // Emoji above U+FFFF require surrogate pair encoding in MUTF-8
+    const EMOJI: &CStr = jni_cstr!("😀");
+    const JEMOJI: &JNIStr = jni_str!("😀");
+
+    let bytes = EMOJI.to_bytes();
+    let jbytes = JEMOJI.to_bytes();
+
+    // Both should produce same bytes
+    assert_eq!(bytes, jbytes);
+
+    // MUTF-8 should be longer than UTF-8 for emoji
+    let utf8_bytes = "😀".as_bytes();
+    assert_eq!(utf8_bytes.len(), 4); // UTF-8: 4 bytes
+    assert_eq!(bytes.len(), 6); // MUTF-8: 6 bytes (surrogate pair)
+
+    // Verify roundtrip
+    verify_roundtrip("😀", bytes);
+}
+
+#[test]
+fn test_unicode_japanese_no_surrogate_pairs() {
+    // Japanese characters below U+FFFF don't need surrogate pairs
+    const JP: &CStr = jni_cstr!("こんにちは");
+
+    let bytes = JP.to_bytes();
+    let utf8_bytes = "こんにちは".as_bytes();
+
+    // UTF-8 and MUTF-8 should be identical for these characters
+    assert_eq!(bytes, utf8_bytes);
+
+    verify_roundtrip("こんにちは", bytes);
+}
+
+#[test]
+fn test_unicode_in_class_name() {
+    const CLASS: &CStr = jni_cstr!("emoji.Type😀");
+
+    verify_roundtrip("emoji.Type😀", CLASS.to_bytes());
+}
+
+#[test]
+fn test_const_context() {
+    // Verify macros work in const contexts
+    const CONST_CSTR: &CStr = jni_cstr!("const.test");
+    const CONST_JSTR: &JNIStr = jni_str!("const.test");
+
+    assert_eq!(CONST_CSTR.to_str().unwrap(), "const.test");
+    assert_eq!(CONST_CSTR.to_bytes(), CONST_JSTR.to_bytes());
+
+    // Test in const fn
+    const fn get_class_name() -> &'static CStr {
+        jni_cstr!("const.fn.Test")
+    }
+
+    const CLASS: &CStr = get_class_name();
+    assert_eq!(CLASS.to_str().unwrap(), "const.fn.Test");
+}
+
+#[test]
+fn test_static_context() {
+    static CLASS: &CStr = jni_cstr!("static.test.Class");
+    static JCLASS: &JNIStr = jni_str!("static.test.Class");
+
+    assert_eq!(CLASS.to_bytes(), JCLASS.to_bytes());
+}
+
+#[test]
+fn test_empty_package() {
+    // Classes in default package (no package)
+    const DEFAULT_PKG: &CStr = jni_cstr!(".DefaultClass");
+
+    assert_eq!(DEFAULT_PKG.to_str().unwrap(), ".DefaultClass");
+    verify_roundtrip(".DefaultClass", DEFAULT_PKG.to_bytes());
+}
+
+#[test]
+fn test_inner_class_notation() {
+    // Inner classes use $ in JNI
+    const INNER: &CStr = jni_cstr!("com.example.Outer$Inner");
+
+    assert_eq!(INNER.to_str().unwrap(), "com.example.Outer$Inner");
+    verify_roundtrip("com.example.Outer$Inner", INNER.to_bytes());
+}
+
+#[test]
+fn test_concatenation_builds_inner_class() {
+    const INNER: &CStr = jni_cstr!("com.example.Outer", "$", "Inner");
+
+    assert_eq!(INNER.to_str().unwrap(), "com.example.Outer$Inner");
+}
+
+#[test]
+fn test_method_name() {
+    const METHOD: &CStr = jni_cstr!("toString");
+    const JMETHOD: &JNIStr = jni_str!("toString");
+
+    assert_eq!(METHOD.to_bytes(), JMETHOD.to_bytes());
+    verify_roundtrip("toString", METHOD.to_bytes());
+}
+
+#[test]
+fn test_field_name() {
+    const FIELD: &CStr = jni_cstr!("value");
+
+    assert_eq!(FIELD.to_str().unwrap(), "value");
+    verify_roundtrip("value", FIELD.to_bytes());
+}
+
+#[test]
+fn test_special_characters() {
+    // Test various special characters that might appear in class names
+    const SPECIAL: &CStr = jni_cstr!("test_class-name.v2");
+
+    assert_eq!(SPECIAL.to_str().unwrap(), "test_class-name.v2");
+    verify_roundtrip("test_class-name.v2", SPECIAL.to_bytes());
+}
+
+#[test]
+fn test_long_package_name() {
+    const LONG: &CStr = jni_cstr!("com.example.very.long.package.name.with.many.segments.MyClass");
+
+    assert_eq!(
+        LONG.to_str().unwrap(),
+        "com.example.very.long.package.name.with.many.segments.MyClass"
+    );
+    verify_roundtrip(
+        "com.example.very.long.package.name.with.many.segments.MyClass",
+        LONG.to_bytes(),
+    );
+}
+
+#[test]
+fn test_jnistr_to_bytes_method() {
+    const JSTR: &JNIStr = jni_str!("test.Class");
+
+    let bytes = JSTR.to_bytes();
+    assert_eq!(bytes, b"test.Class");
+}
+
+#[test]
+fn test_roundtrip_multiple_emoji() {
+    const MULTI_EMOJI: &CStr = jni_cstr!("😀🚀👍");
+
+    let bytes = MULTI_EMOJI.to_bytes();
+
+    // Each emoji should be 6 bytes in MUTF-8
+    assert_eq!(bytes.len(), 18); // 3 emoji * 6 bytes each
+
+    verify_roundtrip("😀🚀👍", bytes);
+}
+
+#[test]
+fn test_mixed_ascii_and_unicode() {
+    const MIXED: &CStr = jni_cstr!("Hello", "世界", "😀");
+
+    verify_roundtrip("Hello世界😀", MIXED.to_bytes());
+}
+
+#[test]
+fn test_trailing_comma_in_concatenation() {
+    const TRAILING: &CStr = jni_cstr!("hello", "world",);
+
+    assert_eq!(TRAILING.to_str().unwrap(), "helloworld");
+}
+
+#[test]
+fn test_negative_numbers() {
+    const NEG: &CStr = jni_cstr!("value=", -42);
+
+    assert_eq!(NEG.to_str().unwrap(), "value=-42");
+}
+
+#[test]
+fn test_zero() {
+    const ZERO: &CStr = jni_cstr!("count=", 0);
+
+    assert_eq!(ZERO.to_str().unwrap(), "count=0");
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -339,4 +339,11 @@ pub mod vm;
 )]
 pub use self::vm::*;
 
+// workaround proc-macro-crate limitations so we can use jni-macros from the jni crate itself
+// ref: https://github.com/bkchr/proc-macro-crate/issues/11
+extern crate self as jni;
+
+pub use jni_macros::jni_cstr;
+pub use jni_macros::jni_str;
+
 pub use jni_macros::jni_mangle;


### PR DESCRIPTION
`jni_str` + `jni_cstr` act like the `std` `concat!()` macro, except they concatenate their arguments into a MUTF-8 encoded `&JNIStr` or `&CStr` literal respectively.

The plan is to remove the `From<CStr>` implementation for `JNIStr` (that can panic) in favour of using this `jni_str!` macro that can encode strings as MUTF-8 at compile time with full unicode support.

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Change is covered by [automated tests](https://github.com/jni-rs/jni-rs/blob/master/CONTRIBUTING.md#tests)
- [x] The [coding guidelines](https://github.com/jni-rs/jni-rs/blob/master/CONTRIBUTING.md#the-code-style) are followed
- [x] Public API has documentation
- [x] User-visible changes are mentioned in the Changelog
- [x] The continuous integration build passes
