### PR TITLE
jni-macros: add `jni_sig!` + `jni_sig_[c,j]str!` macros

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -102,6 +102,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - The `#[jni_mangle()]` attribute proc macro can export an `extern "system"` native method with a mangled name like "Java_com_example_myMethod" so it can be automatically resolved within a shared library by the JVM ([#693](https://github.com/jni-rs/jni-rs/pull/693))
 - The `jni_str!` and `jni_cstr!` macros can encode a MUTF-8 `&'static JNIStr` or `&' static CStr` at compile time with full unicode support.
+- The `jni_sig!`, `jni_sig_str!`, `jni_sig_cstr!` and `jni_sig_jstr!` macros can parse and compile signatures like `(arg0: jint, arg1: JString) -> JString` into `MethodSignature` and `FieldSignature` descriptors or JNI string literals like "(ILjava/lang/String;)Ljava/lang/String;"
 
 ### Changed
 

--- a/jni-macros/examples/jni_sig.rs
+++ b/jni-macros/examples/jni_sig.rs
@@ -1,0 +1,354 @@
+//! Examples demonstrating the `jni_sig!` family of macros for creating JNI signatures.
+//!
+//! The `jni_sig!` macro and its variants provide compile-time parsing and validation
+//! of JNI method and field signatures, with support for both readable Rust-like syntax
+//! and raw JNI signature strings.
+//!
+//! # Output Variants
+//!
+//! - `jni_sig!` - Returns a typed `MethodSignature` or `FieldSignature` struct
+//! - `jni_sig_str!` - Returns a `&str` literal
+//! - `jni_sig_cstr!` - Returns a `&CStr` literal (MUTF-8 encoded)
+//! - `jni_sig_jstr!` - Returns a `&'static JNIStr` (MUTF-8 encoded)
+
+use jni::signature::{FieldSignature, JavaType, MethodSignature, Primitive};
+use jni::strings::JNIStr;
+use jni_macros::{jni_sig, jni_sig_cstr, jni_sig_jstr, jni_sig_str};
+use std::ffi::CStr;
+
+// ============================================================================
+// Method Signatures
+// ============================================================================
+
+fn method_signatures() {
+    // Methods with primitive types
+    // MethodSignature includes JavaType for each argument and the return type
+    const SIMPLE: MethodSignature = jni_sig!((a: jint, b: jboolean) -> void);
+    assert_eq!(SIMPLE.sig().to_bytes(), b"(IZ)V");
+    assert_eq!(SIMPLE.args().len(), 2);
+    assert_eq!(SIMPLE.args()[0], JavaType::Primitive(Primitive::Int));
+    assert_eq!(SIMPLE.args()[1], JavaType::Primitive(Primitive::Boolean));
+    assert_eq!(SIMPLE.ret(), JavaType::Primitive(Primitive::Void));
+
+    // Methods with Java objects
+    const WITH_OBJECTS: MethodSignature = jni_sig!(
+        (id: jint, name: java.lang.String) -> java.lang.Object
+    );
+    assert_eq!(
+        WITH_OBJECTS.sig().to_bytes(),
+        b"(ILjava/lang/String;)Ljava/lang/Object;"
+    );
+    assert_eq!(WITH_OBJECTS.args().len(), 2);
+    assert_eq!(WITH_OBJECTS.args()[0], JavaType::Primitive(Primitive::Int));
+    assert_eq!(WITH_OBJECTS.args()[1], JavaType::Object);
+    assert_eq!(WITH_OBJECTS.ret(), JavaType::Object);
+
+    // No-argument methods
+    const NO_ARGS: MethodSignature = jni_sig!(() -> jint);
+    assert_eq!(NO_ARGS.sig().to_bytes(), b"()I");
+    assert_eq!(NO_ARGS.args().len(), 0);
+    assert_eq!(NO_ARGS.ret(), JavaType::Primitive(Primitive::Int));
+
+    // Methods with arrays (prefix syntax)
+    const ARRAY_PREFIX: MethodSignature = jni_sig!(
+        (data: [jint], labels: [java.lang.String]) -> void
+    );
+    assert_eq!(ARRAY_PREFIX.sig().to_bytes(), b"([I[Ljava/lang/String;)V");
+    assert_eq!(ARRAY_PREFIX.args().len(), 2);
+    assert_eq!(ARRAY_PREFIX.args()[0], JavaType::Array);
+    assert_eq!(ARRAY_PREFIX.args()[1], JavaType::Array);
+    assert_eq!(ARRAY_PREFIX.ret(), JavaType::Primitive(Primitive::Void));
+
+    // Methods with arrays (suffix syntax)
+    const ARRAY_SUFFIX: MethodSignature = jni_sig!(
+        (grid: jint[][]) -> java.lang.String[]
+    );
+    assert_eq!(ARRAY_SUFFIX.sig().to_bytes(), b"([[I)[Ljava/lang/String;");
+    assert_eq!(ARRAY_SUFFIX.args()[0], JavaType::Array);
+    assert_eq!(ARRAY_SUFFIX.ret(), JavaType::Array);
+
+    // Methods with inner classes
+    const INNER_CLASS: MethodSignature = jni_sig!(
+        (state: java.lang.Thread::State) -> void
+    );
+    assert_eq!(INNER_CLASS.sig().to_bytes(), b"(Ljava/lang/Thread$State;)V");
+
+    // Optional parameter names (types only)
+    const UNNAMED_PARAMS: MethodSignature = jni_sig!(
+        (jint, jboolean, java.lang.String) -> void
+    );
+    assert_eq!(UNNAMED_PARAMS.sig().to_bytes(), b"(IZLjava/lang/String;)V");
+
+    // Mixing named and unnamed parameters
+    const MIXED_PARAMS: MethodSignature = jni_sig!(
+        (jint, name: java.lang.String, jboolean) -> void
+    );
+    assert_eq!(MIXED_PARAMS.sig().to_bytes(), b"(ILjava/lang/String;Z)V");
+
+    // Implicit void return (no return type specified)
+    const IMPLICIT_VOID: MethodSignature = jni_sig!((a: jint));
+    assert_eq!(IMPLICIT_VOID.sig().to_bytes(), b"(I)V");
+}
+
+// ============================================================================
+// Field Signatures
+// ============================================================================
+
+fn field_signatures() {
+    // Primitive fields
+    // FieldSignature includes a JavaType for the field type
+    const INT_FIELD: FieldSignature = jni_sig!(jint);
+    assert_eq!(INT_FIELD.sig().to_bytes(), b"I");
+    assert_eq!(INT_FIELD.ty(), JavaType::Primitive(Primitive::Int));
+
+    const BOOLEAN_FIELD: FieldSignature = jni_sig!(jboolean);
+    assert_eq!(BOOLEAN_FIELD.sig().to_bytes(), b"Z");
+    assert_eq!(BOOLEAN_FIELD.ty(), JavaType::Primitive(Primitive::Boolean));
+
+    // Object fields
+    const STRING_FIELD: FieldSignature = jni_sig!(java.lang.String);
+    assert_eq!(STRING_FIELD.sig().to_bytes(), b"Ljava/lang/String;");
+    assert_eq!(STRING_FIELD.ty(), JavaType::Object);
+
+    // Array fields (prefix syntax)
+    const ARRAY_FIELD_PREFIX: FieldSignature = jni_sig!([jint]);
+    assert_eq!(ARRAY_FIELD_PREFIX.sig().to_bytes(), b"[I");
+    assert_eq!(ARRAY_FIELD_PREFIX.ty(), JavaType::Array);
+
+    // Array fields (suffix syntax)
+    const ARRAY_FIELD_SUFFIX: FieldSignature = jni_sig!(java.lang.String[][]);
+    assert_eq!(ARRAY_FIELD_SUFFIX.sig().to_bytes(), b"[[Ljava/lang/String;");
+    assert_eq!(ARRAY_FIELD_SUFFIX.ty(), JavaType::Array);
+
+    // Inner class fields
+    const INNER_CLASS_FIELD: FieldSignature = jni_sig!(java.lang.Thread::State);
+    assert_eq!(
+        INNER_CLASS_FIELD.sig().to_bytes(),
+        b"Ljava/lang/Thread$State;"
+    );
+}
+
+// ============================================================================
+// Type Mappings
+// ============================================================================
+
+fn type_mappings() {
+    // Custom type mappings allow using Rust type names in signatures
+    const CUSTOM_TYPES: MethodSignature = jni_sig!(
+        type_map = {
+            UserId => com.example.UserId,
+            UserProfile => com.example.UserProfile,
+        },
+        (id: UserId) -> UserProfile
+    );
+    assert_eq!(
+        CUSTOM_TYPES.sig().to_bytes(),
+        b"(Lcom/example/UserId;)Lcom/example/UserProfile;"
+    );
+
+    // Type mappings with arrays
+    const MAPPED_ARRAYS: MethodSignature = jni_sig!(
+        type_map = {
+            CustomType => com.example.CustomType,
+        },
+        (items: [CustomType]) -> [[CustomType]]
+    );
+    assert_eq!(
+        MAPPED_ARRAYS.sig().to_bytes(),
+        b"([Lcom/example/CustomType;)[[Lcom/example/CustomType;"
+    );
+
+    // Multiple type_map blocks (useful for wrapper macros)
+    const MULTIPLE_MAPS: MethodSignature = jni_sig!(
+        type_map = { TypeA => com.example.TypeA },
+        type_map = { TypeB => com.example.TypeB },
+        (a: TypeA, b: TypeB) -> void
+    );
+    assert_eq!(
+        MULTIPLE_MAPS.sig().to_bytes(),
+        b"(Lcom/example/TypeA;Lcom/example/TypeB;)V"
+    );
+
+    // Named signature property with type mappings (order doesn't matter)
+    const NAMED_SIG: MethodSignature = jni_sig!(
+        type_map = { MyType => com.example.MyType },
+        sig = (arg: MyType) -> void
+    );
+    assert_eq!(NAMED_SIG.sig().to_bytes(), b"(Lcom/example/MyType;)V");
+
+    // Built-in types (no mapping needed)
+    const BUILTIN_TYPES: MethodSignature = jni_sig!(
+        (obj: JObject, str: JString, class: JClass) -> JThrowable
+    );
+    assert_eq!(
+        BUILTIN_TYPES.sig().to_bytes(),
+        b"(Ljava/lang/Object;Ljava/lang/String;Ljava/lang/Class;)Ljava/lang/Throwable;"
+    );
+
+    // Type aliases
+    const ALIASES: MethodSignature = jni_sig!(
+        type_map = {
+            CustomString => com.example.CustomString,
+            typealias Str => CustomString,
+            typealias Text => JString,
+        },
+        (a: Str, b: Text) -> void
+    );
+    assert_eq!(
+        ALIASES.sig().to_bytes(),
+        b"(Lcom/example/CustomString;Ljava/lang/String;)V"
+    );
+
+    // Unsafe primitive mappings (for handles/pointers passed as long)
+    const UNSAFE_MAPPING: MethodSignature = jni_sig!(
+        type_map = {
+            unsafe NativeHandle => long,
+        },
+        (handle: NativeHandle) -> void
+    );
+    assert_eq!(UNSAFE_MAPPING.sig().to_bytes(), b"(J)V");
+}
+
+// ============================================================================
+// Output Variants
+// ============================================================================
+
+fn output_variants() {
+    // jni_sig! returns a typed MethodSignature struct
+    const METHOD: MethodSignature = jni_sig!((a: jint) -> java.lang.String);
+    assert_eq!(METHOD.sig().to_bytes(), b"(I)Ljava/lang/String;");
+    assert_eq!(METHOD.args().len(), 1);
+    assert_eq!(METHOD.args()[0], JavaType::Primitive(Primitive::Int));
+    assert_eq!(METHOD.ret(), JavaType::Object);
+
+    // jni_sig! returns a typed FieldSignature struct
+    const FIELD: FieldSignature = jni_sig!(jint);
+    assert_eq!(FIELD.sig().to_bytes(), b"I");
+    assert_eq!(FIELD.ty(), JavaType::Primitive(Primitive::Int));
+
+    // jni_sig_str! returns a plain &str
+    const METHOD_STR: &str = jni_sig_str!((a: jint) -> java.lang.String);
+    assert_eq!(METHOD_STR, "(I)Ljava/lang/String;");
+
+    const FIELD_STR: &str = jni_sig_str!(jint);
+    assert_eq!(FIELD_STR, "I");
+
+    // jni_sig_cstr! returns a &CStr (MUTF-8 encoded)
+    const METHOD_CSTR: &CStr = jni_sig_cstr!((a: jint) -> java.lang.String);
+    assert_eq!(METHOD_CSTR.to_bytes(), b"(I)Ljava/lang/String;");
+
+    const FIELD_CSTR: &CStr = jni_sig_cstr!(jint);
+    assert_eq!(FIELD_CSTR.to_bytes(), b"I");
+
+    // jni_sig_jstr! returns a &'static JNIStr (MUTF-8 encoded)
+    const METHOD_JSTR: &JNIStr = jni_sig_jstr!((a: jint) -> java.lang.String);
+    assert_eq!(METHOD_JSTR.to_bytes(), b"(I)Ljava/lang/String;");
+
+    const FIELD_JSTR: &JNIStr = jni_sig_jstr!(jint);
+    assert_eq!(FIELD_JSTR.to_bytes(), b"I");
+
+    // All variants accept the same input syntax
+    const COMPLEX_JSTR: &JNIStr = jni_sig_jstr!(
+        type_map = { MyType => com.example.Type },
+        ([MyType], jint) -> java.lang.String[]
+    );
+    assert_eq!(
+        COMPLEX_JSTR.to_bytes(),
+        b"([Lcom/example/Type;I)[Ljava/lang/String;"
+    );
+}
+
+// ============================================================================
+// Raw JNI Signatures
+// ============================================================================
+
+fn raw_jni_signatures() {
+    // Raw JNI method signatures (validated at compile time)
+    // The parser resolves JavaType for each argument and the return type
+    const RAW_METHOD: MethodSignature = jni_sig!("(ILjava/lang/String;)V");
+    assert_eq!(RAW_METHOD.sig().to_bytes(), b"(ILjava/lang/String;)V");
+    assert_eq!(RAW_METHOD.args().len(), 2);
+    assert_eq!(RAW_METHOD.args()[0], JavaType::Primitive(Primitive::Int));
+    assert_eq!(RAW_METHOD.args()[1], JavaType::Object);
+    assert_eq!(RAW_METHOD.ret(), JavaType::Primitive(Primitive::Void));
+
+    // Raw JNI field signatures
+    // The parser resolves the JavaType for the field
+    const RAW_FIELD: FieldSignature = jni_sig!("Ljava/lang/String;");
+    assert_eq!(RAW_FIELD.sig().to_bytes(), b"Ljava/lang/String;");
+    assert_eq!(RAW_FIELD.ty(), JavaType::Object);
+
+    // Raw signatures work with all output variants
+    const RAW_STR: &str = jni_sig_str!("([I)[[Ljava/lang/Object;");
+    assert_eq!(RAW_STR, "([I)[[Ljava/lang/Object;");
+
+    const RAW_CSTR: &CStr = jni_sig_cstr!("[B");
+    assert_eq!(RAW_CSTR.to_bytes(), b"[B");
+
+    // Java inner classes with dollar sign
+    const RAW_INNER: MethodSignature = jni_sig!("(Ljava/lang/Thread$State;)V");
+    assert_eq!(RAW_INNER.sig().to_bytes(), b"(Ljava/lang/Thread$State;)V");
+    assert_eq!(RAW_INNER.args()[0], JavaType::Object);
+}
+
+// ============================================================================
+// Advanced Features
+// ============================================================================
+
+fn advanced_features() {
+    // String literal syntax for Java types (alternative to dot notation)
+    const STRING_LITERAL: MethodSignature = jni_sig!(
+        (arg: "com.example.Type") -> "com.example.ReturnType"
+    );
+    assert_eq!(
+        STRING_LITERAL.sig().to_bytes(),
+        b"(Lcom/example/Type;)Lcom/example/ReturnType;"
+    );
+
+    // String literal with inner class (dollar sign syntax)
+    const STRING_INNER: FieldSignature = jni_sig!("java.lang.Thread$State");
+    assert_eq!(STRING_INNER.sig().to_bytes(), b"Ljava/lang/Thread$State;");
+
+    // Default package class (leading dot)
+    const DEFAULT_PACKAGE: MethodSignature = jni_sig!((obj: .MyClass) -> void);
+    assert_eq!(DEFAULT_PACKAGE.sig().to_bytes(), b"(LMyClass;)V");
+
+    // Type aliases for primitives (convenience)
+    const PRIMITIVE_ALIASES: MethodSignature = jni_sig!(
+        (a: boolean, b: int, c: long, d: float, e: double) -> void
+    );
+    assert_eq!(PRIMITIVE_ALIASES.sig().to_bytes(), b"(ZIJFD)V");
+
+    // Rust-style primitive aliases
+    const RUST_ALIASES: MethodSignature = jni_sig!(
+        (a: bool, b: i8, c: i16, d: i32, e: i64, f: f32, g: f64) -> void
+    );
+    assert_eq!(RUST_ALIASES.sig().to_bytes(), b"(ZBSIJFD)V");
+
+    // Void as unit type
+    const UNIT_RETURN: MethodSignature = jni_sig!((a: jint) -> ());
+    assert_eq!(UNIT_RETURN.sig().to_bytes(), b"(I)V");
+
+    // Custom jni crate path (must be first property)
+    const CUSTOM_JNI_PATH: MethodSignature = jni_sig!(
+        jni = ::jni,
+        (a: jint) -> void
+    );
+    assert_eq!(CUSTOM_JNI_PATH.sig().to_bytes(), b"(I)V");
+
+    // Trailing comma allowed
+    const TRAILING_COMMA: MethodSignature = jni_sig!(
+        type_map = { MyType => com.example.Type },
+        (a: MyType) -> void,
+    );
+    assert_eq!(TRAILING_COMMA.sig().to_bytes(), b"(Lcom/example/Type;)V");
+}
+
+fn main() {
+    method_signatures();
+    field_signatures();
+    type_mappings();
+    output_variants();
+    raw_jni_signatures();
+    advanced_features();
+}

--- a/jni-macros/examples/jni_sig_wrapper.rs
+++ b/jni-macros/examples/jni_sig_wrapper.rs
@@ -1,0 +1,62 @@
+//! Example demonstrating a wrapper macro that can inject the jni crate path
+//! and a type_map into jni_sig! invocations.
+//!
+//! Notably the wrapper doesn't need to know anything about the syntax of jni_sig!
+//! and it doesn't block the user from adding their own type_map.
+
+use jni::signature::MethodSignature;
+
+extern crate jni as jni2;
+
+// Example wrapper macro that always uses a custom jni path
+// This could be useful in a workspace with a renamed jni dependency or with
+// custom types that are used across many signatures.
+macro_rules! my_jni_sig {
+    ($($tt:tt)*) => {
+        jni_macros::jni_sig!(
+            jni = ::jni2,
+            type_map = {
+                BuiltinType => java.lang.BuiltinType,
+            },
+            $($tt)*
+        )
+    };
+}
+
+fn main() {
+    println!("=== Wrapper Macro Example ===\n");
+
+    // The wrapper macro works with all syntax variations:
+
+    // 1. Simple unnamed signature
+    let sig1: MethodSignature = my_jni_sig!((a: jint, b: BuiltinType) -> void);
+    println!("Simple: {}", sig1.sig());
+    assert_eq!(sig1.sig().to_bytes(), b"(ILjava/lang/BuiltinType;)V");
+
+    // 2. With type_map
+    let sig2: MethodSignature = my_jni_sig!(
+        (a: MyType, b: BuiltinType) -> void,
+        type_map = {
+            MyType => com.example.MyType,
+        }
+    );
+    println!("With type_map: {}", sig2.sig());
+    assert_eq!(
+        sig2.sig().to_bytes(),
+        b"(Lcom/example/MyType;Ljava/lang/BuiltinType;)V"
+    );
+
+    // 3. Named signature
+    let sig3: MethodSignature = my_jni_sig!(
+        sig = (a: jint) -> void
+    );
+    println!("Named sig: {}", sig3.sig());
+    assert_eq!(sig3.sig().to_bytes(), b"(I)V");
+
+    // 4. With trailing comma
+    let sig4: MethodSignature = my_jni_sig!(
+        (a: jint) -> void,
+    );
+    println!("With trailing comma: {}", sig4.sig());
+    assert_eq!(sig4.sig().to_bytes(), b"(I)V");
+}

--- a/jni-macros/src/lib.rs
+++ b/jni-macros/src/lib.rs
@@ -1,5 +1,7 @@
 mod mangle;
+mod signature;
 mod str;
+mod types;
 mod utils;
 
 /// Converts UTF-8 string literals to a MUTF-8 encoded `&'static JNIStr`.
@@ -69,6 +71,397 @@ pub fn jni_str(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
 #[proc_macro]
 pub fn jni_cstr(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
     str::jni_cstr_impl(input.into())
+        .unwrap_or_else(|e| e.to_compile_error())
+        .into()
+}
+
+/// Parses a JNI method or field signature at compile time.
+///
+/// This macro parses method and field signatures with syntax like `(arg0: JString, arg1: jint) ->
+/// JString` and generates a [MethodSignature] or [FieldSignature] struct to represent the
+/// corresponding JNI signature, including the raw string like
+/// "(Ljava/lang/String;I)Ljava/lang/String;" and enumerated argument plus return types.
+///
+/// This macro can also parse raw JNI signature strings like `"(Ljava/lang/String;I)Z"` in order to
+/// validate them at compile time but it's recommended to use the structured syntax for better
+/// readability.
+///
+/// [MethodSignature]: https://docs.rs/jni/latest/jni/signature/struct.MethodSignature.html
+/// [FieldSignature]: https://docs.rs/jni/latest/jni/signature/struct.FieldSignature.html
+///
+/// # Syntax
+///
+/// The macro accepts named properties separated by commas:
+/// ```ignore
+/// jni_sig!(
+///     [jni = <path>],
+///     [type_map = { ... }],
+///     [sig =] <signature>,
+/// )
+/// ```
+/// The parser automatically detects whether it's a method signature (has parentheses) or a field
+/// signature (a single, bare type).
+///
+/// ## Properties
+///
+/// - `jni = <path>` - Optionally override the jni crate path (default: auto-detected via
+///   `proc_macro_crate`, must come first if given)
+/// - `type_map = { RustType => java.lang.ClassName, ... }` - Optional type mappings for Rust types
+/// - `sig = <signature>` - The signature ('`sig =`' prefix is optional for the signature)
+///
+/// The `type_map` property can be provided multiple times and mappings are merged.
+///
+/// The design allows for a `macro_rules` wrapper to inject `jni =` or `type_map =` properties,
+/// without needing to parse anything else.
+///
+/// # Type Syntax
+///
+/// ## Primitive Types
+/// - Java primitives: `jboolean`, `jbyte`, `jchar`, `jshort`, `jint`, `jlong`, `jfloat`, `jdouble`
+/// - Aliases: `boolean`/`bool`, `byte`/`i8`, `char`, `short`/`i16`, `int`/`i32`, `long`/`i64`,
+///   `float`/`f32`, `double`/`f64`
+/// - Void: `void` or `()` or elided return type defaults to `void`
+///
+/// ## Java Object Types
+/// - Fully qualified: `java.lang.String`, `java.util.List` or as string literal: `"java.util.List"`
+/// - With inner classes: `java.lang.Outer::Inner` or as string literal: `"java.lang.Outer$Inner"`
+/// - Default package: `.ClassName` or as string literal: `".ClassName"`
+///
+/// _(Notice that Java object types _always_ contain at least one `.` dot)_
+///
+/// ## Rust Reference Types
+/// - Single identifier or path: `JString`, `JObject`, `jni::objects::JString`, `RustType`,
+///   `custom::RustType`
+///
+/// ## Array Types
+/// - Prefix syntax: `[jint]`, `[[java.lang.String]]`, `[RustType]`
+/// - Suffix syntax: `jint[]`, `java.lang.String[][]`, `RustType[]`
+///
+/// ### Built-in Types
+/// - Types like `JObject`, `JClass`, `JString` etc from the `jni` crate can be used without a
+///   `type_map`
+/// - Built-in types can also be referenced like `jni::objects::JString`
+/// - Java types like `java.lang.Class` are automatically mapped to built-in types like `JClass`
+///
+/// ### Core Types
+/// - The core types `java.lang.Object`, `java.lang.Class`, `java.lang.String` and
+///   `java.lang.Throwable` can not be mapped to custom types.
+/// - Other built-in types, such as `JList` (`java.util.List`) can be overridden by mapping them to
+///   a different type via a `type_map`
+///
+/// ## Type Mappings via `type_map` Block
+///
+/// A `type_map` block:
+/// - Maps Rust [Reference] type names to Java class names for use in method/field signatures.
+/// - Maps Java class names to Rust types
+/// - Allows the definition of type aliases for more ergonomic / readable signatures.
+///
+/// Multiple `type_map` blocks will be merged, so that wrapper macros may forward-declare common
+/// type mappings to avoid repetition.
+///
+/// A `type_map` supports three types of mappings:
+///
+/// ### Reference Type Mappings
+///
+/// Map Rust [Reference] types to Java classes like `RustType => java.type.Name`:
+///
+/// ```ignore
+/// type_map = {
+///     CustomType => com.example.CustomClass,
+///     AnotherType => "com.example.AnotherClass",
+///     InnerType => com.example.Outer::Inner,
+///     AnotherInnerType => "com.example.Outer$AnotherInner",
+///     my_crate::MyType => com.example.MyType,
+/// }
+/// ```
+///
+/// The right-side Java type uses the syntax for Java Object Types described above.
+///
+/// ### Unsafe Primitive Type Mappings
+///
+/// Map Rust types to Java primitive types using the `unsafe` keyword. This is particularly useful
+/// for Rust types that transparently wrap a pointer (e.g., handles) that need to be passed to Java
+/// as a `long`:
+///
+/// ```ignore
+/// type_map = {
+///     unsafe MyHandle => long,
+///     unsafe MyBoxedPointer => long,
+///     unsafe MyRawFd => int,
+/// }
+/// ```
+///
+/// These mappings are marked `unsafe` because it's not possible to verify the safety of casting
+/// between the Rust type and Java primitive type - apart from checking the size and alignment.
+///
+/// ### Type Aliases
+///
+/// Creates aliases for existing type mappings using the `typealias` keyword. This can improve
+/// readability in signatures before defining full type bindings:
+///
+/// ```ignore
+/// type_map = {
+///     MyType => com.example.MyType,
+///     typealias MyAlias => MyType,
+///     typealias MyObjectAlias => JObject,
+/// }
+/// ```
+///
+/// Note: Aliases for array types are not supported.
+///
+/// # Method Signature Syntax
+///
+/// A method can be given in one of these forms:
+/// - `( [args...] ) -> TYPE`
+/// - `( [args...] )`
+/// - `"RAW_JNI_SIG"`
+///
+/// An argument can be given in these forms:
+/// - `name: TYPE`
+/// - `TYPE`
+///
+/// _(with a `TYPE` as described in the `Type Syntax` section above)_
+///
+/// A `TYPE` may have an optional `&` prefix that is ignored
+///
+/// ```
+/// # use jni::{jni_sig, signature::{MethodSignature, JavaType, Primitive}};
+/// const JNI_SIG: MethodSignature =
+///     jni_sig!((arg1: com.example.Type, arg2: JString, arg3: jint) -> JString);
+/// # fn main() {
+/// assert!(JNI_SIG.sig().to_bytes() == b"(Lcom/example/Type;Ljava/lang/String;I)Ljava/lang/String;");
+/// assert!(JNI_SIG.args().len() == 3);
+/// assert!(JNI_SIG.args()[0] == JavaType::Object);
+/// assert!(JNI_SIG.args()[1] == JavaType::Object);
+/// assert!(JNI_SIG.args()[2] == JavaType::Primitive(Primitive::Int));
+/// assert!(JNI_SIG.ret() == JavaType::Object);
+/// # }
+/// ```
+///
+/// Traditional JNI signature syntax is also supported:
+/// ```ignore
+/// jni_sig!("(IILjava/lang/String;)V")
+/// ```
+///
+/// Explicitly named 'sig' property:
+/// ```ignore
+/// jni_sig!(sig = (arg1: Type1, arg2: Type2, ...) -> ReturnType)
+/// ```
+///
+/// With type mappings:
+/// ```
+/// # use jni::{jni_sig, signature::{MethodSignature, JavaType, Primitive}};
+/// const JNI_SIG: MethodSignature = jni_sig!(
+///     type_map = {
+///         CustomType => java.class.Type,
+///         ReturnType => java.class.ReturnType,
+///     },
+///     (arg1: CustomType, arg2: JString, arg3: jint) -> ReturnType,
+/// );
+/// ```
+///
+/// # Field Signature Syntax
+///
+/// ```ignore
+/// jni_sig!(Type)
+/// ```
+///
+/// Traditional JNI signature syntax is also supported:
+/// ```ignore
+/// jni_sig!("Ljava/lang/String;")
+/// ```
+///
+/// Named:
+/// ```ignore
+/// jni_sig!(sig = Type)
+/// ```
+///
+/// With type mappings:
+/// ```ignore
+/// jni_sig!(
+///     Type,
+///     type_map = {
+///         RustType as java.class.Name,
+///         ...
+///     }
+/// )
+/// ```
+///
+/// # Examples
+///
+/// ## Method Signatures
+///
+/// Basic primitive types:
+/// ```ignore
+/// const SIG: MethodSignature = jni_sig!((a: jint, b: jboolean) -> void);
+/// // Result: MethodSignature for "(IZ)V"
+/// ```
+///
+/// Java object types:
+/// ```ignore
+/// const SIG: MethodSignature = jni_sig!(
+///     (a: jint, b: java.lang.String) -> java.lang.Object
+/// );
+/// // Result: MethodSignature for "(ILjava/lang/String;)Ljava/lang/Object;"
+/// ```
+///
+/// Array types:
+/// ```ignore
+/// const SIG: MethodSignature = jni_sig!(
+///     (a: [jint], b: [java.lang.String]) -> [[jint]]
+/// );
+/// // Result: MethodSignature for "([I[Ljava/lang/String;)[[I"
+/// ```
+///
+/// With type mappings:
+/// ```ignore
+/// const SIG: MethodSignature = jni_sig!(
+///     type_map = {
+///         MyString as java.lang.String,
+///         MyObject as java.lang.Object,
+///         MyThrowable as java.lang.Throwable,
+///     },
+///     (a: jint, b: MyString, c: [MyObject]) -> MyThrowable,
+/// );
+/// // Result: MethodSignature for "(ILjava/lang/String;[Ljava/lang/Object;)Ljava/lang/Throwable;"
+/// ```
+/// Multiple type_maps:
+/// ```ignore
+/// const SIG: MethodSignature = jni_sig!(
+///     jni = ::my_jni,
+///     type_map = { MyType0 => custom.Type0 },
+///     type_map = { MyType1 => custom.Type1 },
+///     sig = (arg0: MyType0, arg1: MyType1) -> JString,
+/// );
+/// ```
+///
+/// This makes it possible to write wrapper macros to inject a `type_map` without blocking the use
+/// of `type_map` for additional types.
+///
+/// With named signature property:
+/// ```ignore
+/// const SIG: MethodSignature = jni_sig!(
+///     type_map = { MyType => java.lang.MyType },
+///     sig = (a: jint) -> void,
+/// );
+/// ```
+///
+/// With custom jni crate path:
+/// ```ignore
+/// const SIG: MethodSignature = jni_sig!(
+///     jni = ::my_jni, // must come first!
+///     (a: jint) -> void,
+/// );
+/// ```
+///
+/// ## Field Signatures
+///
+/// Primitive field:
+/// ```ignore
+/// const SIG: FieldSignature = jni_sig!(jint);
+/// // Result: FieldSignature for "I"
+/// ```
+///
+/// Object field:
+/// ```ignore
+/// const SIG: FieldSignature = jni_sig!(java.lang.String);
+/// // Result: FieldSignature for "Ljava/lang/String;"
+/// ```
+///
+/// Array field:
+/// ```ignore
+/// const SIG: FieldSignature = jni_sig!([jint]);
+/// // Result: FieldSignature for "[I"
+/// ```
+///
+/// Field with type mapping:
+/// ```ignore
+/// const SIG: FieldSignature = jni_sig!(
+///     type_map = {
+///         MyType as custom.Type,
+///     },
+///     MyType
+/// );
+/// // Result: FieldSignature for "Lcustom/Type;"
+/// ```
+/// [Reference]: https://docs.rs/jni/latest/jni/refs/trait.Reference.html
+#[proc_macro]
+pub fn jni_sig(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
+    signature::jni_sig_impl(input.into())
+        .unwrap_or_else(|e| e.to_compile_error())
+        .into()
+}
+
+/// Parses a JNI method or field signature at compile time and returns a `&str` literal.
+///
+/// This macro is similar to `jni_sig!` but returns a plain UTF-8 string literal instead
+/// of a `MethodSignature` or `FieldSignature` struct.
+///
+/// See the `jni_sig!` macro documentation for detailed syntax and examples.
+///
+/// # Examples
+///
+/// ```ignore
+/// const SIG: &str = jni_sig_str!((a: jint, b: jboolean) -> void);
+/// // Result: "(IZ)V"
+///
+/// const FIELD_SIG: &str = jni_sig_str!(java.lang.String);
+/// // Result: "Ljava/lang/String;"
+/// ```
+#[proc_macro]
+pub fn jni_sig_str(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
+    signature::jni_sig_str_impl(input.into())
+        .unwrap_or_else(|e| e.to_compile_error())
+        .into()
+}
+
+/// Parses a JNI method or field signature at compile time and returns a CStr literal.
+///
+/// This macro is similar to `jni_sig!` but returns a C string literal (e.g., `c"(IZ)V"`)
+/// with MUTF-8 encoding instead of a `MethodSignature` or `FieldSignature` struct.
+///
+/// The output is encoded using Java's modified UTF-8 (MUTF-8) format via `cesu8::to_java_cesu8`.
+///
+/// See the `jni_sig!` macro documentation for detailed syntax and examples.
+///
+/// # Examples
+///
+/// ```ignore
+/// const SIG: &CStr = jni_sig_cstr!((a: jint, b: jboolean) -> void);
+/// // Result: c"(IZ)V" (MUTF-8 encoded)
+///
+/// const FIELD_SIG: &CStr = jni_sig_cstr!(java.lang.String);
+/// // Result: c"Ljava/lang/String;" (MUTF-8 encoded)
+/// ```
+#[proc_macro]
+pub fn jni_sig_cstr(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
+    signature::jni_sig_cstr_impl(input.into())
+        .unwrap_or_else(|e| e.to_compile_error())
+        .into()
+}
+
+/// Parses a JNI method or field signature at compile time and returns a `&'static JNIStr`.
+///
+/// This macro is similar to `jni_sig!` but returns a `&'static JNIStr` with MUTF-8 encoding
+/// instead of a `MethodSignature` or `FieldSignature` struct.
+///
+/// The output is encoded using Java's modified UTF-8 (MUTF-8) format via `cesu8::to_java_cesu8`
+/// and wrapped in a `JNIStr` via `jni::strings::JNIStr::from_cstr_unchecked()`.
+///
+/// See the `jni_sig!` macro documentation for detailed syntax and examples.
+///
+/// # Examples
+///
+/// ```ignore
+/// const SIG: &JNIStr = jni_sig_jstr!((a: jint, b: jboolean) -> void);
+/// // Result: &'static JNIStr for "(IZ)V" (MUTF-8 encoded)
+///
+/// const FIELD_SIG: &JNIStr = jni_sig_jstr!(java.lang.String);
+/// // Result: &'static JNIStr for "Ljava/lang/String;" (MUTF-8 encoded)
+/// ```
+#[proc_macro]
+pub fn jni_sig_jstr(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
+    signature::jni_sig_jstr_impl(input.into())
         .unwrap_or_else(|e| e.to_compile_error())
         .into()
 }

--- a/jni-macros/src/signature.rs
+++ b/jni-macros/src/signature.rs
@@ -1,0 +1,1125 @@
+#![allow(unused)]
+//! Procedural macro for generating JNI signatures at compile time
+//!
+//! This module provides a `jni_sig!` macro that parses method and field signatures
+//! and generates JNI signature string literals.
+//!
+//! # Method Signatures
+//! Method signatures have the form `(parameters) -> return_type` and generate a JNI
+//! method descriptor like `"(ILjava/lang/String;)V"`.
+//!
+//! # Field Signatures
+//! Field signatures are just a bare type and generate a JNI field descriptor like
+//! `"Ljava/lang/String;"` or `"I"`.
+//!
+//! The parser automatically detects which type of signature based on the presence of
+//! parentheses and a return arrow.
+
+use proc_macro2::{Span, TokenStream};
+use quote::quote;
+use syn::{
+    Ident, Result, Token, custom_keyword, parenthesized,
+    parse::{Parse, ParseStream},
+    token,
+};
+
+use crate::{
+    str::lit_cstr_mutf8,
+    types::{ConcreteType, JavaClassName, PrimitiveType, SigType, TypeMappings, parse_type},
+};
+
+custom_keyword!(sig);
+
+/// Represents a method parameter
+#[derive(Debug, Clone)]
+pub struct Parameter {
+    #[allow(dead_code)]
+    pub name: Ident,
+    pub ty: SigType,
+}
+
+/// Represents a method signature
+#[derive(Debug, Clone)]
+pub struct MethodSignature {
+    pub parameters: Vec<Parameter>,
+    pub return_type: SigType,
+}
+
+impl MethodSignature {
+    /// Convert to JNI method signature string
+    pub fn to_jni_signature(&self, type_mappings: &TypeMappings) -> Result<String> {
+        let mut result = String::from("(");
+
+        for param in &self.parameters {
+            result.push_str(&param.ty.to_jni_descriptor(type_mappings)?);
+        }
+
+        result.push(')');
+        result.push_str(&self.return_type.to_jni_descriptor(type_mappings)?);
+
+        Ok(result)
+    }
+}
+
+/// Parse sig = (args) -> ret
+pub fn parse_method_sig(
+    input: ParseStream,
+    type_mappings: &TypeMappings,
+) -> Result<MethodSignature> {
+    input.parse::<sig>()?;
+    input.parse::<Token![=]>()?;
+
+    let args_content;
+    parenthesized!(args_content in input);
+
+    let mut parameters = Vec::new();
+    let mut param_index = 0;
+
+    while !args_content.is_empty() {
+        let param = parse_parameter_with_index(&args_content, param_index, type_mappings)?;
+        parameters.push(param);
+        param_index += 1;
+
+        if !args_content.is_empty() {
+            args_content.parse::<Token![,]>()?;
+        }
+    }
+
+    let return_type = if input.peek(Token![->]) {
+        input.parse::<Token![->]>()?;
+        parse_type(input, type_mappings)?
+    } else {
+        // No return type implies void
+        SigType::Alias("void".to_string())
+    };
+
+    Ok(MethodSignature {
+        parameters,
+        return_type,
+    })
+}
+
+/// Represents a field signature
+#[derive(Debug, Clone)]
+pub struct FieldSignature {
+    pub field_type: SigType,
+}
+
+impl FieldSignature {
+    /// Convert to JNI field signature string (just the type descriptor)
+    pub fn to_jni_signature(&self, type_mappings: &TypeMappings) -> Result<String> {
+        self.field_type.to_jni_descriptor(type_mappings)
+    }
+}
+
+/// Parse sig = Type for fields
+pub fn parse_field_sig(input: ParseStream, type_mappings: &TypeMappings) -> Result<FieldSignature> {
+    input.parse::<sig>()?;
+    input.parse::<Token![=]>()?;
+    let field_type = parse_type(input, type_mappings)?;
+    Ok(FieldSignature { field_type })
+}
+
+/// Represents either a method or field signature
+#[derive(Debug, Clone)]
+pub enum Signature {
+    Method(MethodSignature),
+    Field(FieldSignature),
+}
+
+impl Signature {
+    /// Convert to JNI signature string
+    pub fn to_jni_signature(&self, type_mappings: &TypeMappings) -> Result<String> {
+        match self {
+            Signature::Method(sig) => sig.to_jni_signature(type_mappings),
+            Signature::Field(sig) => sig.to_jni_signature(type_mappings),
+        }
+    }
+}
+
+/// Parse a parameter with an index for fallback naming: `name: type` or just `type`
+/// If only a type is provided, generates a fallback name like "arg0", "arg1", etc.
+pub fn parse_parameter_with_index(
+    input: ParseStream,
+    index: usize,
+    type_mappings: &TypeMappings,
+) -> Result<Parameter> {
+    // Try to parse as `name: type` first
+    // We need to look ahead to see if there's a colon after the first identifier
+    let fork = input.fork();
+
+    // Try to parse identifier
+    if let Ok(_potential_name) = fork.parse::<Ident>() {
+        // Check if it's followed by a colon
+        if fork.peek(Token![:]) {
+            // This is a named parameter: `name: type`
+            let name = input.parse::<Ident>()?;
+            input.parse::<Token![:]>()?;
+            let ty = parse_type(input, type_mappings)?;
+            return Ok(Parameter { name, ty });
+        }
+    }
+
+    // No colon found, so this is just a type - generate a fallback name
+    let ty = parse_type(input, type_mappings)?;
+    let name = Ident::new(&format!("arg{}", index), Span::call_site());
+
+    Ok(Parameter { name, ty })
+}
+
+/// Represents the full macro input with named properties
+struct SignatureInput {
+    signature: Signature,
+    type_mappings: TypeMappings,
+}
+
+impl Parse for SignatureInput {
+    fn parse(input: ParseStream) -> Result<Self> {
+        // Parse properties in the form: prop = value, prop = value, ...
+        // If an argument is unnamed, it's assumed to be the signature.
+        // This allows properties to be specified in any order and makes it easy
+        // for wrapper macros to inject properties like `jni = foo,` without
+        // needing to parse the syntax or worry about positioning.
+
+        let mut signature: Option<Signature> = None;
+
+        let jni_path = crate::utils::parse_jni_crate_override(&input)?;
+
+        // Initialize TypeMappings unconditionally now that we have jni_crate
+        let mut type_mappings = TypeMappings::new(&jni_path);
+
+        // Parse remaining properties/arguments
+        while !input.is_empty() {
+            // Check if this looks like a named property ('<ident> = <value>' or '<ident> { ... }')
+            let is_named_property = {
+                let fork = input.fork();
+                if fork.peek(Ident) {
+                    if let Ok(_ident) = fork.parse::<Ident>() {
+                        fork.peek(Token![=]) || fork.peek(syn::token::Brace)
+                    } else {
+                        false
+                    }
+                } else {
+                    false
+                }
+            };
+
+            if is_named_property {
+                // Parse named property
+                let prop_name = input.parse::<Ident>()?;
+                let prop_str = prop_name.to_string();
+
+                match prop_str.as_str() {
+                    "jni" => {
+                        // jni can only be the first property
+                        return Err(syn::Error::new(
+                            prop_name.span(),
+                            "jni property must be the first property if specified",
+                        ));
+                    }
+                    "sig" => {
+                        input.parse::<Token![=]>()?;
+                        if signature.is_some() {
+                            return Err(syn::Error::new(
+                                prop_name.span(),
+                                "signature specified multiple times (either as unnamed argument or with 'sig =')",
+                            ));
+                        }
+                        signature = Some(parse_signature(input, &type_mappings)?);
+                    }
+                    "type_map" => {
+                        type_mappings.parse_mappings(input)?;
+                    }
+                    _ => {
+                        return Err(syn::Error::new(
+                            prop_name.span(),
+                            format!(
+                                "unknown property '{}'. Valid properties are: sig, type_map, jni",
+                                prop_str
+                            ),
+                        ));
+                    }
+                }
+            } else {
+                // Unnamed argument - assume it's the signature
+                if signature.is_some() {
+                    return Err(syn::Error::new(
+                        input.span(),
+                        "signature specified multiple times (either as unnamed argument or with 'sig =')",
+                    ));
+                }
+                signature = Some(parse_signature(input, &type_mappings)?);
+            }
+
+            if !input.is_empty() {
+                input.parse::<Token![,]>()?;
+            }
+        }
+
+        // Signature is required
+        let signature = signature.ok_or_else(|| {
+            syn::Error::new(
+                Span::call_site(),
+                "signature is required (either as unnamed argument or with 'sig =')",
+            )
+        })?;
+
+        Ok(SignatureInput {
+            signature,
+            type_mappings,
+        })
+    }
+}
+
+/// Parse a signature (method or field) from input
+fn parse_signature(input: ParseStream, type_mappings: &TypeMappings) -> Result<Signature> {
+    // If the input starts with a string literal, it could either be a raw JNI signature
+    // or a Java class name for a field signature.
+    //
+    // If the string literal contains dots (.), we'll treat it as a Java class name for a field signature.
+    if input.peek(syn::LitStr) || input.peek(syn::LitCStr) {
+        // Parse the string literal
+        let raw_sig: String = if input.peek(syn::LitCStr) {
+            let lit = input.parse::<syn::LitCStr>()?;
+            let cstr = lit.value();
+            cstr.to_str()
+                .map_err(|e| {
+                    syn::Error::new(
+                        lit.span(),
+                        format!("CStr literal must contain valid UTF-8: {}", e),
+                    )
+                })?
+                .to_string()
+        } else {
+            let lit = input.parse::<syn::LitStr>()?;
+            lit.value()
+        };
+
+        let is_raw_jni_sig = !raw_sig.contains('.');
+
+        if is_raw_jni_sig {
+            // Parse as raw JNI signature
+            parse_raw_jni_signature(&raw_sig)
+        } else {
+            // It contains a dot, so treat it as a Java class name for a field signature
+            // Parse it as a JavaClassName
+            let parts: Vec<&str> = raw_sig.split('.').collect();
+            if parts.is_empty() {
+                return Err(syn::Error::new(
+                    input.span(),
+                    format!("Empty Java class name in string literal: '{}'", raw_sig),
+                ));
+            }
+
+            let class = parts.last().unwrap().to_string();
+            let package: Vec<String> = parts[..parts.len() - 1]
+                .iter()
+                .map(|s| s.to_string())
+                .collect();
+
+            let java_class = JavaClassName { package, class };
+            Ok(Signature::Field(FieldSignature {
+                field_type: SigType::Object(java_class),
+            }))
+        }
+    } else if input.peek(token::Paren) {
+        // Method signature: (args) [-> ret]
+        let args_content;
+        parenthesized!(args_content in input);
+
+        let mut parameters = Vec::new();
+
+        if !args_content.is_empty() {
+            let mut param_index = 0;
+            loop {
+                let param = parse_parameter_with_index(&args_content, param_index, type_mappings)?;
+                parameters.push(param);
+                param_index += 1;
+
+                if args_content.is_empty() {
+                    break;
+                }
+                args_content.parse::<Token![,]>()?;
+                if args_content.is_empty() {
+                    break;
+                }
+            }
+        }
+
+        let return_type = if input.peek(Token![->]) {
+            input.parse::<Token![->]>()?;
+
+            parse_type(input, type_mappings)?
+        } else {
+            // Default return type is void
+            SigType::Alias("void".to_string())
+        };
+
+        Ok(Signature::Method(MethodSignature {
+            parameters,
+            return_type,
+        }))
+    } else {
+        // Field signature: just a type
+        let field_type = parse_type(input, type_mappings)?;
+        Ok(Signature::Field(FieldSignature { field_type }))
+    }
+}
+
+/// Parse a raw JNI signature string into a Signature
+/// This parses strings like "(ILjava/lang/String;)V" or "[I" or "Ljava/lang/String;"
+fn parse_raw_jni_signature(sig: &str) -> Result<Signature> {
+    // Check if it's a method signature (starts with '(')
+    if sig.starts_with('(') {
+        parse_raw_jni_method_signature(sig)
+    } else {
+        parse_raw_jni_field_signature(sig)
+    }
+}
+
+/// Parse a raw JNI method signature string
+fn parse_raw_jni_method_signature(sig: &str) -> Result<Signature> {
+    if !sig.starts_with('(') {
+        return Err(syn::Error::new(
+            Span::call_site(),
+            format!("Method signature must start with '(': '{}'", sig),
+        ));
+    }
+
+    // Find the closing ')'
+    let close_paren = sig.find(')').ok_or_else(|| {
+        syn::Error::new(
+            Span::call_site(),
+            format!("Method signature missing closing ')': '{}'", sig),
+        )
+    })?;
+
+    // Parse arguments
+    let args_str = &sig[1..close_paren];
+    let mut args = Vec::new();
+    let mut i = 0;
+    let args_bytes = args_str.as_bytes();
+
+    while i < args_bytes.len() {
+        let (java_type, consumed) = parse_raw_jni_type(&args_str[i..])?;
+        args.push(java_type);
+        i += consumed;
+    }
+
+    // Parse return type
+    let ret_str = &sig[close_paren + 1..];
+    if ret_str.is_empty() {
+        return Err(syn::Error::new(
+            Span::call_site(),
+            format!("Method signature missing return type: '{}'", sig),
+        ));
+    }
+
+    let (ret, consumed) = parse_raw_jni_type(ret_str)?;
+    if consumed != ret_str.len() {
+        return Err(syn::Error::new(
+            Span::call_site(),
+            format!(
+                "Trailing input: '{}' while parsing '{}'",
+                &ret_str[consumed..],
+                sig
+            ),
+        ));
+    }
+
+    // Create dummy parameters with generated names
+    let parameters = args
+        .into_iter()
+        .enumerate()
+        .map(|(i, ty)| Parameter {
+            name: Ident::new(&format!("arg{}", i), Span::call_site()),
+            ty,
+        })
+        .collect();
+
+    Ok(Signature::Method(MethodSignature {
+        parameters,
+        return_type: ret,
+    }))
+}
+
+/// Parse a raw JNI field signature string
+fn parse_raw_jni_field_signature(sig: &str) -> Result<Signature> {
+    let (field_type, consumed) = parse_raw_jni_type(sig)?;
+    if consumed != sig.len() {
+        return Err(syn::Error::new(
+            Span::call_site(),
+            format!(
+                "Trailing input: '{}' while parsing '{}'",
+                &sig[consumed..],
+                sig
+            ),
+        ));
+    }
+
+    // Validate that void cannot be used as a field type
+    if matches!(field_type, SigType::Alias(ref name) if name == "void") {
+        return Err(syn::Error::new(
+            Span::call_site(),
+            format!(
+                "void cannot be used as a field type in signature: '{}'",
+                sig
+            ),
+        ));
+    }
+
+    Ok(Signature::Field(FieldSignature { field_type }))
+}
+
+/// Parse a single JNI type descriptor from a string
+/// Returns the JavaType and the number of bytes consumed
+fn parse_raw_jni_type(s: &str) -> Result<(SigType, usize)> {
+    let bytes = s.as_bytes();
+    if bytes.is_empty() {
+        return Err(syn::Error::new(
+            Span::call_site(),
+            "Expected type descriptor but found empty string",
+        ));
+    }
+
+    match bytes[0] as char {
+        'Z' => Ok((SigType::Alias("jboolean".to_string()), 1)),
+        'B' => Ok((SigType::Alias("jbyte".to_string()), 1)),
+        'C' => Ok((SigType::Alias("jchar".to_string()), 1)),
+        'S' => Ok((SigType::Alias("jshort".to_string()), 1)),
+        'I' => Ok((SigType::Alias("jint".to_string()), 1)),
+        'J' => Ok((SigType::Alias("jlong".to_string()), 1)),
+        'F' => Ok((SigType::Alias("jfloat".to_string()), 1)),
+        'D' => Ok((SigType::Alias("jdouble".to_string()), 1)),
+        'V' => Ok((SigType::Alias("void".to_string()), 1)),
+        '[' => {
+            // Array type - parse element type recursively
+            let (elem_type, elem_consumed) = parse_raw_jni_type(&s[1..])?;
+
+            // Validate that void cannot be used as an array element type
+            if matches!(elem_type, SigType::Alias(ref name) if name == "void") {
+                return Err(syn::Error::new(
+                    Span::call_site(),
+                    format!(
+                        "void cannot be used as an array element type in signature: '{}'",
+                        s
+                    ),
+                ));
+            }
+
+            Ok((SigType::Array(Box::new(elem_type), 1), 1 + elem_consumed))
+        }
+        'L' => {
+            // Object type - find the semicolon
+            let end = s.find(';').ok_or_else(|| {
+                syn::Error::new(
+                    Span::call_site(),
+                    format!("Object type missing closing ';': '{}'", s),
+                )
+            })?;
+
+            let class_name = &s[1..end];
+
+            // Validate class name - should not be empty and should not start/end with '/'
+            if class_name.is_empty() {
+                return Err(syn::Error::new(
+                    Span::call_site(),
+                    format!("Empty class name in object type: '{}'", s),
+                ));
+            }
+            if class_name.starts_with('/') {
+                return Err(syn::Error::new(
+                    Span::call_site(),
+                    format!("Class name cannot start with '/': '{}'", s),
+                ));
+            }
+            if class_name.ends_with('/') {
+                return Err(syn::Error::new(
+                    Span::call_site(),
+                    format!("Class name cannot end with '/': '{}'", s),
+                ));
+            }
+
+            // Validate that name segments are non-empty
+            if class_name.contains("//") {
+                return Err(syn::Error::new(
+                    Span::call_site(),
+                    format!("Class name contains empty segment: '{}'", s),
+                ));
+            }
+
+            // Parse the class name (could be "java/lang/String" or "java/lang/Outer$Inner")
+            // Split by '/' for package segments
+            let parts: Vec<&str> = class_name.split('/').collect();
+
+            // The last part is the class name (may contain '$' for inner classes)
+            let class = parts.last().unwrap().to_string();
+
+            // Everything before the last part is the package
+            let package: Vec<String> = parts[..parts.len() - 1]
+                .iter()
+                .map(|s| s.to_string())
+                .collect();
+
+            let java_class = JavaClassName { package, class };
+
+            Ok((SigType::Object(java_class), end + 1))
+        }
+        c => Err(syn::Error::new(
+            Span::call_site(),
+            format!("Invalid type descriptor: '{}'", c),
+        )),
+    }
+}
+
+/// Convert a JavaType to a TokenStream that constructs jni::signature::JavaType
+fn java_type_to_tokens(ty: &SigType, type_mappings: &TypeMappings) -> Result<TokenStream> {
+    let jni = type_mappings.jni_crate();
+
+    match ty {
+        SigType::Alias(name) => match type_mappings.map_alias(name) {
+            Some(ConcreteType::Object { .. }) => Ok(quote! {
+                #jni::signature::JavaType::Object
+            }),
+            Some(ConcreteType::Primitive { primitive, .. }) => {
+                let variant = match primitive {
+                    PrimitiveType::Boolean => quote! { Boolean },
+                    PrimitiveType::Byte => quote! { Byte },
+                    PrimitiveType::Char => quote! { Char },
+                    PrimitiveType::Short => quote! { Short },
+                    PrimitiveType::Int => quote! { Int },
+                    PrimitiveType::Long => quote! { Long },
+                    PrimitiveType::Float => quote! { Float },
+                    PrimitiveType::Double => quote! { Double },
+                    PrimitiveType::Void => quote! { Void },
+                };
+                Ok(quote! {
+                    #jni::signature::JavaType::Primitive(#jni::signature::Primitive::#variant)
+                })
+            }
+            None => Err(syn::Error::new(
+                Span::call_site(),
+                format!("Unknown type '{}'", name),
+            )),
+        },
+        SigType::Object(_) => Ok(quote! {
+            #jni::signature::JavaType::Object
+        }),
+        SigType::Array(_, _) => {
+            // For arrays, jni::signature::JavaType just uses the Array variant
+            // The dimensionality is encoded in the signature string
+            Ok(quote! {
+                #jni::signature::JavaType::Array
+            })
+        }
+    }
+}
+
+/// The actual procedural macro implementation for jni_sig!
+/// Returns a jni::signature::{MethodSignature, FieldSignature}
+pub fn jni_sig_impl(input: TokenStream) -> Result<TokenStream> {
+    let SignatureInput {
+        signature,
+        type_mappings,
+    } = syn::parse2(input)?;
+
+    // Get the jni crate path
+    let jni = type_mappings.jni_crate();
+
+    // Generate the JNI signature string
+    let jni_sig = signature.to_jni_signature(&type_mappings)?;
+
+    // Create a C string literal for the signature with MUTF-8 encoding
+    let sig_cstr = lit_cstr_mutf8(&jni_sig);
+
+    // Generate the appropriate jni::signature type
+    match signature {
+        Signature::Method(method_sig) => {
+            // Generate the arguments array
+            let args_tokens: Vec<TokenStream> = method_sig
+                .parameters
+                .iter()
+                .map(|param| java_type_to_tokens(&param.ty, &type_mappings))
+                .collect::<Result<Vec<_>>>()?;
+
+            // Generate the return type
+            let ret_token = java_type_to_tokens(&method_sig.return_type, &type_mappings)?;
+
+            Ok(quote! {
+                {
+                    // Safety: The signature was parsed and validated at compile-time
+                    unsafe {
+                        #jni::signature::MethodSignature::from_raw_parts(
+                            #jni::strings::JNIStr::from_cstr_unchecked(#sig_cstr),
+                            &[#(#args_tokens),*],
+                            #ret_token
+                        )
+                    }
+                }
+            })
+        }
+        Signature::Field(field_sig) => {
+            // Generate the field type
+            let ty_token = java_type_to_tokens(&field_sig.field_type, &type_mappings)?;
+
+            Ok(quote! {
+                {
+                    // Safety: The signature was parsed and validated at compile-time
+                    unsafe {
+                        #jni::signature::FieldSignature::from_raw_parts(
+                            #jni::strings::JNIStr::from_cstr_unchecked(#sig_cstr),
+                            #ty_token
+                        )
+                    }
+                }
+            })
+        }
+    }
+}
+
+/// Implementation for jni_sig_str! macro
+/// Returns a &str string literal
+pub fn jni_sig_str_impl(input: TokenStream) -> Result<TokenStream> {
+    let SignatureInput {
+        signature,
+        type_mappings,
+    } = syn::parse2(input)?;
+
+    // Generate the JNI signature string
+    let jni_sig = signature.to_jni_signature(&type_mappings)?;
+
+    Ok(quote! {
+        #jni_sig
+    })
+}
+
+/// Implementation for jni_sig_cstr! macro
+/// Returns a CStr literal (c"...") with MUTF-8 encoding
+pub fn jni_sig_cstr_impl(input: TokenStream) -> Result<TokenStream> {
+    let SignatureInput {
+        signature,
+        type_mappings,
+    } = syn::parse2(input)?;
+
+    // Generate the JNI signature string
+    let jni_sig = signature.to_jni_signature(&type_mappings)?;
+
+    // Create a C string literal with MUTF-8 encoding
+    let sig_cstr = lit_cstr_mutf8(&jni_sig);
+
+    Ok(quote! {
+        #sig_cstr
+    })
+}
+
+/// Implementation for jni_sig_jstr! macro
+/// Returns a &'static JNIStr with MUTF-8 encoding
+pub fn jni_sig_jstr_impl(input: TokenStream) -> Result<TokenStream> {
+    let SignatureInput {
+        signature,
+        type_mappings,
+    } = syn::parse2(input)?;
+
+    // Get the jni crate path
+    let jni = type_mappings.jni_crate();
+
+    // Generate the JNI signature string
+    let jni_sig = signature.to_jni_signature(&type_mappings)?;
+
+    // Create a C string literal with MUTF-8 encoding
+    let sig_cstr = lit_cstr_mutf8(&jni_sig);
+
+    Ok(quote! {
+        {
+            // Safety: The signature was parsed and validated at compile-time
+            unsafe {
+                #jni::strings::JNIStr::from_cstr_unchecked(#sig_cstr)
+            }
+        }
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use quote::quote;
+
+    // Test parsing error: single identifier without dot should fail
+    #[test]
+    fn test_single_ident_fails_as_java_class() {
+        // This should be parsed as a Rust type reference, not a Java class
+        let input = quote! {
+            String
+        };
+
+        let result = jni_sig_impl(input);
+        // Should fail because "String" without a dot is treated as a Rust type
+        // and there's no type mapping for it
+        assert!(result.is_err());
+    }
+
+    // Test that slash-separated package names fail with helpful error
+    // (Users should use dot-separated Java format, not JNI internal format)
+    #[test]
+    fn test_slash_separated_package_fails() {
+        // This should fail because we expect Java dotted format (java.lang.String)
+        // not JNI internal format (java/lang/String)
+        let input = quote! {
+            java/lang/String
+        };
+
+        let result = jni_sig_impl(input);
+        // The parser will treat this as a division operation and fail to parse
+        assert!(result.is_err());
+
+        // Verify the error is about parsing, not about finding the type
+        let err = result.unwrap_err();
+        let err_msg = err.to_string();
+        // The error should be a parse error, not a "type not found" error
+        assert!(!err_msg.contains("No type mapping found"));
+    }
+
+    // Test that string literals don't support slash separators either
+    #[test]
+    fn test_string_literal_with_slashes_in_type_mapping() {
+        // Even in string literals, we expect Java dotted format
+        let input = quote! {
+            MyCustomType,
+            type_map = {
+                MyCustomType => "java/lang/String",
+            }
+        };
+
+        // This should fail during parsing of the type mapping
+        // String literals with slashes should be rejected
+        let result = jni_sig_impl(input);
+        assert!(result.is_err());
+
+        // The error should mention that dots are required
+        let err = result.unwrap_err();
+        let err_msg = err.to_string();
+        assert!(err_msg.contains("must contain at least one dot"));
+    }
+
+    // Test that the parser requires at least one dot to differentiate from Rust types
+    #[test]
+    fn test_no_dots_fails_for_java_class() {
+        // Without dots, this should be treated as a Rust type reference
+        let input = quote! {
+            (arg: SomeType) -> void
+        };
+
+        let result = jni_sig_impl(input);
+        // Should fail with "Unknown type" after attempting to resolve SomeType
+        // via type mappings
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        let err_msg = err.to_string();
+        assert!(err_msg.contains("Unknown type"));
+    }
+
+    // Test that string literal in JavaClassName::parse requires dots
+    #[test]
+    fn test_string_literal_without_dots_fails() {
+        let input = quote! { "String" };
+        let result = syn::parse2::<JavaClassName>(input);
+
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        let err_msg = err.to_string();
+        assert!(err_msg.contains("must contain at least one dot"));
+    }
+
+    // Test that JavaClassName::parse rejects single identifiers without consuming them
+    #[test]
+    fn test_parse_java_class_name_rejects_single_ident() {
+        // A single identifier without a dot should fail to parse as a Java class name
+        let input = quote! { SomeType };
+        let result = syn::parse2::<JavaClassName>(input);
+
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        let err_msg = err.to_string();
+        assert!(err_msg.contains("Expected Java class name"));
+    }
+
+    // ============================================================================
+    // Raw JNI signature tests
+    // ============================================================================
+
+    #[test]
+    fn test_raw_jni_field_primitives() {
+        // Test all primitive types
+        let primitives = [
+            ("Z", "Z", "Boolean"),
+            ("B", "B", "Byte"),
+            ("C", "C", "Char"),
+            ("S", "S", "Short"),
+            ("I", "I", "Int"),
+            ("J", "J", "Long"),
+            ("F", "F", "Float"),
+            ("D", "D", "Double"),
+        ];
+
+        for (input_sig, expected_sig, expected_type) in primitives {
+            let input = quote! { #input_sig };
+            let result = jni_sig_impl(input).unwrap();
+            let result_str = result.to_string();
+            assert!(
+                result_str.contains(&format!("\"{}\"", expected_sig)),
+                "Expected signature '{}' for input '{}'",
+                expected_sig,
+                input_sig
+            );
+            assert!(
+                result_str.contains(&format!("Primitive :: {}", expected_type)),
+                "Expected primitive type '{}' for input '{}'",
+                expected_type,
+                input_sig
+            );
+            assert!(
+                result_str.contains("FieldSignature"),
+                "Expected FieldSignature output for input '{}'",
+                input_sig
+            );
+        }
+    }
+
+    #[test]
+    fn test_raw_jni_errors_empty_string() {
+        let input = quote! { "" };
+        let result = jni_sig_impl(input);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_raw_jni_errors_invalid_primitive() {
+        let input = quote! { "A" };
+        let result = jni_sig_impl(input);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_raw_jni_errors_void_field() {
+        let input = quote! { "V" };
+        let result = jni_sig_impl(input);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_raw_jni_errors_void_array_in_method_arguments() {
+        // Void arrays are invalid in method arguments
+        let input = quote! { "([V)V" };
+        let result = jni_sig_impl(input);
+        assert!(result.is_err());
+
+        let input = quote! { "(I[V)V" };
+        let result = jni_sig_impl(input);
+        assert!(result.is_err());
+
+        let input = quote! { "([VI)V" };
+        let result = jni_sig_impl(input);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_raw_jni_errors_void_array_as_return_type() {
+        // Void arrays are invalid as return types
+        let input = quote! { "()[V" };
+        let result = jni_sig_impl(input);
+        assert!(result.is_err());
+
+        let input = quote! { "(I)[V" };
+        let result = jni_sig_impl(input);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_raw_jni_errors_void_array_field() {
+        // Void arrays are invalid as field types
+        let input = quote! { "[V" };
+        let result = jni_sig_impl(input);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_raw_jni_errors_incomplete_method() {
+        let input = quote! { "(I" };
+        let result = jni_sig_impl(input);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_raw_jni_errors_method_no_return() {
+        let input = quote! { "(I)" };
+        let result = jni_sig_impl(input);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_raw_jni_errors_trailing_input() {
+        let input = quote! { "II" };
+        let result = jni_sig_impl(input);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_raw_jni_errors_invalid_in_method() {
+        let input = quote! { "(Invalid)I" };
+        let result = jni_sig_impl(input);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_raw_jni_errors_object_no_semicolon() {
+        let input = quote! { "Ljava/lang/String" };
+        let result = jni_sig_impl(input);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_raw_jni_errors_object_empty_name() {
+        let input = quote! { "L;" };
+        let result = jni_sig_impl(input);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_raw_jni_errors_leading_slash() {
+        let input = quote! { "L/java/lang/String;" };
+        let result = jni_sig_impl(input);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_raw_jni_string_with_dots_as_field() {
+        // String literal with dots should be treated as Java class name for field
+        let input = quote! { "java.lang.String" };
+        let result = jni_sig_impl(input).unwrap();
+        let result_str = result.to_string();
+        assert!(result_str.contains("\"Ljava/lang/String;\""));
+        assert!(result_str.contains("FieldSignature :: from_raw_parts"));
+    }
+
+    #[test]
+    fn test_raw_jni_inner_classes() {
+        // Test inner classes with $ separator
+        let input = quote! { "Ljava/lang/Outer$Inner;" };
+        let result = jni_sig_impl(input).unwrap();
+        let result_str = result.to_string();
+        assert!(result_str.contains("\"Ljava/lang/Outer$Inner;\""));
+    }
+
+    #[test]
+    fn test_raw_jni_method_with_inner_class() {
+        let input = quote! { "(Ljava/lang/Outer$Inner;)V" };
+        let result = jni_sig_impl(input).unwrap();
+        let result_str = result.to_string();
+        assert!(result_str.contains("\"(Ljava/lang/Outer$Inner;)V\""));
+    }
+
+    #[test]
+    fn test_raw_jni_default_package_class() {
+        // Default package class (no package)
+        let input = quote! { "LNoPackage;" };
+        let result = jni_sig_impl(input).unwrap();
+        let result_str = result.to_string();
+        assert!(result_str.contains("\"LNoPackage;\""));
+    }
+
+    #[test]
+    fn test_raw_jni_multidimensional_array() {
+        let input = quote! { "[[I" };
+        let result = jni_sig_impl(input).unwrap();
+        let result_str = result.to_string();
+        assert!(result_str.contains("\"[[I\""));
+    }
+
+    #[test]
+    fn test_raw_jni_method_returns_array() {
+        let input = quote! { "()[[I" };
+        let result = jni_sig_impl(input).unwrap();
+        let result_str = result.to_string();
+        assert!(result_str.contains("\"()[[I\""));
+    }
+
+    #[test]
+    fn test_non_raw_void_array_prefix_syntax() {
+        // Test void array with prefix syntax [void]
+        let input = quote! { [void] };
+        let result = jni_sig_impl(input);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_non_raw_void_array_suffix_syntax() {
+        // Test void array with suffix syntax void[]
+        let input = quote! { void[] };
+        let result = jni_sig_impl(input);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_non_raw_void_array_in_method_args() {
+        // Test void array in method arguments
+        let input = quote! { (arg: [void]) -> void };
+        let result = jni_sig_impl(input);
+        assert!(result.is_err());
+
+        let input = quote! { (arg: void[]) -> void };
+        let result = jni_sig_impl(input);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_non_raw_void_array_as_return_type() {
+        // Test void array as return type
+        let input = quote! { () -> [void] };
+        let result = jni_sig_impl(input);
+        assert!(result.is_err());
+
+        let input = quote! { () -> void[] };
+        let result = jni_sig_impl(input);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_cstr_literal_invalid_utf8() {
+        // CStr literals can contain byte escapes that create invalid UTF-8 sequences
+        // For example, \xFF is not valid UTF-8
+        // This tests that our code properly rejects such literals with a clear error message
+
+        // Create a CStr literal with invalid UTF-8 using byte escapes
+        // \xFF is not a valid UTF-8 byte sequence
+        let input = quote! { c"(\xFF)V" };
+        let result = jni_sig_impl(input);
+
+        // Should fail with a UTF-8 validation error
+        assert!(
+            result.is_err(),
+            "CStr literal with invalid UTF-8 should be rejected"
+        );
+
+        let err = result.unwrap_err();
+        let err_msg = err.to_string();
+        assert!(
+            err_msg.contains("CStr literal must contain valid UTF-8"),
+            "Error message should mention UTF-8 validation, got: {}",
+            err_msg
+        );
+
+        // Also test that valid UTF-8 in CStr literals works correctly
+        let input = quote! { c"(I)V" };
+        let result = jni_sig_impl(input);
+        assert!(
+            result.is_ok(),
+            "Valid UTF-8 CStr literal should parse successfully"
+        );
+
+        let result_str = result.unwrap().to_string();
+        assert!(
+            result_str.contains("\"(I)V\""),
+            "Should contain the signature string"
+        );
+    }
+}

--- a/jni-macros/src/types.rs
+++ b/jni-macros/src/types.rs
@@ -1,0 +1,1207 @@
+#![allow(unused)]
+use core::panic;
+use std::rc::Rc;
+
+use proc_macro2::{Span, TokenStream};
+use quote::quote;
+use syn::{
+    Ident, Result, Token, braced, custom_keyword, parenthesized,
+    parse::{Parse, ParseStream},
+    token,
+};
+
+custom_keyword!(typealias);
+
+/// Format a syn::Path as a string without spaces (for rustdoc links)
+pub fn path_to_string_no_spaces(path: &syn::Path) -> String {
+    quote!(#path).to_string().replace(" ", "")
+}
+
+/// Represents a primitive Java type
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub enum PrimitiveType {
+    Void,
+    Boolean,
+    Byte,
+    Char,
+    Short,
+    Int,
+    Long,
+    Float,
+    Double,
+}
+
+impl PrimitiveType {
+    /// Convert primitive type to JNI descriptor character
+    pub fn to_jni_descriptor(&self) -> &'static str {
+        match self {
+            PrimitiveType::Void => "V",
+            PrimitiveType::Boolean => "Z",
+            PrimitiveType::Byte => "B",
+            PrimitiveType::Char => "C",
+            PrimitiveType::Short => "S",
+            PrimitiveType::Int => "I",
+            PrimitiveType::Long => "J",
+            PrimitiveType::Float => "F",
+            PrimitiveType::Double => "D",
+        }
+    }
+}
+
+/// Represents a Java class name (package + class)
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct JavaClassName {
+    /// Package segments (e.g., ["java", "lang"])
+    pub package: Vec<String>,
+    /// Class name (including optional inner class names separated by '$')
+    pub class: String,
+}
+
+impl JavaClassName {
+    /// Convert to JNI internal form (e.g., "java/lang/String" or "java/lang/Outer$Inner")
+    pub fn to_jni_internal(&self) -> String {
+        let mut result = String::new();
+
+        // Add package
+        for (i, segment) in self.package.iter().enumerate() {
+            if i > 0 {
+                result.push('/');
+            }
+            result.push_str(segment);
+        }
+
+        // Add class name
+        if !self.package.is_empty() {
+            result.push('/');
+        }
+        result.push_str(&self.class);
+
+        result
+    }
+
+    /// Convert to Java dotted form (e.g., "java.lang.String" or "java.lang.Outer$Inner")
+    pub fn to_java_dotted(&self) -> String {
+        let mut result = String::new();
+
+        // Add package
+        for (i, segment) in self.package.iter().enumerate() {
+            if i > 0 {
+                result.push('.');
+            }
+            result.push_str(segment);
+        }
+
+        // Add class name
+        if !self.package.is_empty() {
+            result.push('.');
+        }
+        result.push_str(&self.class);
+
+        result
+    }
+
+    /// Convert to JNI object descriptor (e.g., "Ljava/lang/String;")
+    pub fn to_jni_descriptor(&self) -> String {
+        format!("L{};", self.to_jni_internal())
+    }
+}
+
+impl Parse for JavaClassName {
+    /// Parse a Java class name from a ParseStream or string literal
+    /// Supports:
+    /// - Dotted package.Class syntax (e.g., `java.lang.String`)
+    /// - Inner classes with :: separator (e.g., `java.lang.Outer::Inner`)
+    /// - String literals with dotted syntax
+    /// - Special case for default-package classes starting with `.` (e.g., `.NoPackage`)
+    ///
+    /// The parser requires at least one dot in the input to differentiate from Rust types,
+    /// except for the special default-package case which starts with a `.`
+    fn parse(input: ParseStream) -> Result<Self> {
+        // Check if it's a string literal
+        if input.peek(syn::LitStr) {
+            let lit = input.parse::<syn::LitStr>()?;
+            let class_str = lit.value();
+
+            // Split by dots
+            let parts: Vec<&str> = class_str.split('.').collect();
+            if parts.is_empty() || (parts.len() == 1 && !class_str.starts_with('.')) {
+                return Err(syn::Error::new(
+                    lit.span(),
+                    "Java class name in string literal must contain at least one dot (e.g., \"java.lang.String\" or \".NoPackage\" for default package)",
+                ));
+            }
+
+            let class = parts.last().unwrap().to_string();
+            let package: Vec<String> = if class_str.starts_with('.') {
+                // Default package case
+                Vec::new()
+            } else {
+                parts[..parts.len() - 1]
+                    .iter()
+                    .map(|s| s.to_string())
+                    .collect()
+            };
+
+            return Ok(JavaClassName { package, class });
+        }
+
+        // Check for dot-prefixed default package class (e.g., .NoPackage)
+        if input.peek(Token![.]) {
+            input.parse::<Token![.]>()?;
+            let mut class_name = input.parse::<Ident>()?.to_string();
+
+            // Parse inner classes if any and concatenate with $
+            while input.peek(Token![::]) {
+                input.parse::<Token![::]>()?;
+                let inner = input.parse::<Ident>()?;
+                class_name.push('$');
+                class_name.push_str(&inner.to_string());
+            }
+
+            return Ok(JavaClassName {
+                package: Vec::new(),
+                class: class_name,
+            });
+        }
+
+        // Check if we have an ident followed by a dot (using lookahead to avoid consuming the ident)
+        // This ensures we don't consume a token that might be a primitive type or Rust type
+        if input.peek(Ident) && input.peek2(Token![.]) {
+            // Parse as ident-based syntax: package.Class
+            let mut segments = Vec::new();
+            let first = input.parse::<Ident>()?;
+            segments.push(first.to_string());
+
+            // Parse dot-separated package/class segments
+            while input.peek(Token![.]) {
+                input.parse::<Token![.]>()?;
+                let segment = input.parse::<Ident>()?;
+                segments.push(segment.to_string());
+            }
+
+            // Parse inner classes (separated by ::) and concatenate with $
+            let mut inner_class_parts = Vec::new();
+            while input.peek(Token![::]) {
+                input.parse::<Token![::]>()?;
+                let inner = input.parse::<Ident>()?;
+                inner_class_parts.push(inner.to_string());
+            }
+
+            // Build the class name: last segment + any inner classes joined with $
+            let mut class = segments.pop().unwrap();
+            if !inner_class_parts.is_empty() {
+                class.push('$');
+                class.push_str(&inner_class_parts.join("$"));
+            }
+
+            return Ok(JavaClassName {
+                package: segments,
+                class,
+            });
+        }
+
+        // None of the valid patterns matched
+        Err(syn::Error::new(
+            input.span(),
+            "Expected Java class name: either a string literal with dots (e.g., \"java.lang.String\"), a dotted identifier (e.g., java.lang.String), or a dot-prefixed class for default package (e.g., .NoPackage)",
+        ))
+    }
+}
+/// Represents a type in the signature
+#[derive(Debug, Clone, PartialEq)]
+pub enum SigType {
+    /// A type alias that must be mapped via TypeMappings
+    /// into a Java class name or a primitive type
+    Alias(String),
+    /// Object type (Java class)
+    Object(JavaClassName),
+    /// Array type with element type and dimensions
+    Array(Box<SigType>, usize),
+}
+
+impl SigType {
+    /// Convert to JNI descriptor
+    pub fn to_jni_descriptor(&self, type_mappings: &TypeMappings) -> Result<String> {
+        match self {
+            SigType::Alias(name) => match type_mappings.map_alias(name) {
+                Some(ConcreteType::Primitive { primitive, .. }) => {
+                    Ok(primitive.to_jni_descriptor().to_string())
+                }
+                Some(ConcreteType::Object {
+                    name: java_class, ..
+                }) => Ok(java_class.to_jni_descriptor()),
+                None => Err(syn::Error::new(
+                    Span::call_site(),
+                    format!("Unknown type '{}'", name),
+                )),
+            },
+            SigType::Object(class) => Ok(class.to_jni_descriptor()),
+            SigType::Array(elem, dims) => {
+                let elem_desc = elem.to_jni_descriptor(type_mappings)?;
+                let mut result = String::new();
+                for _ in 0..*dims {
+                    result.push('[');
+                }
+                result.push_str(&elem_desc);
+                Ok(result)
+            }
+        }
+    }
+
+    pub fn try_as_primitive(&self, type_mappings: &TypeMappings) -> Option<PrimitiveType> {
+        match self {
+            SigType::Alias(name) => match type_mappings.map_alias(name) {
+                Some(ConcreteType::Primitive { primitive, .. }) => Some(primitive),
+                _ => None,
+            },
+            _ => None,
+        }
+    }
+}
+
+/// Parse a type (can be primitive, object, rust reference, or array)
+pub fn parse_type(input: ParseStream, type_mappings: &TypeMappings) -> Result<SigType> {
+    // Check for leading reference operator (ignore it)
+    if input.peek(Token![&]) {
+        input.parse::<Token![&]>()?;
+    }
+
+    // Check for array syntax [...]
+    if input.peek(token::Bracket) {
+        let content;
+        let bracket_span = input.span();
+        syn::bracketed!(content in input);
+        let elem_type = parse_type(&content, type_mappings)?;
+
+        // Validate that the element type can be used in an array
+        validate_array_element_type(&elem_type, type_mappings, bracket_span)?;
+
+        // Count array dimensions
+        let mut dims = 1;
+        while input.peek(token::Bracket) {
+            let _content;
+            syn::bracketed!(_content in input);
+            // Nested array - increment dimensions
+            dims += 1;
+        }
+
+        return Ok(SigType::Array(Box::new(elem_type), dims));
+    }
+
+    // Check for unit type ()
+    if input.peek(token::Paren) {
+        let content;
+        parenthesized!(content in input);
+        if content.is_empty() {
+            return Ok(SigType::Alias("void".to_string()));
+        } else {
+            return Err(syn::Error::new(
+                content.span(),
+                "Expected empty parentheses for void type",
+            ));
+        }
+    }
+
+    // Try to parse as Java class name first (handles string literals, .NoPackage, and package.Class)
+    // This is done speculatively - if it fails, we'll try other interpretations
+    let base_type = if let Ok(java_class) = input.parse::<JavaClassName>() {
+        SigType::Object(java_class)
+    } else {
+        // Not a Java class name, so it must be a path-ish TypeMappings type (could be primitive lie
+        // jint/i32 or Reference like JString/jni::objects::JString)
+        let first_ident = input.parse::<Ident>()?;
+
+        let mut path_segments = vec![first_ident.to_string()];
+        while input.peek(Token![::]) {
+            input.parse::<Token![::]>()?;
+            let segment = input.parse::<Ident>()?;
+            path_segments.push(segment.to_string());
+        }
+        SigType::Alias(path_segments.join("::"))
+    };
+
+    // Check for suffix array syntax (applies to all base types)
+    let mut dims = 0;
+    let mut first_bracket_span = None;
+    while input.peek(token::Bracket) {
+        let bracket_span = input.span();
+        if first_bracket_span.is_none() {
+            first_bracket_span = Some(bracket_span);
+        }
+        let content;
+        syn::bracketed!(content in input);
+        if !content.is_empty() {
+            return Err(syn::Error::new(
+                content.span(),
+                "Expected empty brackets for array suffix syntax",
+            ));
+        }
+        dims += 1;
+    }
+
+    // If we have array dimensions, validate and wrap in Array type
+    if dims > 0 {
+        // Validate that the element type can be used in an array (void cannot)
+        validate_array_element_type(&base_type, type_mappings, first_bracket_span.unwrap())?;
+        Ok(SigType::Array(Box::new(base_type), dims))
+    } else {
+        Ok(base_type)
+    }
+}
+
+#[derive(Clone, Debug, Eq)]
+enum RustTypeTarget {
+    /// A primitive type that maps to a `jni::sys` type
+    Primitive {
+        /// Is this a standard primitive type or a user-defined mapping?
+        is_builtin: bool,
+        /// The primitive type
+        primitive: PrimitiveType,
+        /// The name or full path for the primitive type (e.g., "i32" or "jni::sys::jint")
+        ///
+        /// If the jni crate is renamed, this path will reflect the renamed crate path.
+        ///
+        /// If this represents a Rust primitive type, such as `i32`, then this will match
+        /// that type name.
+        path: String,
+    },
+    Reference {
+        /// Is this a built-in `jni` crate Reference type?
+        is_builtin: bool,
+        /// The full path for a `jni` `Reference` type (e.g., "jni::objects::JString")
+        ///
+        /// If the jni crate is renamed, this path will reflect the renamed crate path.
+        path: String,
+    },
+}
+
+// Ignore the 'is_builtin' field for equality and hashing
+
+impl PartialEq for RustTypeTarget {
+    fn eq(&self, other: &Self) -> bool {
+        match (self, other) {
+            (
+                RustTypeTarget::Primitive {
+                    primitive: p1,
+                    path: path1,
+                    ..
+                },
+                RustTypeTarget::Primitive {
+                    primitive: p2,
+                    path: path2,
+                    ..
+                },
+            ) => p1 == p2 && path1 == path2,
+            (
+                RustTypeTarget::Reference { path: path1, .. },
+                RustTypeTarget::Reference { path: path2, .. },
+            ) => path1 == path2,
+            _ => false,
+        }
+    }
+}
+impl std::hash::Hash for RustTypeTarget {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        match &self {
+            RustTypeTarget::Primitive {
+                primitive, path, ..
+            } => {
+                primitive.hash(state);
+                path.hash(state);
+            }
+            RustTypeTarget::Reference { path, .. } => {
+                path.hash(state);
+            }
+        }
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub struct RustType {
+    target: RustTypeTarget,
+}
+
+impl RustType {
+    pub fn is_builtin(&self) -> bool {
+        match self.target {
+            RustTypeTarget::Primitive { is_builtin, .. } => is_builtin,
+            RustTypeTarget::Reference { is_builtin, .. } => is_builtin,
+        }
+    }
+    pub fn path(&self) -> &str {
+        match &self.target {
+            RustTypeTarget::Primitive { path, .. } => path.as_str(),
+            RustTypeTarget::Reference { path, .. } => path.as_str(),
+        }
+    }
+}
+
+pub enum ConcreteType {
+    Primitive {
+        primitive: PrimitiveType,
+        /// The full path for the primitive type (e.g., "jni::sys::jint")
+        ///
+        /// If the jni crate is renamed, this path will reflect the renamed
+        /// crate path.
+        ///
+        /// If the lookup was done using a Rust type alias such as `i32` then
+        /// this will correspond to that alias.
+        ///
+        /// If the lookup was done using a Java type alias such as `int`, then
+        /// this will correspond to the canonical `jni::sys` type path.
+        path: String,
+        /// Whether this is a built-in primitive type mapping or a user-defined one
+        is_builtin: bool,
+    },
+    Object {
+        name: Rc<JavaClassName>,
+        reference_type: Rc<RustType>,
+    },
+}
+
+/// Type mappings from Rust Reference types to Java class names and aliases for
+/// primitive types
+///
+/// Firstly, the type mappings start with a set of N:1 mapping from Rust type
+/// aliases to RustTypes that either represent a `Primitive` type or a
+/// `Reference` type.
+///
+/// E.g. `"jint"` => `{ Primitive(Int), jni::sys::jint }`, `"i32"` => `{
+///     Primitive(Int), i32 }`, `"JString"` =>
+///     `Reference("jni::objects::JString")`
+///
+/// ## Reference Types
+///
+///   A Reference type is represented by a full Rust type path (e.g.,
+///   "jni::objects::JString") (such as "JString" => "jni::objects::JString")
+///
+///   Additionally, for the Reference types there are also:
+///
+/// - A N:1 mapping from canonical Rust type paths to Java class names (such as
+///   "jni::objects::JString" => "java.lang.String")
+///
+///   Note: that multiple Rust type paths can map to the same Java class name,
+///   such as if a third-party crate provides it's own bindings for a java.lang
+///   type that has a built-in binding in the jni crate. (like
+///   JList/java.util.List)
+///
+///   Note: As a restriction, certain "core" java.lang classes cannot be
+///   remapped, including java.lang.Object, java.lang.Class, java.lang.String,
+///   java.lang.Throwable.
+///
+/// - A 1:1 mapping from Java class names to canonical Rust type paths (such as
+///   "java.lang.String" => "jni::objects::JString")
+///
+///   Note: When there are multiple Rust type paths that map to the same Java
+///   class name, then the most-recently added mapping takes precedence in the
+///   reverse lookup so that built-in (non-core) types can be overridden by
+///   user-defined types.
+///
+/// ## Primitive Types
+///
+/// A primitive type is represented by the `PrimitiveType` enum, and a full path
+/// to the `jni::sys` primitive type (e.g., "jni::sys::jint") or the name of an
+/// equivalent Rust primitive type (e.g., "i32").
+///
+/// Each JNI primitive typically has two primitive RustTypes:
+/// - The `jni::sys` type (e.g., "jni::sys::jint")
+/// - The Rust primitive type (e.g., "i32")
+///
+/// and then one alias for the Java type name (e.g., "int") that points to the
+/// `jni::sys` type.
+///
+/// A `type_map` may add additional aliases for primitive types,
+///
+/// There are no other mappings for primitive types beyond the alias -> RustType
+pub struct TypeMappings {
+    /// Maps Rust type names to canonical Rust type paths
+    ///
+    /// For example, built-in types have multiple aliases, so signatures can
+    /// use types like "JString" or "jni::objects::JString" for the same type.
+    ///
+    /// Note: Even if the jni crate is renamed, the full-path alias for built-in
+    /// types will still have a `jni::` prefix, and it's only the
+    /// `RustType::path` that will have the renamed crate path.
+    alias_to_rust: std::collections::HashMap<String, Rc<RustType>>,
+    /// Maps `RustType::path`s to Java class names
+    ///
+    /// Only includes the canonical Rust type paths, so make sure to resolve
+    /// aliases like "JString" before looking up in this map.
+    rust_to_java: std::collections::HashMap<Rc<RustType>, Rc<JavaClassName>>,
+    /// Reverse mapping from Java class names to the canonical RustType path
+    java_to_rust: std::collections::HashMap<Rc<JavaClassName>, Rc<RustType>>,
+    /// Set of core Java types that can not be mapped to non-jni-crate types
+    ///
+    /// Although some types, like java.util.List, can be remapped to third-party
+    /// bindings, we don't allow alternative mappings for core java.lang types
+    /// like java.lang.Object, java.lang.Class, java.lang.String.
+    ///
+    /// In addition to the types listed here, we also consider any array type
+    /// (any descriptor that starts with '[') to be a core type that cannot be
+    /// remapped.
+    core_java: std::collections::HashSet<Rc<JavaClassName>>,
+    /// The path to the jni crate (e.g., `jni` or `::jni` or `crate::jni`)
+    jni_crate: syn::Path,
+}
+
+impl TypeMappings {
+    /// Create a new TypeMappings with default JNI type mappings
+    ///
+    /// # Arguments
+    /// * `jni_crate` - The path to the jni crate (e.g., `jni` or `::jni` or `crate::jni`)
+    pub fn new(jni_crate: &syn::Path) -> Self {
+        let mut type_mappings = Self {
+            alias_to_rust: std::collections::HashMap::new(),
+            rust_to_java: std::collections::HashMap::new(),
+            java_to_rust: std::collections::HashMap::new(),
+            core_java: std::collections::HashSet::new(),
+            jni_crate: jni_crate.clone(),
+        };
+
+        // Helper function to parse a Java class name from a dotted string
+        let parse_java_class_dotted = |class_str: &str| -> JavaClassName {
+            let parts: Vec<&str> = class_str.split('.').collect();
+            if parts.is_empty() {
+                panic!("Invalid Java class name: {}", class_str);
+            }
+
+            let class = parts.last().unwrap().to_string();
+            let package = parts[..parts.len() - 1]
+                .iter()
+                .map(|s| s.to_string())
+                .collect();
+
+            JavaClassName { package, class }
+        };
+
+        // Convert the jni crate path to a string
+        let jni_crate_str = path_to_string_no_spaces(jni_crate);
+
+        // Add default type mappings for built-in jni crate types
+        let builtins = [
+            (
+                "JByteBuffer",
+                "java.nio.ByteBuffer",
+                "objects::JByteBuffer",
+                false,
+            ),
+            (
+                "JClassLoader",
+                "java.lang.ClassLoader",
+                "objects::JClassLoader",
+                false,
+            ),
+            ("JClass", "java.lang.Class", "objects::JClass", true),
+            (
+                "JCollection",
+                "java.util.Collection",
+                "objects::JCollection",
+                false,
+            ),
+            (
+                "JIterator",
+                "java.util.Iterator",
+                "objects::JIterator",
+                false,
+            ),
+            ("JList", "java.util.List", "objects::JList", false),
+            ("JMap", "java.util.Map", "objects::JMap", false),
+            (
+                "JMapEntry",
+                "java.util.Map$Entry",
+                "objects::JMapEntry",
+                false,
+            ),
+            ("JObject", "java.lang.Object", "objects::JObject", true),
+            ("JSet", "java.util.Set", "objects::JSet", false),
+            (
+                "JStackTraceElement",
+                "java.lang.StackTraceElement",
+                "objects::JStackTraceElement",
+                false,
+            ),
+            ("JString", "java.lang.String", "objects::JString", true),
+            ("JThread", "java.lang.Thread", "objects::JThread", false),
+            (
+                "JThrowable",
+                "java.lang.Throwable",
+                "objects::JThrowable",
+                true,
+            ),
+        ];
+
+        for (simple_name, java_class_str, module_path, is_core) in builtins {
+            let java_class = Rc::new(parse_java_class_dotted(java_class_str));
+
+            let jni_full_path = format!("jni::{}", module_path);
+            let real_full_path = format!("{}::{}", jni_crate_str, module_path);
+
+            type_mappings
+                .insert_ref_type(&jni_full_path, &real_full_path, (*java_class).clone(), true)
+                .expect("Failed to insert built-in jni crate type mapping");
+            type_mappings
+                .insert_alias(simple_name, &jni_full_path)
+                .expect("Failed to insert built-in jni crate type alias");
+            if is_core {
+                type_mappings.core_java.insert(java_class.clone());
+            }
+        }
+
+        // Insert Void as a special case
+        type_mappings
+            .insert_prim_type("void", PrimitiveType::Void, "()", true)
+            .expect("Failed to insert 'void' primitive type mapping");
+
+        let jni_sys_prim_types = [
+            ("jboolean", "sys::jboolean", PrimitiveType::Boolean),
+            ("jbyte", "sys::jbyte", PrimitiveType::Byte),
+            ("jchar", "sys::jchar", PrimitiveType::Char),
+            ("jshort", "sys::jshort", PrimitiveType::Short),
+            ("jint", "sys::jint", PrimitiveType::Int),
+            ("jlong", "sys::jlong", PrimitiveType::Long),
+            ("jfloat", "sys::jfloat", PrimitiveType::Float),
+            ("jdouble", "sys::jdouble", PrimitiveType::Double),
+        ];
+
+        for (rust_name, path, prim_type) in jni_sys_prim_types {
+            let full_path = format!("{}::{}", jni_crate_str, path);
+            type_mappings
+                .insert_prim_type(rust_name, prim_type, &full_path, true)
+                .expect("Failed to insert jni::sys primitive type mapping");
+        }
+
+        let rust_prim_types = [
+            ("bool", PrimitiveType::Boolean),
+            ("i8", PrimitiveType::Byte),
+            ("i16", PrimitiveType::Short),
+            ("i32", PrimitiveType::Int),
+            ("i64", PrimitiveType::Long),
+            ("f32", PrimitiveType::Float),
+            ("f64", PrimitiveType::Double),
+        ];
+
+        for (rust_name, prim_type) in rust_prim_types {
+            type_mappings
+                .insert_prim_type(rust_name, prim_type, rust_name, true)
+                .expect("Failed to insert Rust primitive type mapping");
+        }
+
+        let prim_aliases = [
+            ("boolean", "jboolean"),
+            ("byte", "jbyte"),
+            ("char", "jchar"),
+            ("short", "jshort"),
+            ("int", "jint"),
+            ("long", "jlong"),
+            ("float", "jfloat"),
+            ("double", "jdouble"),
+        ];
+
+        for (alias, target) in prim_aliases {
+            type_mappings
+                .insert_alias(alias, target)
+                .expect("Failed to insert primitive type alias");
+        }
+
+        type_mappings
+    }
+
+    /// Insert a mapping from a Rust `Reference` type path to a Java class
+    ///
+    /// If there is already a a Rust type mapping to the same Java class, the reverse
+    /// mapping from Java class to Rust type path will be updated to point to the new
+    /// Rust type path (so that user-defined types can override built-in types).
+    ///
+    /// Note:
+    /// - User code cannot create mappings for core Java classes.
+    /// - User code cannot _change_ the mapping for an existing Rust type path.
+    /// - User code cannot currently create multiple alias for a single Rust type path.
+    ///
+    /// Returns an error if:
+    /// - Attempting to map a core Java class
+    /// - Attempting to change the mapping for an existing Rust type path
+    pub fn insert_ref_type(
+        &mut self,
+        alias: &str,
+        path: &str,
+        java_class: JavaClassName,
+        is_builtin: bool,
+    ) -> Result<()> {
+        let java_class = if let Some((java_class, _)) = self.java_to_rust.get_key_value(&java_class)
+        {
+            java_class.clone()
+        } else {
+            Rc::new(java_class)
+        };
+
+        // Check if this is a core Java class that cannot be remapped
+        if self.core_java.contains(&java_class) {
+            return Err(syn::Error::new(
+                Span::call_site(),
+                format!(
+                    "Cannot create type mapping for '{}' -> '{}': '{}' is a core Java type. Core types (java.lang.Object, java.lang.Class, java.lang.Throwable and java.lang.String) are automatically mapped to jni crate types and cannot be remapped.",
+                    path,
+                    java_class.to_java_dotted(),
+                    java_class.to_java_dotted()
+                ),
+            ));
+        }
+
+        let rust_type = Rc::new(RustType {
+            target: RustTypeTarget::Reference {
+                path: path.to_string(),
+                is_builtin,
+            },
+        });
+
+        // Check if this alias already has a mapping to a different Rust type
+        if let Some(existing) = self.alias_to_rust.get(alias) {
+            if existing != &rust_type {
+                let existing_java_mapping = self.rust_to_java.get(existing).unwrap();
+                return Err(syn::Error::new(
+                    Span::call_site(),
+                    format!(
+                        "Cannot change existing Rust type mapping for Rust type name '{alias}': already mapped to Java class '{}'/'{}', cannot remap to '{}'/'{}'. Only one mapping per Rust type path is allowed.",
+                        existing_java_mapping.to_java_dotted(),
+                        existing.path(),
+                        java_class.to_java_dotted(),
+                        path
+                    ),
+                ));
+            }
+
+            return Ok(());
+        }
+
+        self.alias_to_rust
+            .insert(alias.to_string(), rust_type.clone());
+
+        // Insert the mappings
+        self.rust_to_java
+            .insert(rust_type.clone(), java_class.clone());
+        self.java_to_rust.insert(java_class, rust_type);
+
+        Ok(())
+    }
+
+    pub fn insert_prim_type(
+        &mut self,
+        alias: &str,
+        primitive: PrimitiveType,
+        path: &str,
+        is_builtin: bool,
+    ) -> Result<()> {
+        let rust_type = Rc::new(RustType {
+            target: RustTypeTarget::Primitive {
+                primitive,
+                path: path.to_string(),
+                is_builtin,
+            },
+        });
+
+        if let Some(existing) = self.alias_to_rust.get(alias) {
+            if existing != &rust_type {
+                return Err(syn::Error::new(
+                    Span::call_site(),
+                    format!(
+                        "Cannot change existing Rust type mapping for Rust type name '{}': already mapped to a different primitive type. Only one mapping per Rust type name is allowed.",
+                        alias
+                    ),
+                ));
+            }
+            return Ok(());
+        }
+
+        self.alias_to_rust
+            .insert(alias.to_string(), rust_type.clone());
+
+        Ok(())
+    }
+
+    pub fn insert_alias(&mut self, from: &str, to: &str) -> Result<()> {
+        if let Some(rust_type) = self.alias_to_rust.get(to) {
+            if let Some(existing) = self.alias_to_rust.get(from) {
+                if existing != rust_type {
+                    return Err(syn::Error::new(
+                        Span::call_site(),
+                        format!(
+                            "Cannot change mapping for typealias '{}' to '{}': already mapped to a different type ({}). Only one mapping per Rust type name is allowed.",
+                            from,
+                            to,
+                            existing.path()
+                        ),
+                    ));
+                }
+                return Ok(());
+            }
+
+            self.alias_to_rust
+                .insert(from.to_string(), rust_type.clone());
+            Ok(())
+        } else {
+            Err(syn::Error::new(
+                Span::call_site(),
+                format!(
+                    "Cannot create alias from '{}' to '{}': target type not found",
+                    from, to
+                ),
+            ))
+        }
+    }
+
+    /// Parse `type_map` block with Reference + primitive mappings and aliases
+    ///
+    /// This is a shared parser used by both bind_java_type! and jni_sig! macros. Parses a
+    /// braced block containing type mappings from Rust type paths to Java class names.
+    ///
+    /// # Syntax
+    ///
+    /// A type_map block can be comprised of:
+    /// - Reference type mappings
+    /// - Primitive type mappings (unsafe)
+    /// - Type aliases
+    ///
+    /// In all cases:
+    /// - The type separator is `=>`
+    /// - Mappings are separated by commas
+    /// - Trailing comma is optional
+    ///
+    /// ## Reference Type Mappings
+    ///
+    /// Each Reference type mapping has the form: `RustPath => java.lang.Class`
+    /// - RustPath can be a simple identifier (e.g., `JString`) or a path (e.g.,
+    ///   `jni::objects::JString`)
+    ///
+    /// ## Primitive Type Mappings
+    ///
+    /// Primitive type mappings are considered `unsafe`, but can be especially useful for mapping
+    /// wrapped pointers types to a Java `long` type (e.g. to associate native handles with Java
+    /// objects).
+    ///
+    /// Each Primitive type mapping has the form: `unsafe RustPrimitive => java_primitive`
+    ///
+    /// ## Aliases
+    ///
+    /// Type aliases allow you to create a new name for an existing type mapping. This can be useful
+    /// for making signatures more readable (e.g. before you have a defined a real type binding).
+    ///
+    /// An alias mapping has the form: `alias NewTypeName => ExistingTypeName`
+    ///
+    /// Aliases for array types are not supported.
+    ///
+    /// # Example
+    /// ```ignore
+    /// type_map = {
+    ///     MyType => java.lang.MyType,
+    ///     custom::MyOtherType => com.example.MyOtherType,
+    ///     unsafe MyBoxHandle => long,
+    ///     typealias MyTypeAlias => MyType,
+    ///     typealias MyOtherTypeAlias => JObject,
+    /// }
+    /// ```
+    pub fn parse_mappings(&mut self, input: ParseStream) -> Result<()> {
+        // Optional '=' before block
+        if input.peek(Token![=]) {
+            input.parse::<Token![=]>()?;
+        }
+
+        let mappings_content;
+        braced!(mappings_content in input);
+
+        while !mappings_content.is_empty() {
+            if mappings_content.peek(typealias) {
+                // Parse alias mapping
+                mappings_content.parse::<typealias>()?;
+
+                // Parse new alias name
+                let new_alias: syn::Path = mappings_content.parse()?;
+
+                // Parse separator
+                mappings_content.parse::<Token![=>]>()?;
+
+                // Parse existing type name
+                let existing_type: syn::Path = mappings_content.parse()?;
+
+                // Insert alias
+                let new_alias_str = path_to_string_no_spaces(&new_alias);
+                let existing_type_str = path_to_string_no_spaces(&existing_type);
+                self.insert_alias(&new_alias_str, &existing_type_str)?;
+
+                // Require comma between entries, but trailing comma is optional
+                if !mappings_content.is_empty() {
+                    mappings_content.parse::<Token![,]>()?;
+                }
+            } else {
+                let is_prim_mapping = if mappings_content.peek(Token![unsafe]) {
+                    mappings_content.parse::<Token![unsafe]>()?;
+                    true
+                } else {
+                    false
+                };
+
+                // Parse Rust path
+                let rust_path: syn::Path = mappings_content.parse()?;
+
+                // Convert path to string without spaces
+                let rust_path_str = path_to_string_no_spaces(&rust_path);
+
+                // Parse separator
+                mappings_content.parse::<Token![=>]>()?;
+
+                if is_prim_mapping {
+                    // Parse primitive type name
+                    let prim_type_ident: Ident = mappings_content.parse()?;
+                    let prim_type_name = prim_type_ident.to_string();
+
+                    // Validate type name by checking that it's a "built-in" primitive type name
+                    match self.map_alias(&prim_type_name) {
+                        Some(ConcreteType::Primitive {
+                            primitive,
+                            is_builtin,
+                            ..
+                        }) if is_builtin => {
+                            self.insert_prim_type(
+                                &rust_path_str,
+                                primitive,
+                                &rust_path_str,
+                                false,
+                            )?;
+                        }
+                        _ => {
+                            return Err(syn::Error::new(
+                                prim_type_ident.span(),
+                                format!(
+                                    "Invalid primitive type name '{}' for unsafe primitive mapping. Must be one of the built-in primitive type names (e.g., 'int', 'long', 'boolean', etc.)",
+                                    prim_type_name
+                                ),
+                            ));
+                        }
+                    }
+                } else {
+                    // Parse Java class name
+                    let java_class_mapping: JavaClassName = mappings_content.parse()?;
+
+                    // Insert mapping
+                    self.insert_ref_type(
+                        &rust_path_str,
+                        &rust_path_str,
+                        java_class_mapping,
+                        false,
+                    )?;
+                }
+
+                // Require comma between entries, but trailing comma is optional
+                if !mappings_content.is_empty() {
+                    mappings_content.parse::<Token![,]>()?;
+                }
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Get the Java class name and canonical Rust type for a Rust type alias
+    pub fn map_alias(&self, alias: &str) -> Option<ConcreteType> {
+        if let Some(rust_type) = self.alias_to_rust.get(alias) {
+            match &rust_type.target {
+                RustTypeTarget::Primitive {
+                    primitive,
+                    path,
+                    is_builtin,
+                } => Some(ConcreteType::Primitive {
+                    primitive: primitive.clone(),
+                    path: path.clone(),
+                    is_builtin: *is_builtin,
+                }),
+                RustTypeTarget::Reference { .. } => {
+                    let java_class = self.rust_to_java.get(rust_type).expect(
+                        "TypeMappings invariant violated: rust_type missing in rust_to_java map",
+                    );
+                    Some(ConcreteType::Object {
+                        name: java_class.clone(),
+                        reference_type: rust_type.clone(),
+                    })
+                }
+            }
+        } else {
+            None
+        }
+    }
+
+    /// Get the canonical Rust type path for a Java class name
+    pub fn map_java_class_to_rust_type(&self, java_class: &JavaClassName) -> Option<&RustType> {
+        self.java_to_rust.get(java_class).map(|s| s.as_ref())
+    }
+
+    /// Get an iterator over all Java class names
+    #[allow(unused)]
+    pub fn java_classes(&self) -> impl Iterator<Item = &Rc<JavaClassName>> {
+        self.java_to_rust.keys()
+    }
+
+    /// Get an iterator over rust_path -> java_class mappings
+    pub fn rust_to_java_iter(&self) -> impl Iterator<Item = (&Rc<RustType>, &Rc<JavaClassName>)> {
+        self.rust_to_java.iter()
+    }
+
+    /// Get the jni crate path
+    pub fn jni_crate(&self) -> &syn::Path {
+        &self.jni_crate
+    }
+
+    /// Check if a Java class is a core type that cannot normally be bound
+    pub fn is_core_java_type(&self, java_class: &JavaClassName) -> bool {
+        self.core_java.contains(java_class)
+    }
+}
+
+/// Helper function to validate that a type can be used as an array element
+/// Returns an error if the element type is void
+fn validate_array_element_type(
+    elem_type: &SigType,
+    type_mappings: &TypeMappings,
+    span: Span,
+) -> Result<()> {
+    if let SigType::Alias(name) = elem_type {
+        match type_mappings.map_alias(name) {
+            Some(ConcreteType::Primitive {
+                primitive: PrimitiveType::Void,
+                ..
+            }) => {
+                return Err(syn::Error::new(
+                    span,
+                    "void cannot be used as an array element type",
+                ));
+            }
+            Some(_) => {}
+            None => {
+                return Err(syn::Error::new(span, format!("Unknown type '{}'", name)));
+            }
+        }
+    }
+
+    Ok(())
+}
+
+/// Core function to convert a JavaType to a concrete Rust type with lifetime
+/// Returns the type WITHOUT any AsRef wrapper
+pub fn sig_type_to_rust_type_core(
+    java_type: &SigType,
+    lifetime: &TokenStream,
+    type_mappings: &TypeMappings,
+    jni: &syn::Path,
+) -> TokenStream {
+    match java_type {
+        SigType::Alias(alias) => match type_mappings.map_alias(alias) {
+            Some(ConcreteType::Primitive {
+                primitive, path, ..
+            }) => {
+                if let PrimitiveType::Void = primitive {
+                    quote! { () }
+                } else {
+                    let path: syn::Path = syn::parse_str(&path)
+                        .unwrap_or_else(|_| panic!("Invalid Rust type path: {}", path));
+
+                    quote! { #path  }
+                }
+            }
+            Some(ConcreteType::Object {
+                reference_type: rust_type,
+                ..
+            }) => {
+                let path_str = rust_type.path();
+
+                let path: syn::Path = syn::parse_str(path_str)
+                    .unwrap_or_else(|_| panic!("Invalid Rust type path: {}", path_str));
+
+                quote! { #path<#lifetime> }
+            }
+            None => {
+                // Should have been validated while parsing
+                unreachable!("Unknown type: {}", alias);
+            }
+        },
+        SigType::Object(class_name) => {
+            // Check if there's a type mapping for this Java class
+            if let Some(rust_type) = type_mappings.map_java_class_to_rust_type(class_name) {
+                // Parse the rust path and generate the type
+                let path_str = rust_type.path();
+                let path: syn::Path = syn::parse_str(path_str)
+                    .unwrap_or_else(|_| panic!("Invalid Rust type path: {}", path_str));
+                quote! { #path<#lifetime> }
+            } else {
+                // Use JObject for unmapped class types
+                quote! { #jni::objects::JObject<#lifetime> }
+            }
+        }
+        SigType::Array(element_type, dimensions) => {
+            // First, resolve the innermost array dimension (the actual array of elements)
+            // This will be either:
+            // - JPrimitiveArray<prim_type> for primitive arrays
+            // - JObjectArray<RustType> for arrays of mapped types
+            // - JObjectArray (defaulting to JObjectArray<JObject>) for unmapped object arrays
+            let innermost_array = match &**element_type {
+                SigType::Alias(alias) => {
+                    match type_mappings.map_alias(alias) {
+                        Some(ConcreteType::Primitive { primitive, .. }) => {
+                            let prim_ident = match primitive {
+                                PrimitiveType::Void => {
+                                    // This should be unreachable since void array elements are rejected during parsing
+                                    unreachable!("void cannot be used as an array element type")
+                                }
+                                PrimitiveType::Boolean => quote! { jboolean },
+                                PrimitiveType::Byte => quote! { jbyte },
+                                PrimitiveType::Char => quote! { jchar },
+                                PrimitiveType::Short => quote! { jshort },
+                                PrimitiveType::Int => quote! { jint },
+                                PrimitiveType::Long => quote! { jlong },
+                                PrimitiveType::Float => quote! { jfloat },
+                                PrimitiveType::Double => quote! { jdouble },
+                            };
+                            quote! { #jni::objects::JPrimitiveArray<#lifetime, #jni::sys::#prim_ident> }
+                        }
+                        Some(ConcreteType::Object {
+                            reference_type: rust_type,
+                            ..
+                        }) => {
+                            let path_str = rust_type.path();
+                            let path: syn::Path = syn::parse_str(path_str)
+                                .unwrap_or_else(|_| panic!("Invalid Rust type path: {}", path_str));
+                            quote! { #jni::objects::JObjectArray<#lifetime, #path<#lifetime>> }
+                        }
+                        None => {
+                            // Should have been validated while parsing
+                            unreachable!("Unknown type: {}", alias);
+                        }
+                    }
+                }
+                SigType::Object(class_name) => {
+                    // Check for type mapping for array element type
+                    if let Some(rust_type) = type_mappings.map_java_class_to_rust_type(class_name) {
+                        let path_str = rust_type.path();
+                        let path: syn::Path = syn::parse_str(path_str)
+                            .unwrap_or_else(|_| panic!("Invalid Rust type path: {}", path_str));
+                        quote! { #jni::objects::JObjectArray<#lifetime, #path<#lifetime>> }
+                    } else {
+                        // Object array with unmapped type
+                        quote! { #jni::objects::JObjectArray<#lifetime> }
+                    }
+                }
+                SigType::Array(_inner_element_type, _dimensions) => {
+                    // An array of arrays should be represented via `Array(_, dimensions > 1)`, not by nesting
+                    // ArgType::Array as the element type.
+                    unreachable!(
+                        "Multi-dimensional arrays should not be represented by nesting ArgType::Array"
+                    )
+                }
+            };
+
+            // Now wrap with JObjectArray for each additional dimension beyond the first
+            let mut result = innermost_array;
+            for _ in 0..(*dimensions - 1) {
+                result = quote! { #jni::objects::JObjectArray<#lifetime, #result> };
+            }
+            result
+        }
+    }
+}

--- a/jni-macros/tests/signature.rs
+++ b/jni-macros/tests/signature.rs
@@ -1,0 +1,1014 @@
+use jni::signature::{JavaType, Primitive};
+use jni_macros::jni_sig;
+
+#[test]
+fn test_primitive_types() {
+    let sig = jni_sig!((a: jint, b: jboolean) -> void);
+
+    assert_eq!(sig.sig().to_bytes(), b"(IZ)V");
+    assert_eq!(sig.args().len(), 2);
+    assert_eq!(sig.args()[0], JavaType::Primitive(Primitive::Int));
+    assert_eq!(sig.args()[1], JavaType::Primitive(Primitive::Boolean));
+    assert_eq!(sig.ret(), JavaType::Primitive(Primitive::Void));
+}
+
+#[test]
+fn test_java_object_types() {
+    let sig = jni_sig!((a: jint, b: java.lang.String) -> java.lang.Object);
+
+    assert_eq!(
+        sig.sig().to_bytes(),
+        b"(ILjava/lang/String;)Ljava/lang/Object;"
+    );
+    assert_eq!(sig.args().len(), 2);
+    assert_eq!(sig.args()[0], JavaType::Primitive(Primitive::Int));
+    assert_eq!(sig.args()[1], JavaType::Object);
+    assert_eq!(sig.ret(), JavaType::Object);
+}
+
+#[test]
+fn test_array_types() {
+    let sig = jni_sig!((a: [jint], b: [java.lang.String]) -> [[jint]]);
+
+    assert_eq!(sig.sig().to_bytes(), b"([I[Ljava/lang/String;)[[I");
+    assert_eq!(sig.args().len(), 2);
+    assert_eq!(sig.args()[0], JavaType::Array);
+    assert_eq!(sig.args()[1], JavaType::Array);
+    assert_eq!(sig.ret(), JavaType::Array);
+}
+
+#[test]
+fn test_suffix_array_syntax() {
+    let sig = jni_sig!((a: jint[], b: java.lang.String[][]) -> void);
+
+    assert_eq!(sig.sig().to_bytes(), b"([I[[Ljava/lang/String;)V");
+    assert_eq!(sig.args().len(), 2);
+    assert_eq!(sig.args()[0], JavaType::Array);
+    assert_eq!(sig.args()[1], JavaType::Array);
+    assert_eq!(sig.ret(), JavaType::Primitive(Primitive::Void));
+}
+
+#[test]
+fn test_type_mappings() {
+    let sig = jni_sig!(
+        type_map = {
+            RustType0 => java.lang.Type0,
+            RustType1 => java.lang.Type1,
+            RustType2 => java.lang.Type2,
+        },
+        (a: jint, b: RustType0, c: [RustType1], d: JString) -> RustType2,
+    );
+
+    assert_eq!(
+        sig.sig().to_bytes(),
+        b"(ILjava/lang/Type0;[Ljava/lang/Type1;Ljava/lang/String;)Ljava/lang/Type2;"
+    );
+    assert_eq!(sig.args().len(), 4);
+    assert_eq!(sig.args()[0], JavaType::Primitive(Primitive::Int));
+    assert_eq!(sig.args()[1], JavaType::Object);
+    assert_eq!(sig.args()[2], JavaType::Array);
+    assert_eq!(sig.args()[3], JavaType::Object);
+    assert_eq!(sig.ret(), JavaType::Object);
+}
+
+#[test]
+fn test_trailing_comma_no_type_map() {
+    let sig = jni_sig!((a: jint, b: jboolean) -> void,);
+
+    assert_eq!(sig.sig().to_bytes(), b"(IZ)V");
+    assert_eq!(sig.args().len(), 2);
+    assert_eq!(sig.args()[0], JavaType::Primitive(Primitive::Int));
+    assert_eq!(sig.args()[1], JavaType::Primitive(Primitive::Boolean));
+    assert_eq!(sig.ret(), JavaType::Primitive(Primitive::Void));
+}
+
+#[test]
+fn test_trailing_comma_with_type_map() {
+    let sig = jni_sig!(
+        (a: RustType) -> void,
+        type_map = {
+            RustType => java.lang.Type,
+        },
+    );
+
+    assert_eq!(sig.sig().to_bytes(), b"(Ljava/lang/Type;)V");
+    assert_eq!(sig.args().len(), 1);
+    assert_eq!(sig.args()[0], JavaType::Object);
+    assert_eq!(sig.ret(), JavaType::Primitive(Primitive::Void));
+}
+
+#[test]
+fn test_inner_classes() {
+    let sig = jni_sig!((a: java.lang.Outer::Inner) -> void);
+
+    assert_eq!(sig.sig().to_bytes(), b"(Ljava/lang/Outer$Inner;)V");
+    assert_eq!(sig.args().len(), 1);
+    assert_eq!(sig.args()[0], JavaType::Object);
+    assert_eq!(sig.ret(), JavaType::Primitive(Primitive::Void));
+}
+
+#[test]
+fn test_default_package() {
+    let sig = jni_sig!((a: .NoPackage) -> void);
+
+    assert_eq!(sig.sig().to_bytes(), b"(LNoPackage;)V");
+    assert_eq!(sig.args().len(), 1);
+    assert_eq!(sig.args()[0], JavaType::Object);
+    assert_eq!(sig.ret(), JavaType::Primitive(Primitive::Void));
+}
+
+#[test]
+fn test_primitive_aliases() {
+    let sig = jni_sig!((a: i32, b: bool, c: f64) -> i64);
+
+    assert_eq!(sig.sig().to_bytes(), b"(IZD)J");
+    assert_eq!(sig.args().len(), 3);
+    assert_eq!(sig.args()[0], JavaType::Primitive(Primitive::Int));
+    assert_eq!(sig.args()[1], JavaType::Primitive(Primitive::Boolean));
+    assert_eq!(sig.args()[2], JavaType::Primitive(Primitive::Double));
+    assert_eq!(sig.ret(), JavaType::Primitive(Primitive::Long));
+}
+
+#[test]
+fn test_builtin_rust_string_type() {
+    let sig = jni_sig!((a: JString) -> void);
+
+    assert_eq!(sig.sig().to_bytes(), b"(Ljava/lang/String;)V");
+    assert_eq!(sig.args().len(), 1);
+    assert_eq!(sig.args()[0], JavaType::Object);
+    assert_eq!(sig.ret(), JavaType::Primitive(Primitive::Void));
+}
+
+#[test]
+fn test_empty_args() {
+    let sig = jni_sig!(() -> jint);
+
+    assert_eq!(sig.sig().to_bytes(), b"()I");
+    assert_eq!(sig.args().len(), 0);
+    assert_eq!(sig.ret(), JavaType::Primitive(Primitive::Int));
+}
+
+#[test]
+fn test_mixed_builtin_rust_types() {
+    let sig = jni_sig!((a: jint, b: JString, c: [java.lang.Object], d: JThrowable) -> void);
+
+    assert_eq!(
+        sig.sig().to_bytes(),
+        b"(ILjava/lang/String;[Ljava/lang/Object;Ljava/lang/Throwable;)V"
+    );
+    assert_eq!(sig.args().len(), 4);
+    assert_eq!(sig.args()[0], JavaType::Primitive(Primitive::Int));
+    assert_eq!(sig.args()[1], JavaType::Object);
+    assert_eq!(sig.args()[2], JavaType::Array);
+    assert_eq!(sig.args()[3], JavaType::Object);
+    assert_eq!(sig.ret(), JavaType::Primitive(Primitive::Void));
+}
+
+// Field signature tests
+
+#[test]
+fn test_field_primitive() {
+    let sig = jni_sig!(jint);
+
+    assert_eq!(sig.sig().to_bytes(), b"I");
+    assert_eq!(sig.ty(), JavaType::Primitive(Primitive::Int));
+}
+
+#[test]
+fn test_field_object() {
+    let sig = jni_sig!(java.lang.String);
+
+    assert_eq!(sig.sig().to_bytes(), b"Ljava/lang/String;");
+    assert_eq!(sig.ty(), JavaType::Object);
+}
+
+#[test]
+fn test_field_array() {
+    let sig = jni_sig!([jint]);
+
+    assert_eq!(sig.sig().to_bytes(), b"[I");
+    assert_eq!(sig.ty(), JavaType::Array);
+}
+
+#[test]
+fn test_field_array_suffix() {
+    let sig = jni_sig!(java.lang.String[]);
+
+    assert_eq!(sig.sig().to_bytes(), b"[Ljava/lang/String;");
+    assert_eq!(sig.ty(), JavaType::Array);
+}
+
+#[test]
+fn test_field_with_type_mapping() {
+    let sig = jni_sig!(
+        RustType,
+        type_map = {
+            RustType => java.lang.Type,
+        }
+    );
+
+    assert_eq!(sig.sig().to_bytes(), b"Ljava/lang/Type;");
+    assert_eq!(sig.ty(), JavaType::Object);
+}
+
+#[test]
+fn test_field_2d_array() {
+    let sig = jni_sig!([[jint]]);
+
+    assert_eq!(sig.sig().to_bytes(), b"[[I");
+    assert_eq!(sig.ty(), JavaType::Array);
+}
+
+#[test]
+fn test_field_inner_class() {
+    let sig = jni_sig!(java.lang.Outer::Inner);
+
+    assert_eq!(sig.sig().to_bytes(), b"Ljava/lang/Outer$Inner;");
+    assert_eq!(sig.ty(), JavaType::Object);
+}
+
+#[test]
+fn test_field_default_package() {
+    let sig = jni_sig!(.NoPackage);
+
+    assert_eq!(sig.sig().to_bytes(), b"LNoPackage;");
+    assert_eq!(sig.ty(), JavaType::Object);
+}
+
+#[test]
+fn test_multiple_inner_classes() {
+    let sig = jni_sig!((a: java.lang.Outer::Inner::Nested) -> void);
+
+    assert_eq!(sig.sig().to_bytes(), b"(Ljava/lang/Outer$Inner$Nested;)V");
+    assert_eq!(sig.args().len(), 1);
+    assert_eq!(sig.args()[0], JavaType::Object);
+}
+
+#[test]
+fn test_inner_class_field() {
+    let sig = jni_sig!(java.lang.Thread::State);
+
+    assert_eq!(sig.sig().to_bytes(), b"Ljava/lang/Thread$State;");
+    assert_eq!(sig.ty(), JavaType::Object);
+}
+
+#[test]
+fn test_default_package_with_inner_class() {
+    let sig = jni_sig!(.OuterClass::InnerClass);
+
+    assert_eq!(sig.sig().to_bytes(), b"LOuterClass$InnerClass;");
+    assert_eq!(sig.ty(), JavaType::Object);
+}
+
+#[test]
+fn test_array_of_inner_classes() {
+    let sig = jni_sig!([java.lang.Thread::State]);
+
+    assert_eq!(sig.sig().to_bytes(), b"[Ljava/lang/Thread$State;");
+    assert_eq!(sig.ty(), JavaType::Array);
+}
+
+#[test]
+fn test_inner_class_array_suffix() {
+    let sig = jni_sig!(java.lang.Outer::Inner[][]);
+
+    assert_eq!(sig.sig().to_bytes(), b"[[Ljava/lang/Outer$Inner;");
+    assert_eq!(sig.ty(), JavaType::Array);
+}
+
+#[test]
+fn test_deeply_nested_inner_classes() {
+    let sig = jni_sig!(com.example.Outer::Middle::Inner::Deep);
+
+    assert_eq!(
+        sig.sig().to_bytes(),
+        b"Lcom/example/Outer$Middle$Inner$Deep;"
+    );
+    assert_eq!(sig.ty(), JavaType::Object);
+}
+
+#[test]
+fn test_default_package_class_explicit() {
+    let sig = jni_sig!((arg: .DefaultPackageClass) -> void);
+
+    assert_eq!(sig.sig().to_bytes(), b"(LDefaultPackageClass;)V");
+    assert_eq!(sig.args().len(), 1);
+    assert_eq!(sig.args()[0], JavaType::Object);
+}
+
+#[test]
+fn test_default_package_nested_inner_classes() {
+    let sig = jni_sig!(.Outer::Inner1::Inner2);
+
+    assert_eq!(sig.sig().to_bytes(), b"LOuter$Inner1$Inner2;");
+    assert_eq!(sig.ty(), JavaType::Object);
+}
+
+// Test parsing of raw signature strings
+
+#[test]
+fn test_raw_method_signature_str() {
+    let sig = jni_sig!("(ILjava/lang/String;)V");
+    assert_eq!(sig.sig().as_ptr(), c"(ILjava/lang/String;)V".as_ptr());
+    assert_eq!(sig.args().len(), 2);
+    assert_eq!(sig.args()[0], JavaType::Primitive(Primitive::Int));
+    assert_eq!(sig.args()[1], JavaType::Object);
+    assert_eq!(sig.ret(), JavaType::Primitive(Primitive::Void));
+}
+
+#[test]
+fn test_raw_method_signature_cstr() {
+    let sig = jni_sig!(c"(Ljava/lang/String;)I");
+    assert_eq!(sig.sig().as_ptr(), c"(Ljava/lang/String;)I".as_ptr());
+    assert_eq!(sig.args().len(), 1);
+    assert_eq!(sig.args()[0], JavaType::Object);
+    assert_eq!(sig.ret(), JavaType::Primitive(Primitive::Int));
+}
+
+#[test]
+fn test_raw_field_signature_primitive() {
+    let sig = jni_sig!("I");
+    assert_eq!(sig.sig().as_ptr(), c"I".as_ptr());
+    assert_eq!(sig.ty(), JavaType::Primitive(Primitive::Int));
+}
+
+#[test]
+fn test_raw_field_signature_object() {
+    let sig = jni_sig!("Ljava/lang/String;");
+    assert_eq!(sig.sig().as_ptr(), c"Ljava/lang/String;".as_ptr());
+    assert_eq!(sig.ty(), JavaType::Object);
+}
+
+#[test]
+fn test_raw_field_signature_array() {
+    let sig = jni_sig!("[I");
+    assert_eq!(sig.sig().as_ptr(), c"[I".as_ptr());
+    assert_eq!(sig.ty(), JavaType::Array);
+}
+
+#[test]
+fn test_raw_field_signature_multidim_array() {
+    let sig = jni_sig!("[[Ljava/lang/String;");
+    assert_eq!(sig.sig().as_ptr(), c"[[Ljava/lang/String;".as_ptr());
+    assert_eq!(sig.ty(), JavaType::Array);
+}
+
+#[test]
+fn test_raw_method_with_arrays() {
+    let sig = jni_sig!("([I[Ljava/lang/String;)[[I");
+    assert_eq!(sig.sig().as_ptr(), c"([I[Ljava/lang/String;)[[I".as_ptr());
+    assert_eq!(sig.args().len(), 2);
+    assert_eq!(sig.args()[0], JavaType::Array);
+    assert_eq!(sig.args()[1], JavaType::Array);
+    assert_eq!(sig.ret(), JavaType::Array);
+}
+
+#[test]
+fn test_raw_method_empty_args() {
+    let sig = jni_sig!("()V");
+    assert_eq!(sig.sig().as_ptr(), c"()V".as_ptr());
+    assert_eq!(sig.args().len(), 0);
+    assert_eq!(sig.ret(), JavaType::Primitive(Primitive::Void));
+}
+
+#[test]
+fn test_raw_field_with_inner_class() {
+    let sig = jni_sig!("Ljava/lang/Outer$Inner;");
+    assert_eq!(sig.sig().as_ptr(), c"Ljava/lang/Outer$Inner;".as_ptr());
+    assert_eq!(sig.ty(), JavaType::Object);
+}
+
+#[test]
+fn test_raw_field_default_package() {
+    let sig = jni_sig!("LNoPackage;");
+    assert_eq!(sig.sig().as_ptr(), c"LNoPackage;".as_ptr());
+    assert_eq!(sig.ty(), JavaType::Object);
+}
+
+// Tests for new named property syntax
+
+#[test]
+fn test_named_sig_property() {
+    // Signature can be named with sig =
+    let sig = jni_sig!(sig = (a: jint) -> void);
+    assert_eq!(sig.sig().to_bytes(), b"(I)V");
+    assert_eq!(sig.args().len(), 1);
+    assert_eq!(sig.ret(), JavaType::Primitive(Primitive::Void));
+}
+
+#[test]
+fn test_named_sig_property_field() {
+    // Field signature can also be named
+    let sig = jni_sig!(sig = jint);
+    assert_eq!(sig.sig().to_bytes(), b"I");
+    assert_eq!(sig.ty(), JavaType::Primitive(Primitive::Int));
+}
+
+#[test]
+fn test_type_map_with_named_sig() {
+    // type_map can be used with named sig in any order
+    let sig1 = jni_sig!(
+        sig = (a: RustType) -> void,
+        type_map = {
+            RustType => java.lang.Type,
+        }
+    );
+
+    let sig2 = jni_sig!(
+        type_map = {
+            RustType => java.lang.Type,
+        },
+        sig = (a: RustType) -> void
+    );
+
+    assert_eq!(sig1.sig().to_bytes(), b"(Ljava/lang/Type;)V");
+    assert_eq!(sig2.sig().to_bytes(), b"(Ljava/lang/Type;)V");
+}
+
+#[test]
+fn test_jni_crate_override() {
+    // Test that jni crate path can be overridden
+    // This should work even though we're specifying a custom path
+    let sig = jni_sig!(
+        jni = ::jni,
+        (a: jint) -> void
+    );
+    assert_eq!(sig.sig().to_bytes(), b"(I)V");
+}
+
+#[test]
+fn test_all_properties_together() {
+    // Test all properties together
+    let sig = jni_sig!(
+        jni = ::jni,
+        type_map = {
+            CustomType => java.lang.Custom,
+        },
+        sig = (a: CustomType) -> void,
+    );
+    assert_eq!(sig.sig().to_bytes(), b"(Ljava/lang/Custom;)V");
+}
+
+#[test]
+fn test_unnamed_sig_with_other_props() {
+    // Unnamed signature can be anywhere (after jni property)
+    let sig = jni_sig!(
+        jni = ::jni,
+        (a: CustomType) -> void,
+        type_map = {
+            CustomType => java.lang.Custom,
+        }
+    );
+    assert_eq!(sig.sig().to_bytes(), b"(Ljava/lang/Custom;)V");
+}
+
+#[test]
+fn test_unnamed_sig_in_middle() {
+    // Unnamed signature in the middle of named properties (after jni)
+    let sig = jni_sig!(
+        jni = ::jni,
+        type_map = {
+            CustomType => java.lang.Custom,
+        },
+        (a: CustomType) -> void
+    );
+    assert_eq!(sig.sig().to_bytes(), b"(Ljava/lang/Custom;)V");
+}
+
+#[test]
+fn test_unnamed_sig_at_end() {
+    // Unnamed signature at the end
+    let sig = jni_sig!(
+        jni = ::jni,
+        type_map = {
+            CustomType => java.lang.Custom,
+        },
+        (a: CustomType) -> void
+    );
+    assert_eq!(sig.sig().to_bytes(), b"(Ljava/lang/Custom;)V");
+}
+
+#[test]
+fn test_unnamed_sig_with_trailing_comma() {
+    // Unnamed signature at end with trailing comma
+    let sig = jni_sig!(
+        jni = ::jni,
+        type_map = {
+            CustomType => java.lang.Custom,
+        },
+        (a: CustomType) -> void,
+    );
+    assert_eq!(sig.sig().to_bytes(), b"(Ljava/lang/Custom;)V");
+}
+
+#[test]
+fn test_type_map_prefix_required() {
+    // This should compile - type_map = is now required
+    let sig = jni_sig!(
+        CustomType,
+        type_map = {
+            CustomType => java.lang.Custom,
+        }
+    );
+    assert_eq!(sig.sig().to_bytes(), b"Ljava/lang/Custom;");
+}
+
+// Tests for MUTF-8 encoding
+
+#[test]
+fn test_mutf8_encoding_basic_ascii() {
+    use jni_macros::{jni_sig_cstr, jni_sig_jstr};
+
+    // Basic ASCII should be the same in MUTF-8
+    let sig = jni_sig!((a: java.lang.String) -> void);
+    assert_eq!(sig.sig().to_bytes(), b"(Ljava/lang/String;)V");
+
+    let cstr_sig = jni_sig_cstr!((a: java.lang.String) -> void);
+    assert_eq!(cstr_sig.to_bytes(), b"(Ljava/lang/String;)V");
+
+    let jstr_sig = jni_sig_jstr!((a: java.lang.String) -> void);
+    assert_eq!(jstr_sig.to_bytes(), b"(Ljava/lang/String;)V");
+}
+
+#[test]
+fn test_mutf8_encoding_unicode_emoji() {
+    use jni_macros::{jni_sig_cstr, jni_sig_jstr};
+
+    // Test Unicode emoji in class name - requires MUTF-8 encoding
+    // The emoji 😀 (U+1F600) in MUTF-8 is encoded as surrogate pairs:
+    // U+1F600 -> UTF-16 surrogate pair: D83D DE00
+    // In MUTF-8: ED A0 BD ED B8 80
+    let sig = jni_sig!((a: "unicode.Type😀") -> bool);
+    let expected = b"(Lunicode/Type\xed\xa0\xbd\xed\xb8\x80;)Z";
+    assert_eq!(sig.sig().to_bytes(), expected);
+
+    let cstr_sig = jni_sig_cstr!((a: "unicode.Type😀") -> bool);
+    assert_eq!(cstr_sig.to_bytes(), expected);
+
+    let jstr_sig = jni_sig_jstr!((a: "unicode.Type😀") -> bool);
+    assert_eq!(jstr_sig.to_bytes(), expected);
+}
+
+#[test]
+fn test_mutf8_encoding_unicode_field() {
+    use jni_macros::{jni_sig_cstr, jni_sig_jstr};
+
+    // Test Unicode emoji in field signature
+    let sig = jni_sig!("unicode.Field😀");
+    let expected = b"Lunicode/Field\xed\xa0\xbd\xed\xb8\x80;";
+    assert_eq!(sig.sig().to_bytes(), expected);
+
+    let cstr_sig = jni_sig_cstr!("unicode.Field😀");
+    assert_eq!(cstr_sig.to_bytes(), expected);
+
+    let jstr_sig = jni_sig_jstr!("unicode.Field😀");
+    assert_eq!(jstr_sig.to_bytes(), expected);
+}
+
+#[test]
+fn test_mutf8_encoding_unicode_various_chars() {
+    use jni_macros::jni_sig_cstr;
+
+    // Test various Unicode characters
+    // Japanese: こんにちは (Konnichiwa)
+    let sig_jp = jni_sig_cstr!("jp.こんにちは");
+    // こ (U+3053) -> E3 81 93
+    // ん (U+3093) -> E3 82 93
+    // に (U+306B) -> E3 81 AB
+    // ち (U+3061) -> E3 81 A1
+    // は (U+306F) -> E3 81 AF
+    assert_eq!(
+        sig_jp.to_bytes(),
+        b"Ljp/\xe3\x81\x93\xe3\x82\x93\xe3\x81\xab\xe3\x81\xa1\xe3\x81\xaf;"
+    );
+
+    // Emoji combination: 👍 (U+1F44D)
+    // U+1F44D -> UTF-16 surrogate pair: D83D DC4D
+    // In MUTF-8: ED A0 BD ED B1 8D
+    let sig_emoji = jni_sig_cstr!("emoji.👍");
+    assert_eq!(sig_emoji.to_bytes(), b"Lemoji/\xed\xa0\xbd\xed\xb1\x8d;");
+}
+
+#[test]
+fn test_all_three_macros_produce_same_encoding() {
+    use jni_macros::{jni_sig_cstr, jni_sig_jstr};
+
+    // All three macros should produce the same byte sequence for the signature
+    let sig = jni_sig!((a: jint, b: java.lang.String) -> java.lang.Object);
+    let cstr_sig = jni_sig_cstr!((a: jint, b: java.lang.String) -> java.lang.Object);
+    let jstr_sig = jni_sig_jstr!((a: jint, b: java.lang.String) -> java.lang.Object);
+
+    assert_eq!(sig.sig().to_bytes(), cstr_sig.to_bytes());
+    assert_eq!(sig.sig().to_bytes(), jstr_sig.to_bytes());
+    assert_eq!(
+        sig.sig().to_bytes(),
+        b"(ILjava/lang/String;)Ljava/lang/Object;"
+    );
+}
+
+#[test]
+fn test_const_evaluation_all_macros() {
+    use jni::strings::JNIStr;
+    use jni_macros::{jni_sig_cstr, jni_sig_jstr, jni_sig_str};
+    use std::ffi::CStr;
+
+    // Test that all macros work in const contexts
+    const STR_SIG: &str = jni_sig_str!((a: jint) -> void);
+    const CSTR_SIG: &CStr = jni_sig_cstr!((a: jint) -> void);
+    const JSTR_SIG: &JNIStr = jni_sig_jstr!((a: jint) -> void);
+
+    assert_eq!(STR_SIG, "(I)V");
+    assert_eq!(CSTR_SIG.to_bytes(), b"(I)V");
+    assert_eq!(JSTR_SIG.to_bytes(), b"(I)V");
+}
+
+// Tests for jni_sig_str! macro
+
+#[test]
+fn test_jni_sig_str_basic() {
+    use jni_macros::jni_sig_str;
+
+    const SIG: &str = jni_sig_str!((a: jint, b: jboolean) -> void);
+    assert_eq!(SIG, "(IZ)V");
+}
+
+#[test]
+fn test_jni_sig_str_object() {
+    use jni_macros::jni_sig_str;
+
+    const SIG: &str = jni_sig_str!((a: java.lang.String) -> java.lang.Object);
+    assert_eq!(SIG, "(Ljava/lang/String;)Ljava/lang/Object;");
+}
+
+#[test]
+fn test_jni_sig_str_field() {
+    use jni_macros::jni_sig_str;
+
+    const FIELD_SIG: &str = jni_sig_str!(java.lang.String);
+    assert_eq!(FIELD_SIG, "Ljava/lang/String;");
+}
+
+#[test]
+fn test_jni_sig_str_array() {
+    use jni_macros::jni_sig_str;
+
+    const SIG: &str = jni_sig_str!(([jint], [java.lang.String]) -> [[jint]]);
+    assert_eq!(SIG, "([I[Ljava/lang/String;)[[I");
+}
+
+#[test]
+fn test_jni_sig_str_with_type_map() {
+    use jni_macros::jni_sig_str;
+
+    const SIG: &str = jni_sig_str!(
+        (a: CustomType) -> void,
+        type_map = {
+            CustomType => java.lang.Custom,
+        }
+    );
+    assert_eq!(SIG, "(Ljava/lang/Custom;)V");
+}
+
+// Tests for jni_sig_cstr! macro
+
+#[test]
+fn test_jni_sig_cstr_basic() {
+    use jni_macros::jni_sig_cstr;
+    use std::ffi::CStr;
+
+    const SIG: &CStr = jni_sig_cstr!((a: jint, b: jboolean) -> void);
+    assert_eq!(SIG.to_bytes(), b"(IZ)V");
+}
+
+#[test]
+fn test_jni_sig_cstr_object() {
+    use jni_macros::jni_sig_cstr;
+    use std::ffi::CStr;
+
+    const SIG: &CStr = jni_sig_cstr!((a: java.lang.String) -> java.lang.Object);
+    assert_eq!(SIG.to_bytes(), b"(Ljava/lang/String;)Ljava/lang/Object;");
+}
+
+#[test]
+fn test_jni_sig_cstr_field() {
+    use jni_macros::jni_sig_cstr;
+    use std::ffi::CStr;
+
+    const FIELD_SIG: &CStr = jni_sig_cstr!(java.lang.String);
+    assert_eq!(FIELD_SIG.to_bytes(), b"Ljava/lang/String;");
+}
+
+#[test]
+fn test_jni_sig_cstr_array() {
+    use jni_macros::jni_sig_cstr;
+    use std::ffi::CStr;
+
+    const SIG: &CStr = jni_sig_cstr!(([jint], [java.lang.String]) -> [[jint]]);
+    assert_eq!(SIG.to_bytes(), b"([I[Ljava/lang/String;)[[I");
+}
+
+// Tests for jni_sig_jstr! macro
+
+#[test]
+fn test_jni_sig_jstr_basic() {
+    use jni::strings::JNIStr;
+    use jni_macros::jni_sig_jstr;
+
+    const SIG: &JNIStr = jni_sig_jstr!((a: jint, b: jboolean) -> void);
+    assert_eq!(SIG.to_bytes(), b"(IZ)V");
+}
+
+#[test]
+fn test_jni_sig_jstr_object() {
+    use jni::strings::JNIStr;
+    use jni_macros::jni_sig_jstr;
+
+    const SIG: &JNIStr = jni_sig_jstr!((a: java.lang.String) -> java.lang.Object);
+    assert_eq!(SIG.to_bytes(), b"(Ljava/lang/String;)Ljava/lang/Object;");
+}
+
+#[test]
+fn test_jni_sig_jstr_field() {
+    use jni::strings::JNIStr;
+    use jni_macros::jni_sig_jstr;
+
+    const FIELD_SIG: &JNIStr = jni_sig_jstr!(java.lang.String);
+    assert_eq!(FIELD_SIG.to_bytes(), b"Ljava/lang/String;");
+}
+
+#[test]
+fn test_jni_sig_jstr_array() {
+    use jni::strings::JNIStr;
+    use jni_macros::jni_sig_jstr;
+
+    const SIG: &JNIStr = jni_sig_jstr!(([jint], [java.lang.String]) -> [[jint]]);
+    assert_eq!(SIG.to_bytes(), b"([I[Ljava/lang/String;)[[I");
+}
+
+#[test]
+fn test_jni_sig_jstr_with_type_map() {
+    use jni::strings::JNIStr;
+    use jni_macros::jni_sig_jstr;
+
+    const SIG: &JNIStr = jni_sig_jstr!(
+        (a: CustomType) -> void,
+        type_map = {
+            CustomType => java.lang.Custom,
+        }
+    );
+    assert_eq!(SIG.to_bytes(), b"(Ljava/lang/Custom;)V");
+}
+
+#[test]
+fn test_jni_sig_str_produces_utf8_string() {
+    use jni_macros::jni_sig_str;
+
+    // jni_sig_str! should produce a regular UTF-8 string
+    const SIG: &str = jni_sig_str!((a: jint, b: java.lang.String) -> void);
+    assert_eq!(SIG, "(ILjava/lang/String;)V");
+    assert_eq!(SIG.as_bytes(), b"(ILjava/lang/String;)V");
+}
+
+#[test]
+fn test_field_signatures_all_variants() {
+    use jni_macros::{jni_sig_cstr, jni_sig_jstr, jni_sig_str};
+
+    // Test that field signatures work with all macro variants
+    let field_sig = jni_sig!(java.util.List);
+    assert_eq!(field_sig.sig().to_bytes(), b"Ljava/util/List;");
+
+    let cstr_field = jni_sig_cstr!(java.util.List);
+    assert_eq!(cstr_field.to_bytes(), b"Ljava/util/List;");
+
+    let jstr_field = jni_sig_jstr!(java.util.List);
+    assert_eq!(jstr_field.to_bytes(), b"Ljava/util/List;");
+
+    const STR_FIELD: &str = jni_sig_str!(java.util.List);
+    assert_eq!(STR_FIELD, "Ljava/util/List;");
+}
+
+#[test]
+fn test_raw_signature_all_variants() {
+    use jni_macros::{jni_sig_cstr, jni_sig_jstr, jni_sig_str};
+
+    // Test raw signatures with all macro variants
+    let sig = jni_sig!("(ILjava/lang/String;)V");
+    assert_eq!(sig.sig().to_bytes(), b"(ILjava/lang/String;)V");
+
+    let cstr_sig = jni_sig_cstr!("(ILjava/lang/String;)V");
+    assert_eq!(cstr_sig.to_bytes(), b"(ILjava/lang/String;)V");
+
+    let jstr_sig = jni_sig_jstr!("(ILjava/lang/String;)V");
+    assert_eq!(jstr_sig.to_bytes(), b"(ILjava/lang/String;)V");
+
+    const STR_SIG: &str = jni_sig_str!("(ILjava/lang/String;)V");
+    assert_eq!(STR_SIG, "(ILjava/lang/String;)V");
+}
+
+// Tests for jni_cstr! and jni_str! macros
+
+#[test]
+fn test_jni_cstr_basic() {
+    use jni_macros::jni_cstr;
+    use std::ffi::CStr;
+
+    const CLASS_NAME: &CStr = jni_cstr!("java.lang.String");
+    assert_eq!(CLASS_NAME.to_bytes(), b"java.lang.String");
+}
+
+#[test]
+fn test_jni_cstr_unicode_emoji() {
+    use jni_macros::jni_cstr;
+    use std::ffi::CStr;
+
+    // Test Unicode emoji (above U+FFFF) - requires MUTF-8 encoding with surrogate pairs
+    const EMOJI_CLASS: &CStr = jni_cstr!("unicode.Type😀");
+    // The emoji 😀 (U+1F600) in MUTF-8 is encoded as surrogate pairs:
+    // U+1F600 -> UTF-16 surrogate pair: D83D DE00
+    // In MUTF-8: ED A0 BD ED B8 80
+    assert_eq!(
+        EMOJI_CLASS.to_bytes(),
+        b"unicode.Type\xed\xa0\xbd\xed\xb8\x80"
+    );
+
+    // Verify roundtrip decode
+    let decoded = cesu8::from_java_cesu8(EMOJI_CLASS.to_bytes()).expect("Failed to decode MUTF-8");
+    assert_eq!(decoded, "unicode.Type😀");
+}
+
+#[test]
+fn test_jni_str_basic() {
+    use jni::strings::JNIStr;
+    use jni_macros::jni_str;
+
+    const CLASS_NAME: &JNIStr = jni_str!("java.lang.String");
+    assert_eq!(CLASS_NAME.to_bytes(), b"java.lang.String");
+}
+
+#[test]
+fn test_jni_str_unicode_emoji() {
+    use jni::strings::JNIStr;
+    use jni_macros::jni_str;
+
+    // Test Unicode emoji (above U+FFFF) - requires MUTF-8 encoding with surrogate pairs
+    const EMOJI_CLASS: &JNIStr = jni_str!("unicode.Type😀");
+    assert_eq!(
+        EMOJI_CLASS.to_bytes(),
+        b"unicode.Type\xed\xa0\xbd\xed\xb8\x80"
+    );
+
+    // Verify roundtrip decode
+    let decoded = cesu8::from_java_cesu8(EMOJI_CLASS.to_bytes()).expect("Failed to decode MUTF-8");
+    assert_eq!(decoded, "unicode.Type😀");
+}
+
+#[test]
+fn test_jni_cstr_and_jni_str_produce_same_encoding() {
+    use jni_macros::{jni_cstr, jni_str};
+
+    // Test that jni_cstr! and jni_str! produce the same byte encoding
+    const CSTR: &std::ffi::CStr = jni_cstr!("java.util.ArrayList");
+    const JSTR: &jni::strings::JNIStr = jni_str!("java.util.ArrayList");
+
+    assert_eq!(CSTR.to_bytes(), JSTR.to_bytes());
+    assert_eq!(CSTR.to_bytes(), b"java.util.ArrayList");
+}
+
+#[test]
+fn test_jni_cstr_const_evaluation() {
+    use jni_macros::jni_cstr;
+    use std::ffi::CStr;
+
+    // Verify that jni_cstr! works in const contexts
+    const PATH_SEP: &CStr = jni_cstr!("/");
+    const PACKAGE: &CStr = jni_cstr!("com.example");
+    const NESTED: &CStr = jni_cstr!("com.example.nested.Class");
+
+    assert_eq!(PATH_SEP.to_bytes(), b"/");
+    assert_eq!(PACKAGE.to_bytes(), b"com.example");
+    assert_eq!(NESTED.to_bytes(), b"com.example.nested.Class");
+}
+
+#[test]
+fn test_jni_str_const_evaluation() {
+    use jni::strings::JNIStr;
+    use jni_macros::jni_str;
+
+    // Verify that jni_str! works in const contexts
+    const PATH_SEP: &JNIStr = jni_str!("/");
+    const PACKAGE: &JNIStr = jni_str!("com.example");
+    const NESTED: &JNIStr = jni_str!("com.example.nested.Class");
+
+    assert_eq!(PATH_SEP.to_bytes(), b"/");
+    assert_eq!(PACKAGE.to_bytes(), b"com.example");
+    assert_eq!(NESTED.to_bytes(), b"com.example.nested.Class");
+}
+
+#[test]
+fn test_jni_cstr_concat_multiple_literals() {
+    use jni_macros::jni_cstr;
+    use std::ffi::CStr;
+
+    // Test concat-like behavior with multiple string literals
+    const CONCATENATED: &CStr = jni_cstr!("java", ".", "lang", ".", "String");
+    assert_eq!(CONCATENATED.to_bytes(), b"java.lang.String");
+
+    const TWO_PART: &CStr = jni_cstr!("com.example", ".MyClass");
+    assert_eq!(TWO_PART.to_bytes(), b"com.example.MyClass");
+
+    const WITH_TRAILING_COMMA: &CStr = jni_cstr!("hello", " ", "world",);
+    assert_eq!(WITH_TRAILING_COMMA.to_bytes(), b"hello world");
+}
+
+#[test]
+fn test_jni_str_concat_multiple_literals() {
+    use jni::strings::JNIStr;
+    use jni_macros::jni_str;
+
+    // Test concat-like behavior with multiple string literals
+    const CONCATENATED: &JNIStr = jni_str!("java", ".", "lang", ".", "String");
+    assert_eq!(CONCATENATED.to_bytes(), b"java.lang.String");
+
+    const TWO_PART: &JNIStr = jni_str!("com.example", ".MyClass");
+    assert_eq!(TWO_PART.to_bytes(), b"com.example.MyClass");
+
+    const WITH_TRAILING_COMMA: &JNIStr = jni_str!("hello", " ", "world",);
+    assert_eq!(WITH_TRAILING_COMMA.to_bytes(), b"hello world");
+}
+
+#[test]
+fn test_jni_str_with_jni_crate_override() {
+    use jni_macros::jni_str;
+
+    // Test that we can override the jni crate path
+    // This should compile successfully with jni = jni
+    const WITH_JNI_OVERRIDE: &jni::strings::JNIStr = jni_str!(jni = jni, "test.Class");
+    assert_eq!(WITH_JNI_OVERRIDE.to_bytes(), b"test.Class");
+
+    // Test with multiple literals after jni override
+    const MULTI_WITH_OVERRIDE: &jni::strings::JNIStr = jni_str!(jni = jni, "test", ".", "Class");
+    assert_eq!(MULTI_WITH_OVERRIDE.to_bytes(), b"test.Class");
+}
+
+#[test]
+fn test_jni_cstr_and_jni_str_concat_same_encoding() {
+    use jni_macros::{jni_cstr, jni_str};
+
+    // Test that jni_cstr! and jni_str! produce the same byte encoding when concatenating
+    const CSTR: &std::ffi::CStr = jni_cstr!("java", ".", "util", ".", "ArrayList");
+    const JSTR: &jni::strings::JNIStr = jni_str!("java", ".", "util", ".", "ArrayList");
+
+    assert_eq!(CSTR.to_bytes(), JSTR.to_bytes());
+    assert_eq!(CSTR.to_bytes(), b"java.util.ArrayList");
+}
+
+#[test]
+fn test_jni_cstr_mixed_literal_types() {
+    use jni_macros::jni_cstr;
+    use std::ffi::CStr;
+
+    // Test mixing different literal types
+    const PORT: &CStr = jni_cstr!("localhost:", 8080);
+    assert_eq!(PORT.to_bytes(), b"localhost:8080");
+
+    const VERSION: &CStr = jni_cstr!("Version ", 1, '.', 2, '.', 3);
+    assert_eq!(VERSION.to_bytes(), b"Version 1.2.3");
+
+    const FLAG: &CStr = jni_cstr!("enabled=", true);
+    assert_eq!(FLAG.to_bytes(), b"enabled=true");
+}
+
+#[test]
+fn test_jni_str_mixed_literal_types() {
+    use jni::strings::JNIStr;
+    use jni_macros::jni_str;
+
+    // Test mixing different literal types
+    const PORT: &JNIStr = jni_str!("localhost:", 8080);
+    assert_eq!(PORT.to_bytes(), b"localhost:8080");
+
+    const VERSION: &JNIStr = jni_str!("v", 2, '.', 0);
+    assert_eq!(VERSION.to_bytes(), b"v2.0");
+
+    const BYTE_VAL: &JNIStr = jni_str!("byte=", b'A');
+    assert_eq!(BYTE_VAL.to_bytes(), b"byte=65"); // ASCII value of 'A'
+}
+
+#[test]
+fn test_jni_cstr_float_literal() {
+    use jni_macros::jni_cstr;
+    use std::ffi::CStr;
+
+    const PI: &CStr = jni_cstr!("pi=", 3.14159);
+    assert_eq!(PI.to_bytes(), b"pi=3.14159");
+}
+
+#[test]
+fn test_jni_str_cstr_literal() {
+    use jni::strings::JNIStr;
+    use jni_macros::jni_str;
+
+    // CStr literals can be used if they're valid UTF-8
+    const HELLO: &JNIStr = jni_str!(c"Hello", " ", c"World");
+    assert_eq!(HELLO.to_bytes(), b"Hello World");
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -347,3 +347,8 @@ pub use jni_macros::jni_cstr;
 pub use jni_macros::jni_str;
 
 pub use jni_macros::jni_mangle;
+
+pub use jni_macros::jni_sig;
+pub use jni_macros::jni_sig_cstr;
+pub use jni_macros::jni_sig_jstr;
+pub use jni_macros::jni_sig_str;


### PR DESCRIPTION
# `jni_sig` macro

This macro enables compile-time parsing of a method or field signature and outputs a `MethodSignature` or `FieldSignature` struct that includes a literal signature string (encoded as MUTF-8) and maps method arguments, return values and field types into `JavaType` enum variants.

The macro can either be passed a standard JNI signature as input (e.g. "(ILjava/lang/String;)Z") or it accepts a syntax like this:

- `(jint, JString) -> jboolean`
- `(arg0: JObject, arg1: bool) -> JObject`
- `(MyType, byte[][]) -> int[]`
- `(com.example.JavaType, bool) -> com.example.OtherType`

# `jni_sig_str`, `jni_sig_cstr` + `jni_sig_jstr` macros

Accept the same input as `jni_sig` but instead of outputting a struct they just output a string literal for the signature, either as a plain `&'static str`, a `&'static CStr` or a `&'static JNIStr` respectively.

# Groundwork for `bind_java_type` + `native_method` macros

The plan is to build on this same signature parsing syntax in follow up work to implement a `bind_java_type!` and `native_method!` macros.

Although it's overkill for this initial `jni_sig!` macro, this macro includes type mapping functionality that will be shared with the `bind_java_type` and `native_method` macros in order to support signatures that refer to rust types.

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Change is covered by [automated tests](https://github.com/jni-rs/jni-rs/blob/master/CONTRIBUTING.md#tests)
- [x] The [coding guidelines](https://github.com/jni-rs/jni-rs/blob/master/CONTRIBUTING.md#the-code-style) are followed
- [x] Public API has documentation
- [x] User-visible changes are mentioned in the Changelog
- [x] The continuous integration build passes
