### PR TITLE
jni-macros: add `native_method!` macro

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -101,8 +101,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 #### Macros
 
 - The `#[jni_mangle()]` attribute proc macro can export an `extern "system"` native method with a mangled name like "Java_com_example_myMethod" so it can be automatically resolved within a shared library by the JVM ([#693](https://github.com/jni-rs/jni-rs/pull/693))
-- The `jni_str!` and `jni_cstr!` macros can encode a MUTF-8 `&'static JNIStr` or `&' static CStr` at compile time with full unicode support.
-- The `jni_sig!`, `jni_sig_str!`, `jni_sig_cstr!` and `jni_sig_jstr!` macros can parse and compile signatures like `(arg0: jint, arg1: JString) -> JString` into `MethodSignature` and `FieldSignature` descriptors or JNI string literals like "(ILjava/lang/String;)Ljava/lang/String;"
+- The `jni_str!` and `jni_cstr!` macros can encode a MUTF-8 `&'static JNIStr` or `&' static CStr` at compile time with full unicode support. ([#696](https://github.com/jni-rs/jni-rs/pull/696))
+- The `jni_sig!`, `jni_sig_str!`, `jni_sig_cstr!` and `jni_sig_jstr!` macros can parse and compile signatures like `(arg0: jint, arg1: JString) -> JString` into `MethodSignature` and `FieldSignature` descriptors or JNI string literals like "(ILjava/lang/String;)Ljava/lang/String;" ([#697](https://github.com/jni-rs/jni-rs/pull/697))
+- The `native_method!` macro binds a single native method to a Rust function with type safety and optionally exports it too. ([#698](https://github.com/jni-rs/jni-rs/pull/698))
 
 ### Changed
 

--- a/jni-macros/Cargo.toml
+++ b/jni-macros/Cargo.toml
@@ -30,3 +30,7 @@ cesu8 = "1.1.0"
 
 [dev-dependencies]
 jni = { path = "../", version = "0.21.0", features = ["invocation"] }
+javac = { path = "../javac" }
+rusty-fork = "0.3.0"
+trybuild = "1"
+thiserror = "2"

--- a/jni-macros/examples/java/com/example/NativeMethodOverview.java
+++ b/jni-macros/examples/java/com/example/NativeMethodOverview.java
@@ -1,0 +1,77 @@
+package com.example;
+
+public class NativeMethodOverview {
+    public int value;
+    public String name;
+
+    // Constructors
+    public NativeMethodOverview() {
+        this.value = 0;
+        this.name = "default";
+    }
+
+    public NativeMethodOverview(int initialValue) {
+        this.value = initialValue;
+        this.name = "initialized";
+    }
+
+    // Native methods - instance methods
+    public native int nativeAdd(int a, int b);
+
+    public native String nativeConcatenate(String a, String b);
+
+    public native int nativeRaw(int value);
+
+    public native int nativeWithFunction(int value);
+
+    public native int nativeNoUnwind(int value);
+
+    public native int nativeCustomErrorPolicy(int value);
+
+    public native String nativeProcessHandle(long handle);
+
+    // Native methods - static methods
+    public static native String nativeGreet(String name);
+
+    public static native int[] nativeEchoIntArray(int[] arr);
+
+    // Test method that calls all native methods from Java
+    public String testAllNativeMethods() {
+        StringBuilder result = new StringBuilder();
+
+        // Test instance native method
+        int sum = nativeAdd(10, 20);
+        result.append("nativeAdd(10, 20) = ").append(sum).append("; ");
+
+        // Test concatenate
+        String concat = nativeConcatenate("Hello, ", "World!");
+        result.append("nativeConcatenate = ").append(concat).append("; ");
+
+        // Test static native method
+        String greeting = nativeGreet("Rust");
+        result.append("nativeGreet(Rust) = ").append(greeting).append("; ");
+
+        // Test raw native method
+        int raw = nativeRaw(42);
+        result.append("nativeRaw(42) = ").append(raw).append("; ");
+
+        // Test function-based native method
+        int func = nativeWithFunction(100);
+        result.append("nativeWithFunction(100) = ").append(func).append("; ");
+
+        // Test no-unwind native method
+        int noUnwind = nativeNoUnwind(99);
+        result.append("nativeNoUnwind(99) = ").append(noUnwind).append("; ");
+
+        // Test custom error policy native method
+        int customError = nativeCustomErrorPolicy(50);
+        result.append("nativeCustomErrorPolicy(50) = ").append(customError).append("; ");
+
+        // Test array methods
+        int[] intArray = { 1, 2, 3 };
+        int[] echoedInts = nativeEchoIntArray(intArray);
+        result.append("nativeEchoIntArray length = ").append(echoedInts.length);
+
+        return result.toString();
+    }
+}

--- a/jni-macros/examples/java/com/example/NativeMethodWrapper.java
+++ b/jni-macros/examples/java/com/example/NativeMethodWrapper.java
@@ -1,0 +1,17 @@
+package com.example;
+
+class CommonBuiltinType {
+    public CommonBuiltinType() {
+    }
+}
+
+class CustomType {
+    public CustomType() {
+    }
+}
+
+public class NativeMethodWrapper {
+    public native String processResource(long handle);
+
+    public static native String mixTypes(CommonBuiltinType builtin, CustomType custom);
+}

--- a/jni-macros/examples/native_method.rs
+++ b/jni-macros/examples/native_method.rs
@@ -1,0 +1,269 @@
+//! This example demonstrates the key features of the `native_method!` macro
+//!
+//! The `native_method!` macro creates compile-time type-checked `NativeMethod` descriptors
+//! that can be registered with the JVM.
+//!
+//! Run with: `cargo run --example native_method`
+
+use jni::errors::LogErrorAndDefault;
+use jni::objects::{JClass, JIntArray, JObject, JString};
+use jni::sys::jint;
+use jni::{Env, EnvUnowned, NativeMethod, jni_str, native_method};
+
+#[path = "utils/lib.rs"]
+mod utils;
+
+struct RustThing {
+    pub message: String,
+}
+
+// Sometimes bindings need to pass raw pointers around as Java long values, so
+// we define a simple wrapper type as an example.
+// (this is not a well-considered design for real-world use)
+#[repr(transparent)]
+#[derive(Copy, Clone)]
+struct ThingHandle(*const RustThing);
+impl ThingHandle {
+    pub fn new(thing: RustThing) -> Self {
+        let boxed = Box::new(thing);
+        ThingHandle(Box::into_raw(boxed))
+    }
+
+    unsafe fn as_ref(&self) -> &RustThing {
+        unsafe { &*self.0 }
+    }
+
+    // Safety: only convert back to Box (to drop) when sure handle is no longer shared.
+    pub unsafe fn into_box(self) -> Box<RustThing> {
+        unsafe { Box::from_raw(self.0 as *mut RustThing) }
+    }
+}
+// In order to pass ThingHandle values to/from Java as jlong, we need From<ThingHandle> for jlong
+impl From<ThingHandle> for jni::sys::jlong {
+    fn from(handle: ThingHandle) -> Self {
+        handle.0 as jni::sys::jlong
+    }
+}
+
+// Create an array of native methods using the native_method! macro
+//
+// Note: the use of `extern` (and with the provision of a `java_type` name) here means there will
+// also be an `extern "system"` ABI function exported with a mangled JNI name that the JVM could
+// resolve within a shared library without necessarily registering the methods explicitly.
+//
+// Since this example isn't linked as a shared library loaded by the JVM, it registers the methods
+// explicitly with `env.register_native_methods()`.
+const NATIVE_METHODS: &[NativeMethod] = &[
+    // Instance methods - shorthand syntax
+    // Without a `rust_type` the binding will use `JObject` for 'this'
+    native_method! {
+        java_type = "com.example.NativeMethodOverview",
+        extern fn native_add(a: jint, b: jint) -> jint,
+    },
+    native_method! {
+        java_type = "com.example.NativeMethodOverview",
+        extern fn native_concatenate(a: JString, b: JString) -> JString,
+    },
+    native_method! {
+        java_type = "com.example.NativeMethodOverview",
+        type_map = {
+            unsafe ThingHandle => long,
+        },
+        extern fn native_process_handle(handle: ThingHandle) -> JString,
+    },
+    // Raw native method (no catch_unwind, receives EnvUnowned directly)
+    native_method! {
+        java_type = "com.example.NativeMethodOverview",
+        raw extern fn native_raw(value: jint) -> jint,
+    },
+    // Native method with direct function implementation
+    native_method! {
+        java_type = "com.example.NativeMethodOverview",
+        extern fn native_with_function(value: jint) -> jint,
+        fn = native_with_function_impl,
+    },
+    // Native method with catch_unwind disabled
+    native_method! {
+        java_type = "com.example.NativeMethodOverview",
+        extern fn native_no_unwind(value: jint) -> jint,
+        fn = native_no_unwind,
+        catch_unwind = false,
+    },
+    // Native method with custom error policy
+    native_method! {
+        java_type = "com.example.NativeMethodOverview",
+        extern fn native_custom_error_policy(value: jint) -> jint,
+        fn = native_custom_error_policy,
+        error_policy = LogErrorAndDefault,
+    },
+    // Static methods
+    native_method! {
+        java_type = "com.example.NativeMethodOverview",
+        static extern fn native_greet(name: JString) -> JString,
+    },
+    native_method! {
+        java_type = "com.example.NativeMethodOverview",
+        static extern fn native_echo_int_array(arr: jint[]) -> jint[],
+    },
+];
+
+// Implementation functions for native methods
+
+fn native_add<'local>(
+    _env: &mut Env<'local>,
+    _this: JObject<'local>,
+    a: jint,
+    b: jint,
+) -> Result<jint, jni::errors::Error> {
+    Ok(a + b)
+}
+
+fn native_concatenate<'local>(
+    env: &mut Env<'local>,
+    _this: JObject<'local>,
+    a: JString<'local>,
+    b: JString<'local>,
+) -> Result<JString<'local>, jni::errors::Error> {
+    let a_str = a.try_to_string(env)?;
+    let b_str = b.try_to_string(env)?;
+    JString::from_str(env, format!("{}{}", a_str, b_str))
+}
+
+fn native_process_handle<'local>(
+    env: &mut Env<'local>,
+    _this: JObject<'local>,
+    handle: ThingHandle,
+) -> Result<JString<'local>, jni::errors::Error> {
+    let thing_ref = unsafe { handle.as_ref() };
+    let response = format!("RustThing says: {}", thing_ref.message);
+    JString::from_str(env, response)
+}
+
+fn native_raw<'local>(
+    _unowned_env: EnvUnowned<'local>,
+    _this: JObject<'local>,
+    value: jint,
+) -> jint {
+    value * 2
+}
+
+fn native_with_function_impl<'local>(
+    _env: &mut Env<'local>,
+    _this: JObject<'local>,
+    value: jint,
+) -> Result<jint, jni::errors::Error> {
+    Ok(value * 3)
+}
+
+fn native_no_unwind<'local>(
+    _env: &mut Env<'local>,
+    _this: JObject<'local>,
+    value: jint,
+) -> Result<jint, jni::errors::Error> {
+    Ok(value - 1)
+}
+
+fn native_custom_error_policy<'local>(
+    _env: &mut Env<'local>,
+    _this: JObject<'local>,
+    value: jint,
+) -> Result<jint, jni::errors::Error> {
+    if value < 0 {
+        Err(jni::errors::Error::JniCall(jni::errors::JniError::Unknown))
+    } else {
+        Ok(value)
+    }
+}
+
+fn native_greet<'local>(
+    env: &mut Env<'local>,
+    _class: JClass<'local>,
+    name: JString<'local>,
+) -> Result<JString<'local>, jni::errors::Error> {
+    let name_str = name.try_to_string(env)?;
+    JString::from_str(env, format!("Hello, {}!", name_str))
+}
+
+fn native_echo_int_array<'local>(
+    _env: &mut Env<'local>,
+    _class: JClass<'local>,
+    arr: JIntArray<'local>,
+) -> Result<JIntArray<'local>, jni::errors::Error> {
+    Ok(arr)
+}
+
+fn main() {
+    utils::attach_current_thread(|env| {
+        utils::load_class(env, "NativeMethodOverview")?;
+
+        println!("=== native_method! Overview Example ===\n");
+
+        // Register native methods
+        println!("--- Registering Native Methods ---");
+        let class = env.find_class(jni_str!("com/example/NativeMethodOverview"))?;
+        unsafe {
+            env.register_native_methods(&class, NATIVE_METHODS)?;
+        }
+        println!("Registered {} native methods", NATIVE_METHODS.len());
+
+        // Create an instance
+        println!("\n--- Creating Instance ---");
+        let obj = env.new_object(&class, jni_str!("()V"), &[])?;
+        //let obj = env.new_object(&class, &jni_sig!(()->void), &[])?; TODO
+        println!("Created NativeMethodOverview instance");
+
+        // Call the test method that exercises all native methods
+        println!("\n--- Testing Native Methods ---");
+        let test_method = env.get_method_id(
+            &class,
+            jni_str!("testAllNativeMethods"),
+            jni_str!("()Ljava/lang/String;"),
+            //&jni_sig!(()->JString), TODO
+        )?;
+        let result = unsafe {
+            env.call_method_unchecked(&obj, test_method, jni::signature::ReturnType::Object, &[])?
+                .l()?
+        };
+        let result = unsafe { JString::from_raw(env, result.as_raw()) };
+        println!("Test results: {}", result.try_to_string(env)?);
+
+        // Test the handle method separately
+        println!("\n--- Testing Handle Method ---");
+        let thing = RustThing {
+            message: "Hello from Rust!".to_string(),
+        };
+        let handle = ThingHandle::new(thing);
+
+        // Call native_process_handle via Java
+        let handle_value = jni::sys::jvalue { j: handle.into() };
+        let handle_method = env.get_method_id(
+            &class,
+            jni_str!("nativeProcessHandle"),
+            jni_str!("(J)Ljava/lang/String;"),
+            //&jni_sig!((jlong)->JString), TODO
+        )?;
+        let response = unsafe {
+            env.call_method_unchecked(
+                &obj,
+                handle_method,
+                jni::signature::ReturnType::Object,
+                &[handle_value],
+            )?
+            .l()?
+        };
+        let response = unsafe { JString::from_raw(env, response.as_raw()) };
+        println!(
+            "nativeProcessHandle response: {}",
+            response.try_to_string(env)?
+        );
+
+        // Safety: we are done with the handle, so convert back to Box to drop
+        unsafe {
+            drop(handle.into_box());
+        }
+
+        println!("\n=== Example completed successfully ===");
+        Ok(())
+    })
+    .expect("Failed to run example");
+}

--- a/jni-macros/examples/native_method_wrapper.rs
+++ b/jni-macros/examples/native_method_wrapper.rs
@@ -1,0 +1,200 @@
+//! Example demonstrating a wrapper macro that can inject the jni crate path and
+//! a type_map into native_method! invocations.
+//!
+//! Notably the wrapper doesn't need to know anything about the syntax of
+//! native_method! and it doesn't stop you from adding additional type_map
+//! entries.
+//!
+//! This could be useful in a workspace with:
+//! - Multiple jni version dependencies
+//! - Common Reference types used across many native methods
+//! - Custom handle types that are used across many native methods
+
+extern crate jni as jni2;
+
+use jni2::JValue;
+use jni2::objects::{JClass, JObject, JString};
+use jni2::refs::LoaderContext;
+use jni2::refs::Reference;
+use jni2::{Env, NativeMethod};
+use std::ffi::{CStr, c_char};
+
+use thiserror::Error;
+
+#[derive(Error, Debug)]
+enum MyError {
+    #[error("Invalid UTF-8 in handle: {0}")]
+    InvalidUtf8(#[from] std::str::Utf8Error),
+    #[error("JNI call failed")]
+    Jni(#[from] jni2::errors::Error),
+}
+
+#[path = "utils/lib.rs"]
+mod utils;
+
+// First, define some simple bindings for types we'll reference in the example type_maps
+// (macro from utils/lib.rs)
+define_stub_type!(JNativeMethodWrapper, "com.example.NativeMethodWrapper");
+define_stub_type!(JBuiltinType, "com.example.CommonBuiltinType");
+define_stub_type!(JCustomType, "com.example.CustomType");
+
+// Define an FFI handle type that can be added to a common type_map
+#[repr(transparent)]
+#[derive(Copy, Clone)]
+struct CommonHandle(*const c_char);
+impl From<CommonHandle> for jni::sys::jlong {
+    fn from(handle: CommonHandle) -> Self {
+        handle.0 as *const u8 as jni::sys::jlong
+    }
+}
+
+/// Example wrapper macro that always uses a custom jni path and provides common type mappings
+macro_rules! my_native_method {
+    ($($tt:tt)*) => {
+        ::jni2::native_method! {
+            jni = ::jni2,
+            type_map = {
+                // Common types shared across all native methods
+                // These must be defined before the wrapper is used
+                crate::JBuiltinType => "com.example.CommonBuiltinType",
+                typealias JBuiltinType => crate::JBuiltinType,
+                // Common handle types shared across all native methods
+                unsafe CommonHandle => long,
+            },
+            $($tt)*
+        }
+    };
+}
+// For consistency, do the same for jni_sig! macro which we'll use to call the methods
+/* TODO: uncomment after landing JNI signature changes for method call APIs
+macro_rules! my_jni_sig {
+    ($($tt:tt)*) => {
+        ::jni2::jni_sig!(
+            jni = ::jni2,
+            type_map = {
+                crate::JBuiltinType => "com.example.CommonBuiltinType",
+                typealias JBuiltinType => crate::JBuiltinType,
+            },
+            $($tt)*
+        )
+    };
+}
+*/
+
+// and, for consistency, also rename the jni crate for the jni_str macro
+macro_rules! my_jni_str {
+    ($($tt:tt)*) => {
+        ::jni2::jni_str!(
+            jni = ::jni2,
+            $($tt)*
+        )
+    };
+}
+
+// Create an array of native methods using the wrapper macro
+const NATIVE_METHODS: &[NativeMethod] = &[
+    // Method using a handle type from the wrapper's type_map
+    my_native_method! {
+        fn JNativeMethodWrapper::process_resource(handle: CommonHandle) -> JString,
+    },
+    // Static method using a builtin type from the wrapper's type_map and an additional type_map entry
+    my_native_method! {
+        type_map = {
+            // Additional type mapping specific to this method
+            JCustomType => com.example.CustomType,
+        },
+        static fn JNativeMethodWrapper::mix_types(builtin: JBuiltinType, custom: JCustomType) -> JString,
+    },
+];
+
+// Implementation functions for native methods
+
+impl JNativeMethodWrapper<'_> {
+    fn process_resource<'local>(
+        env: &mut Env<'local>,
+        _this: JNativeMethodWrapper<'local>,
+        handle: CommonHandle,
+    ) -> Result<JString<'local>, MyError> {
+        // Safely: we assume the handle is a valid CStr pointer for this example
+        let c_str = unsafe { CStr::from_ptr(handle.0) };
+        let str_slice = c_str.to_str().map_err(MyError::InvalidUtf8)?;
+        let response = format!("Processed resource: {}", str_slice);
+        Ok(JString::from_str(env, response)?)
+    }
+
+    fn mix_types<'local>(
+        env: &mut Env<'local>,
+        _class: JClass<'local>,
+        _builtin: JBuiltinType<'local>,
+        _custom: JCustomType<'local>,
+    ) -> Result<JString<'local>, jni2::errors::Error> {
+        JString::new(env, "Mixed types successfully")
+    }
+}
+
+fn main() {
+    utils::attach_current_thread(|env| {
+        utils::load_class(env, "NativeMethodWrapper")?;
+
+        println!("=== native_method! Wrapper Example ===\n");
+
+        // Register native methods
+        println!("--- Registering Native Methods (via wrapper macro) ---");
+        let class = JNativeMethodWrapper::lookup_class(env, &LoaderContext::default())?;
+        let class: &JClass = &class;
+        unsafe {
+            env.register_native_methods(class, NATIVE_METHODS)?;
+        }
+        println!("Registered {} native methods", NATIVE_METHODS.len());
+
+        // Create an instance
+        println!("\n--- Creating Instance ---");
+        let obj = JNativeMethodWrapper::new(env)?;
+        println!("Created NativeMethodWrapper instance");
+
+        // Test process_resource with a CStr handle
+        println!("\n--- Testing process_resource ---");
+        let resource_data = c"my_resource_data";
+        let resource_handle = CommonHandle(resource_data.as_ptr());
+        let obj = env
+            .call_method(
+                &obj,
+                my_jni_str!("processResource"),
+                my_jni_str!("(J)Ljava/lang/String;"),
+                //my_jni_sig!((jlong)->JString), TODO
+                &[JValue::Long(resource_handle.into())],
+            )?
+            .l()?;
+        let s = JString::cast_local(obj, env)?;
+        println!("Result: {}", s.try_to_string(env)?);
+
+        // Test mix_types with JCommonBuiltinType and JCustomType
+        // Note: we refer to CustomType via the full Java type name here so we
+        // don't need to pass a type_map for just one usage
+        println!("\n--- Testing mix_types ---");
+        let builtin_obj = JBuiltinType::new(env)?;
+        let custom_obj = JCustomType::new(env)?;
+        let result = env
+            .call_static_method(
+                class,
+                my_jni_str!("mixTypes"),
+                my_jni_str!(
+                    "(Lcom/example/CommonBuiltinType;Lcom/example/CustomType;)Ljava/lang/String;"
+                ),
+                //my_jni_sig!((builtin: JBuiltinType, custom: com.example.CustomType)->JString), TODO
+                &[
+                    JValue::Object(&builtin_obj.into()),
+                    JValue::Object(&custom_obj.into()),
+                ],
+            )?
+            .l()?;
+        println!(
+            "Result: {}",
+            JString::cast_local(result, env)?.try_to_string(env)?
+        );
+
+        println!("\n=== Example completed successfully ===");
+        Ok(())
+    })
+    .expect("Failed to run example");
+}

--- a/jni-macros/examples/utils/lib.rs
+++ b/jni-macros/examples/utils/lib.rs
@@ -1,0 +1,179 @@
+#![allow(dead_code)]
+
+use std::path::{Path, PathBuf};
+use std::sync::Once;
+
+use jni::{Env, InitArgsBuilder, JNIVersion, JavaVM};
+
+pub fn jvm() -> JavaVM {
+    static INIT: Once = Once::new();
+    INIT.call_once(|| {
+        let jvm_args = InitArgsBuilder::new()
+            .version(JNIVersion::V1_8)
+            .option("-Xcheck:jni")
+            .build()
+            .unwrap_or_else(|e| panic!("{:#?}", e));
+
+        let _jvm = JavaVM::new(jvm_args).unwrap_or_else(|e| panic!("{:#?}", e));
+    });
+    JavaVM::singleton().expect("Failed to get singleton JVM")
+}
+
+pub fn attach_current_thread<F, T>(callback: F) -> jni::errors::Result<T>
+where
+    F: FnOnce(&mut Env) -> jni::errors::Result<T>,
+{
+    jvm().attach_current_thread(|env| callback(env))
+}
+
+fn setup_javac_output_dir() -> PathBuf {
+    let build_dir = if let Some(dir) = option_env!("JAVA_BUILD_DIR") {
+        PathBuf::from(dir)
+    } else {
+        let target_dir = if let Some(target_dir) = option_env!("CARGO_TARGET_DIR") {
+            PathBuf::from(target_dir)
+        } else if let Some(out_dir) = option_env!("OUT_DIR") {
+            // OUT_DIR is something like .../target/debug/build/jni-macros-xxxx/out
+            let mut path = PathBuf::from(out_dir);
+            while path.file_name().is_some() {
+                if path.file_name().unwrap() == "target" {
+                    break;
+                }
+                path.pop();
+            }
+            let cachedir_tag = path.join("CACHEDIR.TAG");
+            if !Path::exists(&cachedir_tag) {
+                panic!("Couldn't find 'target' directory from OUT_DIR");
+            }
+            path
+        } else {
+            PathBuf::from("target")
+        };
+        target_dir.join("examples-java-classes")
+    };
+
+    std::fs::create_dir_all(&build_dir)
+        .unwrap_or_else(|e| panic!("Failed to create javac output directory: {}", e));
+
+    build_dir
+}
+
+fn jni_macros_dir() -> PathBuf {
+    let manifest_dir =
+        std::env::var("CARGO_MANIFEST_DIR").expect("CARGO_MANIFEST_DIR not set in environment");
+    PathBuf::from(manifest_dir)
+}
+
+pub fn compile_class(name: &str) -> Vec<PathBuf> {
+    let out_dir = setup_javac_output_dir();
+    let jni_macros_dir = jni_macros_dir();
+
+    let path = jni_macros_dir
+        .join("examples/java/com/example")
+        .join(name)
+        .with_extension("java");
+    let files = javac::Build::new()
+        .file(path)
+        .output_dir(&out_dir)
+        .cargo_metadata(false) // don't output build.rs lines like "cargo:rerun-if-changed=..."
+        .compile();
+
+    println!("Compiled Java class {name}.java as: {:?}", files);
+    files
+}
+
+pub fn define_class(env: &mut Env, class_path: &Path) -> jni::errors::Result<()> {
+    use jni::strings::JNIStr;
+
+    let class_bytes = std::fs::read(class_path)
+        .unwrap_or_else(|_| panic!("Failed to read class file: {}", class_path.display()));
+
+    let class_loader = jni::objects::JClassLoader::get_system_class_loader(env)?;
+
+    env.define_class(Option::<&JNIStr>::None, &class_loader, &class_bytes)?;
+
+    Ok(())
+}
+
+pub fn load_class(env: &mut Env, name: &str) -> jni::errors::Result<()> {
+    let files = compile_class(name);
+    for class_file in &files {
+        define_class(env, class_file)?;
+    }
+    Ok(())
+}
+
+/// Define a stub Reference type for use in examples, without depending on
+/// the bind_java_type! macro.
+#[macro_export]
+macro_rules! define_stub_type {
+    ($rust_type:ident, $java_type:literal) => {
+        #[repr(transparent)]
+        #[derive(Default)]
+        struct $rust_type<'local>(JObject<'local>);
+        impl<'local> AsRef<JObject<'local>> for $rust_type<'local> {
+            fn as_ref(&self) -> &JObject<'local> {
+                &self.0
+            }
+        }
+        impl<'local> From<$rust_type<'local>> for JObject<'local> {
+            fn from(value: $rust_type<'local>) -> Self {
+                value.0
+            }
+        }
+        unsafe impl Reference for $rust_type<'_> {
+            type Kind<'local> = $rust_type<'local>;
+            type GlobalKind = $rust_type<'static>;
+
+            fn as_raw(&self) -> jni2::sys::jobject {
+                self.0.as_raw()
+            }
+
+            fn class_name() -> std::borrow::Cow<'static, jni2::strings::JNIStr> {
+                std::borrow::Cow::Borrowed(jni::jni_str!($java_type))
+            }
+
+            fn lookup_class<'caller>(
+                env: &Env<'_>,
+                loader_context: &jni2::refs::LoaderContext,
+            ) -> jni2::errors::Result<
+                impl std::ops::Deref<Target = jni2::refs::Global<JClass<'static>>> + 'caller,
+            > {
+                static CLASS: std::sync::OnceLock<jni::objects::Global<jni::objects::JClass>> =
+                    std::sync::OnceLock::new();
+
+                let class = if let Some(class) = CLASS.get() {
+                    class
+                } else {
+                    env.with_local_frame(4, |env| -> jni::errors::Result<_> {
+                        let class: jni::objects::JClass =
+                            loader_context.load_class_for_type::<Self>(env, false)?;
+                        let global_class = env.new_global_ref(&class)?;
+                        let _ = CLASS.set(global_class);
+                        Ok(CLASS.get().unwrap())
+                    })?
+                };
+
+                Ok(class)
+            }
+
+            unsafe fn kind_from_raw<'env>(reference: jni2::sys::jobject) -> Self::Kind<'env> {
+                unsafe { $rust_type(JObject::kind_from_raw(reference)) }
+            }
+
+            unsafe fn global_kind_from_raw(global_ref: jni2::sys::jobject) -> Self::GlobalKind {
+                unsafe { $rust_type(JObject::global_kind_from_raw(global_ref)) }
+            }
+        }
+        impl<'local> $rust_type<'local> {
+            #[allow(dead_code)]
+            pub fn new(env: &mut Env<'local>) -> jni2::errors::Result<Self> {
+                let class = Self::lookup_class(env, &jni2::refs::LoaderContext::default())?;
+                let class: &JClass = class.as_ref();
+                let obj = env.new_object(class, jni::jni_str!("()V"), &[])?;
+                //let obj = env.new_object(class, jni::jni_sig!("()V"), &[])?;
+                Ok(Self(obj))
+            }
+        }
+    };
+}

--- a/jni-macros/src/lib.rs
+++ b/jni-macros/src/lib.rs
@@ -1,4 +1,5 @@
 mod mangle;
+mod native_method;
 mod signature;
 mod str;
 mod types;
@@ -86,6 +87,9 @@ pub fn jni_cstr(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
 /// validate them at compile time but it's recommended to use the structured syntax for better
 /// readability.
 ///
+/// **Note:** The signature and `type_map` syntax supported by this macro is also used by the
+/// [`native_method`] macro.
+///
 /// [MethodSignature]: https://docs.rs/jni/latest/jni/signature/struct.MethodSignature.html
 /// [FieldSignature]: https://docs.rs/jni/latest/jni/signature/struct.FieldSignature.html
 ///
@@ -115,6 +119,8 @@ pub fn jni_cstr(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
 /// without needing to parse anything else.
 ///
 /// # Type Syntax
+///
+/// Note: this syntax for signature types is also used by the  [`native_method`] macro.
 ///
 /// ## Primitive Types
 /// - Java primitives: `jboolean`, `jbyte`, `jchar`, `jshort`, `jint`, `jlong`, `jfloat`, `jdouble`
@@ -153,7 +159,7 @@ pub fn jni_cstr(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
 ///
 /// A `type_map` block:
 /// - Maps Rust [Reference] type names to Java class names for use in method/field signatures.
-/// - Maps Java class names to Rust types
+/// - Maps Java class names to Rust types (primarily for use with the [`native_method`] macro)
 /// - Allows the definition of type aliases for more ergonomic / readable signatures.
 ///
 /// Multiple `type_map` blocks will be merged, so that wrapper macros may forward-declare common
@@ -191,8 +197,8 @@ pub fn jni_cstr(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
 /// }
 /// ```
 ///
-/// These mappings are marked `unsafe` because it's not possible to verify the safety of casting
-/// between the Rust type and Java primitive type - apart from checking the size and alignment.
+/// These mappings are marked `unsafe` since there's no way to automatically verify that these are
+/// FFI-safe types - apart from checking the size and alignment.
 ///
 /// ### Type Aliases
 ///
@@ -620,4 +626,555 @@ pub fn jni_mangle(
     item: proc_macro::TokenStream,
 ) -> proc_macro::TokenStream {
     mangle::jni_mangle2(attr.into(), item.into()).into()
+}
+
+/// Create a compile-time type-checked `NativeMethod` for registering native methods with the JVM.
+///
+/// This macro generates a [`NativeMethod`] struct with compile-time guarantees that the Rust
+/// function matches the JNI signature. It can optionally:
+/// - Wrap implementations with panic safety (`catch_unwind`) and error handling
+/// - Generate JNI export symbols for automatic JVM resolution
+/// - Perform runtime ABI checks to ensure static/instance methods are registered correctly
+///
+/// This macro provides strong type safety for implementing individual native methods.
+///
+/// [`NativeMethod`]: https://docs.rs/jni/latest/jni/struct.NativeMethod.html
+///
+/// # Quick Example
+///
+/// ```
+/// # use jni::{Env, native_method, objects::JObject, sys::jint};
+/// // Instance method with default settings
+/// const ADD_METHOD: jni::NativeMethod = native_method! {
+///     java_type = "com.example.MyClass",
+///     extern fn native_add(a: jint, b: jint) -> jint,
+/// };
+/// // Will export `Java_com_example_MyClass_nativeAdd__II` symbol and
+/// // `ADD_METHOD` can be passed to `Env::register_native_methods`
+///
+/// fn native_add<'local>(
+///     _env: &mut Env<'local>,
+///     _this: JObject<'local>,
+///     a: jint,
+///     b: jint,
+/// ) -> Result<jint, jni::errors::Error> {
+///     Ok(a + b)
+/// }
+/// ```
+///
+/// # Syntax Overview
+///
+/// The macro supports both property-based and shorthand syntax, which can be combined:
+///
+/// ```ignore
+/// native_method! {
+///     [java_type = "com.example.MyClass",]  // For exports (required with `extern` or `export = true`)
+///     [rust_type = CustomType,]             // Type for 'this' (default: JObject)
+///     [static] [raw] [extern] fn [RustType::]method_name(args) -> ret, // Shorthand signature
+///     [fn = implementation_fn,]             // Function path (default: RustType::method_name from shorthand)
+///     [... other properties ...]
+/// }
+/// ```
+///
+/// # Generated Code
+///
+/// The macro generates a `const` block containing:
+/// 1. A type-checked wrapper function
+/// 2. An optional runtime type-check for the second parameter (to distinguish static vs instance
+///    methods)
+/// 3. An optional export function with a mangled JNI name
+/// 4. A `NativeMethod` struct created via `NativeMethod::from_raw_parts`
+///
+/// For non-raw methods with the default settings:
+///
+/// ```ignore
+/// const {
+///     // Generated wrapper with panic safety and error handling
+///     extern "system" fn __native_method_wrapper<'local>(
+///         mut unowned_env: EnvUnowned<'local>,
+///         this: JObject<'local>,
+///         a: jint,
+///         b: jint,
+///     ) -> jint {
+///         // One-time ABI check: validates that 'this' is NOT a Class (i.e., instance method)
+///         static _ABI_CHECK: ::std::sync::Once = ::std::sync::Once::new();
+///         _ABI_CHECK.call_once(|| {
+///             // ... check that second parameter is not java.lang.Class ...
+///         });
+///
+///         unowned_env
+///             .with_env(|env| {
+///                 // Call your implementation
+///                 native_add(env, this, a, b)
+///             })
+///             .resolve::<ThrowRuntimeExAndDefault>()
+///     }
+///
+///     unsafe {
+///         NativeMethod::from_raw_parts(
+///             jni_str!("nativeAdd"),
+///             jni_str!("(II)I"),
+///             __native_method_wrapper as *mut c_void,
+///         )
+///     }
+/// }
+/// ```
+///
+/// With `export = true` or `extern` qualifier, an additional export function is generated:
+///
+/// ```ignore
+/// #[export_name = "Java_com_example_MyClass_nativeAdd__II"]
+/// pub extern "system" fn __native_method_export<'local>(...) -> jint {
+///     __native_method_wrapper(...)
+/// }
+/// ```
+///
+/// # Property Reference
+///
+/// ## `java_type` - Java Class Name
+///
+/// **Required** when using `export = true` or the `extern` qualifier.
+///
+/// The fully-qualified Java class name containing this native method.
+///
+/// ```ignore
+/// java_type = "com.example.MyClass"
+/// ```
+///
+/// Can also be specified as dot-separated identifiers:
+/// ```ignore
+/// java_type = com.example.MyClass
+/// ```
+///
+/// See the 'Java Object Types' section in the [`jni_sig!`] documentation for details on how to
+/// specify Java types, including inner classes and default-package classes.
+///
+/// ## `rust_type` - Custom Type for 'this' Parameter
+///
+/// For instance methods, specifies the Rust type for the `this` parameter. Defaults to `JObject`.
+///
+/// ```ignore
+/// rust_type = MyCustomType
+/// ```
+///
+/// This type must implement `jni::refs::Reference`.
+///
+/// ## Shorthand Signature
+///
+/// The shorthand syntax allows specifying method details in a function-like form:
+///
+/// ```ignore
+/// [static] [raw] [extern] fn [RustType::]method_name(args) -> ret
+/// ```
+///
+/// Where:
+/// - `static` - Static method (receives `class: JClass` instead of `this`)
+/// - `raw` - No panic safety wrapper, receives `EnvUnowned`, returns value directly (not `Result`)
+/// - `extern` - Generate JNI export symbol (requires `java_type`)
+/// - `RustType::` - If present, sets `rust_type = RustType` and defaults `fn =
+///   RustType::method_name`
+/// - `method_name` - Converted from snake_case to lowerCamelCase for the Java method name
+///
+/// and the `args` and `ret` specify the method signature using the syntax from [`jni_sig!`].
+///
+/// Example:
+/// ```
+/// # use jni::{Env, native_method, sys::jint};
+/// # struct MyType<'a>(std::marker::PhantomData<&'a ()>);
+/// const METHOD: jni::NativeMethod = native_method! {
+///     static fn MyType::compute_sum(a: jint, b: jint) -> jint,
+/// };
+///
+/// impl MyType<'_> {
+///     fn compute_sum<'local>(
+///         _env: &mut Env<'local>,
+///         _class: jni::objects::JClass<'local>,
+///         a: jint,
+///         b: jint,
+///     ) -> Result<jint, jni::errors::Error> {
+///         Ok(a + b)
+///     }
+/// }
+/// ```
+///
+/// ## `fn` - Implementation Function Path
+///
+/// Path to the Rust function implementing this native method. Defaults to `RustType::method_name`
+/// or `method_name` if a shorthand signature is given.
+///
+/// ```ignore
+/// fn = my_module::my_implementation
+/// ```
+///
+/// ## `name` - Java Method Name
+///
+/// The Java method name as a string literal. Defaults to the `method_name` name converted from
+/// `snake_case` to `lowerCamelCase` if a shorthand signature is given.
+///
+/// ```ignore
+/// name = "customMethodName"
+/// ```
+///
+/// ## `sig` / Method Signature
+///
+/// Typically the signature will come from the shorthand syntax, but it can also be specified
+/// explicitly via the `sig` property.
+///
+/// The method signature using the syntax from [`jni_sig!`].
+///
+/// ```ignore
+/// sig = (param1: jint, param2: JString) -> jboolean
+/// // or shorthand (part of function-like syntax):
+/// fn my_method(param1: jint, param2: JString) -> jboolean
+/// ```
+///
+/// ## `type_map` - Type Mappings
+///
+/// Optional type mappings for custom Rust types. See [`jni_sig!`] for full syntax.
+///
+/// ```ignore
+/// type_map = {
+///     CustomType => com.example.CustomClass,
+///     unsafe HandleType => long,
+/// }
+/// ```
+///
+/// ## `static` - Static Method Flag
+///
+/// Indicates a static method. The second parameter will be `class: JClass` instead of a `this`
+/// object.
+///
+/// ```ignore
+/// static = true
+/// // or as qualifier:
+/// static fn my_method() -> jint
+/// ```
+///
+/// ## `raw` - Raw Function Flag
+///
+/// When `raw = true` or the `raw` qualifier is used:
+/// - Function receives `EnvUnowned<'local>` (not `&mut Env<'local>`)
+/// - Function returns the value directly (not `Result`)
+/// - No panic safety wrapper (`catch_unwind`)
+/// - No automatic error handling
+///
+/// ```ignore
+/// raw = true
+/// // or as qualifier:
+/// raw fn my_method(value: jint) -> jint
+/// ```
+///
+/// Raw function signature:
+/// ```ignore
+/// fn my_raw_method<'local>(
+///     env: EnvUnowned<'local>,
+///     this: JObject<'local>,
+///     value: jint,
+/// ) -> jint {
+///     value * 2
+/// }
+/// ```
+///
+/// ## `export` - JNI Export Symbol
+///
+/// Controls whether a JNI export symbol is generated:
+/// - `true` - Generate auto-mangled JNI export name (e.g., `Java_com_example_Class_method__II`)
+/// - `false` - Don't generate export
+/// - `"CustomName"` - Use custom export name
+///
+/// Specifying the `extern` qualifier is equivalent to `export = true`.
+///
+/// **Note:** `java_type` must be provided when `export = true` or the `extern` qualifier is used.
+///
+/// ```ignore
+/// export = true
+/// // or as qualifier:
+/// extern fn my_method() -> jint
+/// // or with custom name:
+/// export = "Java_custom_Name"
+/// ```
+///
+/// ## `error_policy` - Error Handling Policy
+///
+/// For non-raw methods, specifies how to convert `Result` errors to JNI exceptions. Default is
+/// `ThrowRuntimeExAndDefault`.
+///
+/// Built-in policies:
+/// - `jni::errors::ThrowRuntimeExAndDefault` - Throws `RuntimeException`, returns default value
+/// - `jni::errors::LogErrorAndDefault` - Logs error, returns default value
+///
+/// Or implement your own policy by implementing the `jni::errors::ErrorPolicy` trait.
+///
+/// ```ignore
+/// error_policy = jni::errors::LogErrorAndDefault
+/// ```
+///
+/// ## `catch_unwind` - Panic Safety
+///
+/// For non-raw methods, controls whether panics are caught and converted to Java exceptions.
+/// Default is `true`.
+///
+/// - `true` - Use `EnvUnowned::with_env` (catches panics)
+/// - `false` - Use `EnvUnowned::with_env_no_catch` (panics will abort when crossing FFI boundary)
+///
+/// ```ignore
+/// catch_unwind = false
+/// ```
+///
+/// **Note:** Not applicable to raw methods (which never have panic safety).
+///
+/// ## `abi_check` - Runtime ABI Validation
+///
+/// Controls runtime validation that the method is registered correctly as static/instance.
+///
+/// Values:
+/// - `Always` - Always check (default)
+/// - `UnsafeNever` - Never check (unsafe micro-optimization, for production if needed)
+/// - `UnsafeDebugOnly` - Check only in debug builds (unsafe micro-optimization, for production if
+///   needed)
+///
+/// ```ignore
+/// abi_check = Always
+/// ```
+///
+/// The check validates that the second parameter (`this` for instance, `class` for static) matches
+/// how Java called the method. This is performed once per method via `std::sync::Once`.
+///
+/// Check failures for non-raw methods will throw an error that will be mapped via the specified
+/// error handling policy. For raw methods, a panic will occur, which will abort at the FFI
+/// boundary.
+///
+/// ## `jni` - Override JNI Crate Path
+///
+/// Override the path to the `jni` crate. Must be the first property if provided.
+///
+/// ```ignore
+/// jni = ::my_jni_crate
+/// ```
+///
+/// # Function Signature Requirements
+///
+/// ## Non-raw (Default)
+///
+/// Instance method:
+/// ```ignore
+/// fn<'local>(
+///     env: &mut Env<'local>,
+///     this: RustType<'local>,  // Or JObject<'local>
+///     param1: jint,
+///     param2: JString<'local>,
+///     ...
+/// ) -> Result<ReturnType, E>
+/// where E: Into<jni::errors::Error>
+/// ```
+///
+/// Static method:
+/// ```ignore
+/// fn<'local>(
+///     env: &mut Env<'local>,
+///     class: JClass<'local>,
+///     param1: jint,
+///     ...
+/// ) -> Result<ReturnType, E>
+/// where E: Into<jni::errors::Error>
+/// ```
+///
+/// ## Raw
+///
+/// Instance method:
+/// ```ignore
+/// fn<'local>(
+///     env: EnvUnowned<'local>,
+///     this: RustType<'local>,  // Or JObject<'local>
+///     param1: jint,
+///     ...
+/// ) -> ReturnType
+/// ```
+///
+/// Static method:
+/// ```ignore
+/// fn<'local>(
+///     env: EnvUnowned<'local>,
+///     class: JClass<'local>,
+///     param1: jint,
+///     ...
+/// ) -> ReturnType
+/// ```
+///
+/// # Complete Examples
+///
+/// ## Basic Static Method
+///
+/// ```
+/// # use jni::{Env, native_method, objects::JClass, sys::jint};
+/// const METHOD: jni::NativeMethod = native_method! {
+///     static fn native_compute(value: jint) -> jint,
+/// };
+///
+/// fn native_compute<'local>(
+///     _env: &mut Env<'local>,
+///     _class: JClass<'local>,
+///     value: jint,
+/// ) -> Result<jint, jni::errors::Error> {
+///     Ok(value * 100)
+/// }
+/// ```
+///
+/// ## Instance Method with Custom Type
+///
+/// ```
+/// # use jni::{Env, native_method, sys::jint};
+/// # struct Calculator<'a>(std::marker::PhantomData<&'a ()>);
+/// const METHOD: jni::NativeMethod = native_method! {
+///     fn Calculator::multiply(a: jint, b: jint) -> jint,
+/// #   abi_check = UnsafeNever, // because Calculator isn't a real Reference type
+/// };
+///
+/// impl Calculator<'_> {
+///     fn multiply<'local>(
+///         _env: &mut Env<'local>,
+///         _this: Calculator<'local>,
+///         a: jint,
+///         b: jint,
+///     ) -> Result<jint, jni::errors::Error> {
+///         Ok(a * b)
+///     }
+/// }
+/// ```
+///
+/// ## Exported Method with Type Mapping
+///
+/// ```
+/// # use jni::{Env, native_method, objects::JString, sys::jint};
+/// # struct MyHandle(*const u8);
+/// # impl From<MyHandle> for jni::sys::jlong { fn from(h: MyHandle) -> jni::sys::jlong { h.0 as jni::sys::jlong } }
+/// # struct MyType<'a>(std::marker::PhantomData<&'a ()>);
+/// const METHOD: jni::NativeMethod = native_method! {
+///     java_type = "com.example.MyClass",
+///     type_map = {
+///         unsafe MyHandle => long,
+///     },
+///     extern fn MyType::process(handle: MyHandle) -> JString,
+/// #   abi_check = UnsafeNever, // because MyType isn't a real Reference type
+/// };
+///
+/// impl MyType<'_> {
+///     fn process<'local>(
+///         env: &mut Env<'local>,
+///         _this: MyType<'local>,
+///         handle: MyHandle,
+///     ) -> Result<JString<'local>, jni::errors::Error> {
+///         JString::from_str(env, "processed")
+///     }
+/// }
+/// ```
+///
+/// ## Raw Method (No Wrapping)
+///
+/// ```
+/// # use jni::{EnvUnowned, native_method, objects::JObject, sys::jint};
+/// const METHOD: jni::NativeMethod = native_method! {
+///     raw fn fast_compute(value: jint) -> jint,
+/// };
+///
+/// fn fast_compute<'local>(
+///     _env: EnvUnowned<'local>,
+///     _this: JObject<'local>,
+///     value: jint,
+/// ) -> jint {
+///     value * 2
+/// }
+/// ```
+///
+/// ## Array of Methods for Registration
+///
+/// ```
+/// # use jni::{Env, EnvUnowned, NativeMethod, native_method};
+/// # use jni::objects::{JClass, JObject, JString};
+/// # use jni::sys::jint;
+/// const METHODS: &[NativeMethod] = &[
+///     native_method! {
+///         fn add(a: jint, b: jint) -> jint,
+///     },
+///     native_method! {
+///         fn greet(name: JString) -> JString,
+///     },
+///     native_method! {
+///         static fn get_version() -> jint,
+///     },
+///     native_method! {
+///         raw fn fast_path(value: jint) -> jint,
+///     },
+/// ];
+///
+/// fn add<'local>(
+///     _env: &mut Env<'local>, _this: JObject<'local>, a: jint, b: jint
+/// ) -> Result<jint, jni::errors::Error> { Ok(a + b) }
+///
+/// fn greet<'local>(
+///     env: &mut Env<'local>, _this: JObject<'local>, name: JString<'local>
+/// ) -> Result<JString<'local>, jni::errors::Error> {
+///     JString::from_str(env, &format!("Hello, {}", name.try_to_string(env)?))
+/// }
+///
+/// fn get_version<'local>(
+///     _env: &mut Env<'local>, _class: JClass<'local>
+/// ) -> Result<jint, jni::errors::Error> { Ok(1) }
+///
+/// fn fast_path<'local>(
+///     _env: EnvUnowned<'local>, _this: JObject<'local>, value: jint
+/// ) -> jint { value }
+///
+/// fn register_native_methods<'local>(
+///     env: &mut Env<'local>,
+///     class: JClass<'local>,
+/// ) -> Result<(), jni::errors::Error> {
+///     unsafe { env.register_native_methods(class, METHODS) }
+/// }
+/// ```
+///
+/// # Type Safety
+///
+/// The macro ensures compile-time type safety by:
+/// - Generating an `extern "system"` wrapper that has the correct ABI for registration with the
+///   associated JNI signature
+/// - Type-checking arguments when calling your implementation function
+/// - Rejecting mismatches between the JNI signature and Rust types
+///
+/// **Important:** The macro cannot determine if a method is `static` or instance at compile time.
+/// You must specify `static` correctly to ensure the second parameter type (`JClass` vs `JObject`)
+/// matches. The `abi_check` property (enabled by default) adds runtime validation to catch
+/// registration errors.
+///
+/// # Wrapper Macros
+///
+/// You can create wrapper macros to inject common configuration:
+///
+/// ```
+/// # extern crate jni as jni2;
+/// macro_rules! my_native_method {
+///     ($($tt:tt)*) => {
+///         ::jni2::native_method! {
+///             jni = ::jni2,
+///             type_map = {
+///                 // Common type mappings
+///             },
+///             $($tt)*
+///         }
+///     };
+/// }
+/// ```
+///
+/// # See Also
+///
+/// - [`NativeMethod`] - The struct created by this macro
+/// - [`jni_sig!`] - Signature syntax reference
+/// - [`jni_mangle`] - Lower-level attribute macro for exports
+///
+/// [`NativeMethod`]: https://docs.rs/jni/latest/jni/struct.NativeMethod.html
+#[proc_macro]
+pub fn native_method(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
+    native_method::native_method_impl(input.into())
+        .unwrap_or_else(|e| e.to_compile_error())
+        .into()
 }

--- a/jni-macros/src/native_method.rs
+++ b/jni-macros/src/native_method.rs
@@ -1,0 +1,707 @@
+//! Procedural macros for generating compile-time type-checked NativeMethod
+//! structs
+//!
+//! This module implements the `native_method!` macro that create `NativeMethod`
+//! descriptors with compile-time guarantees that the function pointer matches
+//! the JNI signature.
+
+use proc_macro2::TokenStream;
+use quote::quote;
+use syn::{
+    Ident, Result, Token, custom_keyword,
+    ext::IdentExt,
+    parse::{Parse, ParseStream},
+};
+
+use crate::types::{TypeMappings, parse_type};
+use crate::types::{generate_type_mapping_checks, sig_type_to_rust_type_core};
+use crate::{
+    mangle::{create_jni_fn_name, snake_case_to_lower_camel_case},
+    types::SigType,
+};
+use crate::{
+    signature::{MethodSignature, parse_method_sig, parse_parameter_with_index},
+    types::AbiCheck,
+};
+use crate::{str::lit_cstr_mutf8, types::JavaClassName};
+
+custom_keyword!(jni);
+custom_keyword!(rust_type);
+custom_keyword!(java_type);
+custom_keyword!(name);
+custom_keyword!(sig);
+custom_keyword!(type_map);
+custom_keyword!(error);
+custom_keyword!(error_policy);
+custom_keyword!(export);
+custom_keyword!(raw);
+custom_keyword!(abi_check);
+custom_keyword!(catch_unwind);
+
+/// Represents the export behavior for a native method
+#[derive(Clone)]
+pub enum NativeMethodExport {
+    /// Use the default behavior
+    #[allow(unused)]
+    Default,
+    /// Don't export this method (override global setting)
+    No,
+    /// Export with automatically mangled JNI name
+    WithAutoMangle,
+    /// Export with explicitly provided name
+    WithName(String),
+}
+
+/// Input structure for native_method!
+struct NativeMethodStructInput {
+    #[allow(dead_code)]
+    is_static: bool,
+    jni_crate: syn::Path,
+    rust_type: Option<syn::Path>,
+    /// Java class name for export (e.g., "com.example.MyClass")
+    java_type: Option<JavaClassName>,
+    java_method_name: String,
+    method_signature: MethodSignature,
+    fn_path: syn::Path,
+    type_mappings: TypeMappings,
+    /// true if `raw = true` or `raw` qualifier with inline signature
+    is_raw_fn: bool,
+    /// Only used when is_raw_fn is false
+    error_policy: Option<Ident>,
+    /// `WithAutoMangle` if `export = true` or `extern` qualifier with inline signature
+    export: NativeMethodExport,
+    /// ABI check policy, for checking the type of the 'this'/'class' parameter at runtime
+    abi_check: AbiCheck,
+    /// non-raw wrapper uses `EnvUnowned::with_env` if true, else `with_env_no_catch`
+    catch_unwind: bool,
+}
+
+impl NativeMethodStructInput {
+    fn parse(input: ParseStream) -> Result<Self> {
+        // Try to detect jni crate path using parse_jni_crate_override
+        let jni_crate = crate::utils::parse_jni_crate_override(&input)?;
+
+        let mut rust_type_opt = None;
+        let mut java_type_opt = None;
+        let mut type_mappings = TypeMappings::new(&jni_crate);
+        let mut error_policy_ident = None;
+
+        let mut is_static_fn = false;
+        let mut is_raw_fn = false;
+        let mut export_opt = NativeMethodExport::No;
+        let mut abi_check = AbiCheck::default();
+        let mut catch_unwind = None;
+
+        let mut java_method_name = None;
+        let mut method_signature = None;
+        let mut inline_fn_path = None;
+        let mut fn_path = None;
+
+        // Parse properties and inline signature
+        while !input.is_empty() {
+            // Try to peek for <ident> = pattern or <ident> { ... }
+            // (anything else is treated as inline signature)
+            let fork = input.fork();
+            let is_prop = if let Ok(_ident) = fork.call(Ident::parse_any) {
+                fork.peek(Token![=]) || fork.peek(syn::token::Brace)
+            } else {
+                false
+            };
+
+            if is_prop {
+                // Parse as property: <ident> = <value> or <ident> { ... }
+                let lookahead = input.lookahead1();
+
+                if lookahead.peek(rust_type) {
+                    // Parse: rust_type = Type
+                    input.parse::<rust_type>()?;
+                    input.parse::<Token![=]>()?;
+                    rust_type_opt = Some(input.parse::<syn::Path>()?);
+                } else if lookahead.peek(java_type) {
+                    // Parse: java_type = "com.example.MyClass"
+                    input.parse::<java_type>()?;
+                    input.parse::<Token![=]>()?;
+                    let class_name = input.parse::<JavaClassName>()?;
+                    java_type_opt = Some(class_name);
+                } else if lookahead.peek(name) {
+                    // Parse: name = "methodName"
+                    input.parse::<name>()?;
+                    input.parse::<Token![=]>()?;
+                    let lit = input.parse::<syn::LitStr>()?;
+                    java_method_name = Some(lit.value());
+                } else if lookahead.peek(sig) {
+                    // Parse: sig = (args) -> ret
+                    method_signature = Some(parse_method_sig(input, &type_mappings)?);
+                } else if lookahead.peek(Token![static]) {
+                    // Parse: static = true/false
+                    input.parse::<Token![static]>()?;
+                    input.parse::<Token![=]>()?;
+                    let lit = input.parse::<syn::LitBool>()?;
+                    is_static_fn = lit.value();
+                } else if lookahead.peek(raw) {
+                    // Parse: raw = true/false
+                    input.parse::<raw>()?;
+                    input.parse::<Token![=]>()?;
+                    let lit = input.parse::<syn::LitBool>()?;
+                    is_raw_fn = lit.value();
+                } else if lookahead.peek(export) {
+                    // Parse: export = true/false/"name"
+                    input.parse::<export>()?;
+                    input.parse::<Token![=]>()?;
+                    if input.peek(syn::LitStr) {
+                        // export = "customName"
+                        let name = input.parse::<syn::LitStr>()?.value();
+                        export_opt = NativeMethodExport::WithName(name);
+                    } else if input.peek(syn::LitBool) {
+                        // export = true or export = false
+                        let lit_bool = input.parse::<syn::LitBool>()?;
+                        export_opt = if lit_bool.value() {
+                            NativeMethodExport::WithAutoMangle
+                        } else {
+                            NativeMethodExport::No
+                        };
+                    } else {
+                        return Err(syn::Error::new(
+                            input.span(),
+                            "export must be 'true', 'false', or a string literal",
+                        ));
+                    }
+                } else if lookahead.peek(self::abi_check) {
+                    // Parse: abi_check = Always | UnsafeNever | UnsafeDebugOnly
+                    input.parse::<self::abi_check>()?;
+                    input.parse::<Token![=]>()?;
+                    abi_check = input.parse::<AbiCheck>()?;
+                } else if lookahead.peek(self::catch_unwind) {
+                    // Parse: catch_unwind = true/false
+                    input.parse::<self::catch_unwind>()?;
+                    input.parse::<Token![=]>()?;
+                    let lit = input.parse::<syn::LitBool>()?;
+                    catch_unwind = Some(lit.value());
+                } else if lookahead.peek(Token![fn]) {
+                    // Parse: fn = path_to_fn
+                    input.parse::<Token![fn]>()?;
+                    input.parse::<Token![=]>()?;
+
+                    fn_path = Some(input.parse::<syn::Path>()?);
+                } else if lookahead.peek(error_policy) {
+                    // Parse: error_policy = ErrorPolicyIdent
+                    input.parse::<error_policy>()?;
+                    input.parse::<Token![=]>()?;
+                    error_policy_ident = Some(input.parse::<Ident>()?);
+                } else if lookahead.peek(type_map) {
+                    // Parse: type_map = { ... }
+                    input.parse::<type_map>()?;
+                    type_mappings.parse_mappings(input)?;
+                } else {
+                    return Err(lookahead.error());
+                }
+            } else {
+                // Parse inline signature: [static] [raw] [extern] fn [Path::][method](args) -> ret
+
+                // Parse qualifiers in any order (static, raw, extern)
+                loop {
+                    if input.peek(Token![static]) {
+                        input.parse::<Token![static]>()?;
+                        is_static_fn = true;
+                    } else if input.peek(Token![extern]) {
+                        input.parse::<Token![extern]>()?;
+                        // give export = true | "name" higher precedence
+                        if matches!(export_opt, NativeMethodExport::No) {
+                            export_opt = NativeMethodExport::WithAutoMangle;
+                        }
+                    } else if input.peek(raw) {
+                        input.parse::<raw>()?;
+                        is_raw_fn = true;
+                    } else {
+                        break;
+                    }
+                }
+
+                // Require 'fn' keyword for both shorthand and block syntax
+                if !input.peek(Token![fn]) {
+                    return Err(syn::Error::new(
+                        input.span(),
+                        "Expected 'fn' keyword before RustType::method_name",
+                    ));
+                }
+                input.parse::<Token![fn]>()?;
+
+                // Try to parse a path followed by parentheses
+                let full_path = input.parse::<syn::Path>()?;
+                inline_fn_path = Some(full_path.clone());
+
+                // Check if this path has multiple segments (Type::method pattern)
+                let segments: Vec<_> = full_path.segments.iter().collect();
+
+                let (type_path_opt, method_name_from_path) = if segments.len() >= 2 {
+                    // Split into type path and method name
+                    let method_ident = &segments[segments.len() - 1].ident;
+                    let method_name_snake = method_ident.to_string();
+
+                    // Build the type path (everything except the last segment)
+                    let type_segments = &segments[..segments.len() - 1];
+                    let mut type_path = syn::Path {
+                        leading_colon: full_path.leading_colon,
+                        segments: syn::punctuated::Punctuated::new(),
+                    };
+                    for seg in type_segments {
+                        type_path.segments.push((*seg).clone());
+                    }
+
+                    (Some(type_path), method_name_snake)
+                } else {
+                    // Single segment - just a method name
+                    (None, segments[0].ident.to_string())
+                };
+
+                // Parse method signature: (args) -> ret
+                let args_content;
+                syn::parenthesized!(args_content in input);
+
+                let mut parameters = Vec::new();
+                let mut param_index = 0;
+
+                while !args_content.is_empty() {
+                    let param =
+                        parse_parameter_with_index(&args_content, param_index, &type_mappings)?;
+                    parameters.push(param);
+                    param_index += 1;
+
+                    if !args_content.is_empty() {
+                        args_content.parse::<Token![,]>()?;
+                    }
+                }
+
+                let return_type = if input.peek(Token![->]) {
+                    input.parse::<Token![->]>()?;
+                    parse_type(input, &type_mappings)?
+                } else {
+                    // No return type means this is constructor shorthand - use void
+                    SigType::Alias("void".to_string())
+                };
+
+                method_signature = Some(MethodSignature {
+                    parameters,
+                    return_type,
+                });
+
+                // Set values from parsed signature
+                if type_path_opt.is_some() && rust_type_opt.is_none() {
+                    rust_type_opt = type_path_opt;
+                }
+
+                if java_method_name.is_none() {
+                    // Convert snake_case to lowerCamelCase for Java method name
+                    java_method_name = Some(snake_case_to_lower_camel_case(&method_name_from_path));
+                }
+
+                // fn = <path> takes precedence over the default RustType::method_name path
+                if fn_path.is_none() {
+                    fn_path = full_path.clone().into();
+                } else if fn_path.is_none() {
+                    // Default to the full path if no => was given
+                    fn_path = Some(full_path.clone());
+                }
+            }
+
+            // Optional trailing comma
+            if !input.is_empty() {
+                input.parse::<Token![,]>()?;
+            }
+        }
+
+        // Validate required properties
+        let method_name = java_method_name.ok_or_else(|| {
+            syn::Error::new(
+                input.span(),
+                "Missing method name (use 'name = \"javaCamelCaseName\"' or inline signature like 'fn RustType::snake_case_method_name()')",
+            )
+        })?;
+        let method_signature = method_signature.ok_or_else(|| {
+            syn::Error::new(
+                input.span(),
+                "Missing method signature (use 'sig = (args...) -> ret' or inline signature like 'fn RustType::method_name(args...) -> ret')",
+            )
+        })?;
+        // fn = <path> takes precedence over the default RustType::method_name path from an inline signature
+        let fn_path = if let Some(fn_path) = fn_path {
+            fn_path
+        } else {
+            if inline_fn_path.is_none() {
+                return Err(syn::Error::new(
+                    input.span(),
+                    "Missing 'fn' and can't infer a default function path without an inline signature like 'fn RustType::method_name(args..) -> ret'.",
+                ));
+            }
+            inline_fn_path.clone().unwrap()
+        };
+
+        // Validate: java_type required if export = true
+        if matches!(export_opt, NativeMethodExport::WithAutoMangle) && java_type_opt.is_none() {
+            return Err(syn::Error::new(
+                input.span(),
+                "java_type = \"...\" is required when 'export = true' or 'extern' qualifier is used in signature",
+            ));
+        }
+
+        // Validate that error / error_policy / catch_unwind are not specified with raw = true
+        if is_raw_fn {
+            if error_policy_ident.is_some() {
+                return Err(syn::Error::new(
+                    input.span(),
+                    "Cannot specify 'error_policy' when using 'raw = true' or 'raw' in signature - error_policy only applies to wrapped functions",
+                ));
+            }
+            if catch_unwind.is_some() {
+                return Err(syn::Error::new(
+                    input.span(),
+                    "Cannot specify 'catch_unwind' when using 'raw = true' or 'raw' in signature - catch_unwind only applies to wrapped functions",
+                ));
+            }
+        }
+
+        Ok(NativeMethodStructInput {
+            is_static: is_static_fn,
+            jni_crate,
+            rust_type: rust_type_opt,
+            java_type: java_type_opt,
+            java_method_name: method_name,
+            method_signature,
+            fn_path,
+            type_mappings,
+            is_raw_fn,
+            error_policy: error_policy_ident,
+            export: export_opt,
+            abi_check,
+            catch_unwind: catch_unwind.unwrap_or(true),
+        })
+    }
+}
+
+impl Parse for NativeMethodStructInput {
+    fn parse(input: ParseStream) -> Result<Self> {
+        Self::parse(input)
+    }
+}
+
+pub fn generate_native_method_abi_check(
+    jni: &syn::Path,
+    method_name: &str,
+    need_abi_check: AbiCheck,
+    is_raw: bool,
+    is_static: bool,
+    check_type_mappings: Option<&TypeMappings>,
+) -> TokenStream {
+    if !need_abi_check.requires_abi_check() {
+        return quote! {};
+    }
+
+    // Check at runtime that the method was correctly registered as static or instance
+    // We assume this can't change dynamically so we use Once to only check once
+    let abi_check_ensure_env = if is_raw {
+        quote! {
+            let mut _guard = unsafe {
+                #jni::AttachGuard::from_unowned(unowned_env.as_raw())
+            };
+            let env: &mut #jni::Env<'local> = _guard.borrow_env_mut();
+        }
+    } else {
+        quote! {}
+    };
+    let abi_assertion = if is_static {
+        quote! {
+            let is_class_reciever = env.is_instance_of(&class, lang_class_class).expect("Failed to check 2nd arg type for native method ABI check");
+            assert!(is_class_reciever, "Native method '{}' was registered as static but called as instance method", stringify!(#method_name));
+        }
+    } else {
+        quote! {
+            let is_class_reciever = env.is_instance_of(&this, lang_class_class).expect("Failed to check 2nd arg type for native method ABI check");
+            assert!(!is_class_reciever, "Native method '{}' was registered as instance but called as static method", stringify!(#method_name));
+        }
+    };
+
+    let type_mapping_runtime_checks = if let Some(type_mappings) = check_type_mappings {
+        generate_type_mapping_checks(type_mappings, jni)
+    } else {
+        quote! {}
+    };
+
+    quote! {
+        // Use atomic fetch_update to guard the ABI check. The closure runs without holding
+        // any lock, so multiple threads may race and perform the check concurrently on first
+        // invocation. This is acceptable since the check should always succeed or fail consistently.
+        //
+        // Critically: we only set the flag to true if the checks succeed. If a check fails and
+        // panics, the flag remains false, forcing subsequent threads to retry the check (in case
+        // the program doesn't abort).
+        //
+        // This approach avoids locks that could cause deadlocks if the check triggers class
+        // initialization which calls back into native methods.
+        static _ABI_CHECK_DONE: ::std::sync::atomic::AtomicBool = ::std::sync::atomic::AtomicBool::new(false);
+
+        // The closure returns Some(true) only after the check succeeds.
+        // If the check panics, the flag stays false and other attempts to call this method will
+        // retry the check (in case the program doesn't abort).
+        let _ = _ABI_CHECK_DONE.fetch_update(
+            ::std::sync::atomic::Ordering::AcqRel,   // set ordering
+            ::std::sync::atomic::Ordering::Acquire,   // fetch ordering
+            |done| {
+                if done {
+                    // The checks have already been completed successfully
+                    None
+                } else {
+                    // Perform the ABI check (runs outside any lock)
+                    #abi_check_ensure_env
+
+                    // Note: The `jni` crate has a MSRV that lets us assume it's safe to panic and unwind
+                    // up to a JNI boundary and then abort. Therefore we can use expect + assertions here.
+                    let lang_class_class = <#jni::objects::JClass as #jni::refs::Reference>::lookup_class(
+                        env,
+                        &#jni::refs::LoaderContext::None,
+                    ).expect("Failed to lookup Java class for java.lang.class, for native method ABI check");
+                    let lang_class_class: &#jni::objects::JClass = &lang_class_class;
+                    #abi_assertion
+                    #type_mapping_runtime_checks
+
+                    // Check succeeded - set flag to true
+                    Some(true)
+                }
+            }
+        );
+        // If fetch_update returned Ok, we successfully set the flag (check passed)
+        // If it returned Err, another thread beat us to it (also check passed)
+        // If the check failed, we panicked and never reached here
+    }
+}
+
+/// Generate the NativeMethod struct creation
+pub fn native_method_impl(input: TokenStream) -> Result<TokenStream> {
+    let input: NativeMethodStructInput = syn::parse2(input)?;
+
+    let is_static = input.is_static;
+    let jni = &input.jni_crate;
+    let java_method_name = &input.java_method_name;
+    let fn_path = &input.fn_path;
+    let type_mappings = &input.type_mappings;
+
+    // Generate JNI signature
+    let jni_signature = input
+        .method_signature
+        .to_jni_signature(type_mappings)
+        .map_err(|e| {
+            syn::Error::new(
+                proc_macro2::Span::call_site(),
+                format!("Failed to generate JNI signature: {}", e),
+            )
+        })?;
+
+    // Create CStr literals for name and signature
+    let name_cstr = lit_cstr_mutf8(java_method_name);
+    let sig_cstr = lit_cstr_mutf8(&jni_signature);
+
+    // Generate the type-checked wrapper function
+    let lifetime = quote! { 'local };
+
+    // Build parameter list - differs for raw vs wrapped functions
+    // For raw functions: extern "system" signature with EnvUnowned<'local> (no &mut)
+    // For wrapped functions: the user's function takes &mut Env<'local>
+    let mut raw_params = Vec::new();
+    let mut user_fn_params = Vec::new();
+
+    if input.is_raw_fn {
+        // Raw function: extern "system" fn(unowned_env: EnvUnowned<'local>, ...)
+        raw_params.push(quote! { unowned_env: #jni::EnvUnowned<#lifetime> });
+        user_fn_params.push(quote! { unowned_env: #jni::EnvUnowned<#lifetime> });
+    } else {
+        // Wrapped function: extern "system" wrapper, but user's fn takes &mut Env<'local>
+        raw_params.push(quote! { mut unowned_env: #jni::EnvUnowned<#lifetime> });
+        user_fn_params.push(quote! { env: &mut #jni::Env<#lifetime> });
+    }
+
+    // Add this/class parameter
+    if is_static {
+        raw_params.push(quote! { class: #jni::objects::JClass<#lifetime> });
+        user_fn_params.push(quote! { class: #jni::objects::JClass<#lifetime> });
+    } else {
+        let this_type = if let Some(rust_type) = &input.rust_type {
+            quote! { #rust_type<#lifetime> }
+        } else {
+            quote! { #jni::objects::JObject<#lifetime> }
+        };
+        raw_params.push(quote! { this: #this_type });
+        user_fn_params.push(quote! { this: #this_type });
+    }
+
+    // Add method parameters
+    for param in &input.method_signature.parameters {
+        let param_name = &param.name;
+        let rust_type = sig_type_to_rust_type_core(&param.ty, &lifetime, type_mappings, jni);
+        raw_params.push(quote! { #param_name: #rust_type });
+        user_fn_params.push(quote! { #param_name: #rust_type });
+    }
+
+    // Get return type
+    let return_type = sig_type_to_rust_type_core(
+        &input.method_signature.return_type,
+        &lifetime,
+        type_mappings,
+        jni,
+    );
+
+    // Build argument list for calling the user's function
+    let mut call_args = Vec::new();
+    if is_static {
+        call_args.push(quote! { class });
+    } else {
+        call_args.push(quote! { this });
+    }
+    for param in &input.method_signature.parameters {
+        let param_name = &param.name;
+        call_args.push(quote! { #param_name });
+    }
+
+    // Note: we unconditionally generate a wrapper, even for raw functions without
+    // an ABI check, so we can be sure we register an `extern "system"` ABI function
+    // pointer.
+
+    let abi_check = generate_native_method_abi_check(
+        jni,
+        java_method_name,
+        input.abi_check,
+        input.is_raw_fn,
+        input.is_static,
+        Some(type_mappings),
+    );
+
+    let (wrapper_path, native_method_block) = if input.is_raw_fn {
+        // For raw functions with ABI check: create wrapper that does ABI check
+        // The wrapper has extern "system" signature with raw_params
+        // The user's function is called with user_fn_params (EnvUnowned)
+        let wrapper_ident =
+            syn::Ident::new("__native_method_wrapper", proc_macro2::Span::call_site());
+        let wrapper_path: syn::Path = syn::parse_quote! { #wrapper_ident };
+
+        let block = quote! {
+            // ABI-checking wrapper function that converts from extern "system" to Rust calling convention
+            extern "system" fn #wrapper_ident<#lifetime>(
+                #(#raw_params),*
+            ) -> #return_type {
+                #abi_check
+
+                // Call the user's raw function
+                #fn_path(unowned_env, #(#call_args),*)
+            }
+
+            // Safety: The wrapper function is type-checked at compile time to match
+            // the signature specified in the macro. The function pointer is valid
+            // and points to __native_method_abi_check_wrapper.
+            unsafe {
+                #jni::NativeMethod::from_raw_parts(
+                    #jni::strings::JNIStr::from_cstr_unchecked(#name_cstr),
+                    #jni::strings::JNIStr::from_cstr_unchecked(#sig_cstr),
+                    #wrapper_ident as *mut ::std::ffi::c_void,
+                )
+            }
+        };
+        (wrapper_path, block)
+    } else {
+        let with_env_api = if input.catch_unwind {
+            quote! { with_env }
+        } else {
+            quote! { with_env_no_catch }
+        };
+        // For safe wrapped functions: create wrapper that calls with_env and resolve
+        // The wrapper has extern "system" signature with raw_params
+        // The user's function is called with user_fn_params (env: &mut Env)
+        // Type checking happens naturally when calling the user function
+        let error_policy = input
+            .error_policy
+            .as_ref()
+            .map(|p| quote! { #p })
+            .unwrap_or_else(|| quote! { #jni::errors::ThrowRuntimeExAndDefault });
+
+        let wrapper_ident =
+            syn::Ident::new("__native_method_wrapper", proc_macro2::Span::call_site());
+        let wrapper_path: syn::Path = syn::parse_quote! { #wrapper_ident };
+
+        let block = quote! {
+            // Type-checked wrapper function that converts from extern "system" to Rust calling convention
+            // and handles error resolution
+            extern "system" fn #wrapper_ident<#lifetime>(
+                #(#raw_params),*
+            ) -> #return_type {
+                unowned_env
+                    .#with_env_api(|env| {
+                        #abi_check
+
+                        #fn_path(env, #(#call_args),*)
+                    })
+                    .resolve::<#error_policy>()
+            }
+
+            // Safety: The wrapper function is type-checked at compile time to match
+            // the signature specified in the macro. The function pointer is valid
+            // and points to __native_method_wrapper.
+            unsafe {
+                #jni::NativeMethod::from_raw_parts(
+                    #jni::strings::JNIStr::from_cstr_unchecked(#name_cstr),
+                    #jni::strings::JNIStr::from_cstr_unchecked(#sig_cstr),
+                    #wrapper_ident as *mut ::std::ffi::c_void,
+                )
+            }
+        };
+        (wrapper_path, block)
+    };
+
+    // Generate export wrapper if requested
+    if !matches!(input.export, NativeMethodExport::No) {
+        let java_class = input.java_type.as_ref().unwrap(); // Validated earlier
+        let java_class_dotted = java_class.to_java_dotted();
+
+        // Generate the mangled JNI function name
+        let mangled_name = if let NativeMethodExport::WithName(export_name) = input.export {
+            export_name.clone()
+        } else {
+            create_jni_fn_name(&java_class_dotted, java_method_name, Some(&jni_signature))
+        };
+
+        // Use export_name attribute - check if has_unsafe_attr is set
+        let export_name_attr = if cfg!(has_unsafe_attr) {
+            quote! { #[unsafe(export_name = #mangled_name)] }
+        } else {
+            quote! { #[export_name = #mangled_name] }
+        };
+
+        // Build call arguments for the wrapper (just pass through all params)
+        let mut export_call_args = vec![quote! { unowned_env }];
+        if is_static {
+            export_call_args.push(quote! { class });
+        } else {
+            export_call_args.push(quote! { this });
+        }
+        for param in &input.method_signature.parameters {
+            let param_name = &param.name;
+            export_call_args.push(quote! { #param_name });
+        }
+
+        // The export wrapper calls the wrapper function (for wrapped) or user function (for raw)
+        Ok(quote! {
+            const {
+                #export_name_attr
+                pub extern "system" fn __native_method_export<#lifetime>(
+                    #(#raw_params),*
+                ) -> #return_type {
+                    #wrapper_path(#(#export_call_args),*)
+                }
+
+                #native_method_block
+            }
+        })
+    } else {
+        Ok(quote! {
+            const {
+                #native_method_block
+            }
+        })
+    }
+}

--- a/jni-macros/tests/java/com/example/TestNativeAbiCheck.java
+++ b/jni-macros/tests/java/com/example/TestNativeAbiCheck.java
@@ -1,0 +1,18 @@
+package com.example;
+
+public class TestNativeAbiCheck {
+    public TestNativeAbiCheck() {
+    }
+
+    public native int nativeMethod(int value);
+
+    public static native int nativeStaticMethod(int value);
+
+    public int callMethod(int value) {
+        return nativeMethod(value);
+    }
+
+    public static int callStaticMethod(int value) {
+        return nativeStaticMethod(value);
+    }
+}

--- a/jni-macros/tests/java/com/example/TestNativeCatchUnwind.java
+++ b/jni-macros/tests/java/com/example/TestNativeCatchUnwind.java
@@ -1,0 +1,10 @@
+package com.example;
+
+public class TestNativeCatchUnwind {
+    public TestNativeCatchUnwind() {
+    }
+
+    public native int methodThatPanics0();
+
+    public native int methodThatPanics1();
+}

--- a/jni-macros/tests/java/com/example/TestNativeCombinations.java
+++ b/jni-macros/tests/java/com/example/TestNativeCombinations.java
@@ -1,0 +1,73 @@
+package com.example;
+
+public class TestNativeCombinations {
+    public TestNativeCombinations() {
+    }
+
+    public native int methodNonExported(int value);
+
+    public native int methodNonExported2(int value);
+
+    public static native int staticMethodNonExported(int value);
+
+    public static native int staticMethodNonExported2(int value);
+
+    // Numbered methods that can be exported without clashing symbol names...
+    public native int method1(int value);
+
+    public native int method2(int value);
+
+    public native int method3(int value);
+
+    public native int method4(int value);
+
+    public static native int staticMethod1(int value);
+
+    public static native int staticMethod2(int value);
+
+    public static native int staticMethod3(int value);
+
+    public int callMethodNonExported(int value) {
+        return methodNonExported(value);
+    }
+
+    public int callMethodNonExported2(int value) {
+        return methodNonExported2(value);
+    }
+
+    public static int callStaticMethodNonExported(int value) {
+        return staticMethodNonExported(value);
+    }
+
+    public static int callStaticMethodNonExported2(int value) {
+        return staticMethodNonExported2(value);
+    }
+
+    public int callMethod1(int value) {
+        return method1(value);
+    }
+
+    public int callMethod2(int value) {
+        return method2(value);
+    }
+
+    public int callMethod3(int value) {
+        return method3(value);
+    }
+
+    public int callMethod4(int value) {
+        return method4(value);
+    }
+
+    public static int callStaticMethod1(int value) {
+        return staticMethod1(value);
+    }
+
+    public static int callStaticMethod2(int value) {
+        return staticMethod2(value);
+    }
+
+    public static int callStaticMethod3(int value) {
+        return staticMethod3(value);
+    }
+}

--- a/jni-macros/tests/java/com/example/TestNativeExports.java
+++ b/jni-macros/tests/java/com/example/TestNativeExports.java
@@ -1,0 +1,42 @@
+package com.example;
+
+public class TestNativeExports {
+    public TestNativeExports() {
+    }
+
+    // Test: no arguments
+    public native int noArgs();
+
+    // Test: primitive arguments
+    public native int primitiveArgs(int a, long b, boolean c);
+
+    // Test: primitive array arguments
+    public native void primitiveArrayArgs(int[] arr, byte[] bytes);
+
+    // Test: object arguments
+    public native String objectArgs(String str, Object obj);
+
+    // Test: object array arguments
+    public native void objectArrayArgs(String[] strings, Object[] objects);
+
+    // Test: overloaded methods
+    public native int overloaded();
+
+    public native int overloaded(int x);
+
+    public native int overloaded(String s);
+
+    // Test: unicode in method name (needs mangling)
+    public native void méthod();
+
+    // Test: underscore in method name (needs mangling)
+    public native void method_with_underscore();
+
+    // Test: manual export symbol
+    public native void manualExport();
+
+    // Inner class for testing '$' in class name
+    public static class Inner {
+        public native void innerMethod();
+    }
+}

--- a/jni-macros/tests/java/com/example/TestNativeMethods.java
+++ b/jni-macros/tests/java/com/example/TestNativeMethods.java
@@ -1,0 +1,97 @@
+package com.example;
+
+public class TestNativeMethods {
+    // Instance fields to test state mutation
+    private int counter = 0;
+    private String message = "initial";
+
+    // Note: in terms of argument + return types, there's very little difference
+    // between instance and static native methods, we don't need to test every
+    // combination of both so we just split our tests evenly. We want to cover:
+    // - void args/return
+    // - primitive args/return
+    // - String (Reference type) args/return
+    // - Array args/return
+    // - Multi-dimensional Array args/return
+
+    // Instance native methods
+    public native int nativeAdd(int a, int b);
+
+    public native void nativeLog(String message);
+
+    public native int[] nativeArrayAdd(int[] arr, int value);
+
+    public native void nativeSetCounter(int value);
+
+    public native void nativeSetMessage(String msg);
+
+    public native String nativeGetMessage();
+
+    // Static native methods
+    public static native int nativeGetVersion();
+
+    public static native boolean[][] native2DArrayInvert(boolean[][] arr);
+
+    public static native String[] nativeStringArrayEcho(String[] arr);
+
+    public static native String[][] native2DStringArrayEcho(String[][] arr);
+
+    // Non-native methods that can be used to test native method calls
+    public int getCounter() {
+        return counter;
+    }
+
+    public void setCounter(int value) {
+        counter = value;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+
+    public void setMessage(String msg) {
+        message = msg;
+    }
+
+    // Wrapper methods that call native methods (for testing)
+    public int callNativeAdd(int a, int b) {
+        return nativeAdd(a, b);
+    }
+
+    public void callNativeLog(String msg) {
+        nativeLog(msg);
+    }
+
+    public int[] callNativeArrayAdd(int[] arr, int value) {
+        return nativeArrayAdd(arr, value);
+    }
+
+    public void callNativeSetCounter(int value) {
+        nativeSetCounter(value);
+    }
+
+    public void callNativeSetMessage(String msg) {
+        nativeSetMessage(msg);
+    }
+
+    public String callNativeGetMessage() {
+        return nativeGetMessage();
+    }
+
+    // Wrapper methods for static native methods
+    public static int callNativeGetVersion() {
+        return nativeGetVersion();
+    }
+
+    public static boolean[][] callNative2DArrayInvert(boolean[][] arr) {
+        return native2DArrayInvert(arr);
+    }
+
+    public static String[] callNativeStringArrayEcho(String[] arr) {
+        return nativeStringArrayEcho(arr);
+    }
+
+    public static String[][] callNative2DStringArrayEcho(String[][] arr) {
+        return native2DStringArrayEcho(arr);
+    }
+}

--- a/jni-macros/tests/java/com/example/TestNativeStaticInit.java
+++ b/jni-macros/tests/java/com/example/TestNativeStaticInit.java
@@ -1,0 +1,21 @@
+package com.example;
+
+public class TestNativeStaticInit {
+    // Static field that will be incremented to 15 when the initializer runs
+    private static int staticValue = 5;
+
+    // Static initializer that calls a native method
+    static {
+        staticValue += 10;
+        System.out.println("Static initializer starting...");
+        staticValue = nativeInitializeStatic(staticValue);
+        System.out.println("Static initializer completed. Value: " + staticValue);
+    }
+
+    // Native methods called during static initialization
+    private static native int nativeInitializeStatic(int counter);
+
+    public static int getStaticValue() {
+        return staticValue;
+    }
+}

--- a/jni-macros/tests/native_methods.rs
+++ b/jni-macros/tests/native_methods.rs
@@ -1,0 +1,457 @@
+#![allow(unused)]
+mod native_methods_utils;
+mod util;
+
+use jni::Env;
+use jni::native_method;
+use jni::objects::JBooleanArray;
+use jni::objects::{JClass, JObjectArray, JPrimitiveArray, JString};
+use jni::refs::IntoAuto as _;
+use jni::sys::{jboolean, jint};
+use rusty_fork::rusty_fork_test;
+
+// ====================================================================================
+// Native method implementations
+// ====================================================================================
+
+fn native_add_impl<'local>(
+    _env: &mut Env<'local>,
+    _this: jni::objects::JObject<'local>,
+    a: jint,
+    b: jint,
+) -> Result<jint, jni::errors::Error> {
+    Ok(a + b)
+}
+
+fn native_log_impl<'local>(
+    _env: &mut Env<'local>,
+    _this: jni::objects::JObject<'local>,
+    message: JString<'local>,
+) -> Result<(), jni::errors::Error> {
+    println!("Native log: {}", message);
+    Ok(())
+}
+
+fn native_array_add_impl<'local>(
+    env: &mut Env<'local>,
+    _this: jni::objects::JObject<'local>,
+    arr: JPrimitiveArray<'local, jint>,
+    value: jint,
+) -> Result<JPrimitiveArray<'local, jint>, jni::errors::Error> {
+    unsafe {
+        let mut elem = arr.get_elements(env, jni::elements::ReleaseMode::CopyBack)?;
+        for i in 0..elem.len() {
+            elem[i] += value;
+        }
+        elem.commit()?;
+    }
+    Ok(arr)
+}
+
+fn native_2d_array_invert_impl<'local>(
+    env: &mut Env<'local>,
+    _class: JClass<'local>,
+    arr: JObjectArray<'local, JPrimitiveArray<'local, jboolean>>,
+) -> Result<JObjectArray<'local, JPrimitiveArray<'local, jboolean>>, jni::errors::Error> {
+    unsafe {
+        for i in 0..arr.len(env)? {
+            let row = arr.get_element(env, i)?.auto();
+            let mut row_elems = row.get_elements(env, jni::elements::ReleaseMode::CopyBack)?;
+            for j in 0..row_elems.len() {
+                row_elems[j] = !row_elems[j];
+            }
+            row_elems.commit()?;
+        }
+    }
+    Ok(arr)
+}
+
+fn native_set_counter_impl<'local>(
+    env: &mut Env<'local>,
+    this: jni::objects::JObject<'local>,
+    value: jint,
+) -> Result<(), jni::errors::Error> {
+    use jni::{jni_sig, jni_str};
+    env.call_method(
+        this,
+        jni_str!("setCounter"),
+        jni_str!("(I)V"),
+        //jni_sig!("(I)V"), TODO
+        &[jni::objects::JValue::Int(value)],
+    )?;
+    Ok(())
+}
+
+fn native_get_message_impl<'local>(
+    env: &mut Env<'local>,
+    this: jni::objects::JObject<'local>,
+) -> Result<JString<'local>, jni::errors::Error> {
+    use jni::{jni_sig, jni_str};
+    let result = env.call_method(
+        this,
+        jni_str!("getMessage"),
+        jni_str!("()Ljava/lang/String;"),
+        //jni_sig!("()Ljava/lang/String;"), TODO
+        &[],
+    )?;
+    // Use cast_local to safely convert JObject to JString
+    let result = JString::cast_local(result.l()?, env)?;
+    Ok(result)
+}
+
+fn native_get_version_impl<'local>(
+    _env: &mut Env<'local>,
+    _class: JClass<'local>,
+) -> Result<jint, jni::errors::Error> {
+    Ok(100)
+}
+
+fn native_string_array_echo_impl<'local>(
+    _env: &mut Env<'local>,
+    _class: JClass<'local>,
+    arr: JObjectArray<'local, JString<'local>>,
+) -> Result<JObjectArray<'local, JString<'local>>, jni::errors::Error> {
+    Ok(arr)
+}
+
+fn native_2d_string_array_echo_impl<'local>(
+    _env: &mut Env<'local>,
+    _class: JClass<'local>,
+    arr: JObjectArray<'local, JObjectArray<'local, JString<'local>>>,
+) -> Result<JObjectArray<'local, JObjectArray<'local, JString<'local>>>, jni::errors::Error> {
+    Ok(arr)
+}
+
+// ====================================================================================
+// Test: Instance native method with primitive args and return
+// ====================================================================================
+
+native_method_test! {
+    test_name: test_instance_primitive_args_and_return,
+    java_class: "com/example/TestNativeMethods.java",
+    methods: |class| &[
+        native_method! {
+            fn native_add(a: jint, b: jint) -> jint,
+            fn = native_add_impl,
+        },
+    ],
+    test_body: |env, class| {
+        let obj = new_object!(env, class)?;
+
+        // Call via Java wrapper method
+        use jni::{jni_sig, jni_str};
+        let result = env.call_method(
+            &obj,
+            jni_str!("callNativeAdd"),
+            jni_str!("(II)I"),
+            //jni_sig!("(II)I"), TODO
+            &[jni::objects::JValue::Int(10), jni::objects::JValue::Int(20)],
+        )?.i()?;
+        assert_eq!(result, 30);
+
+        let result = env.call_method(
+            &obj,
+            jni_str!("callNativeAdd"),
+            jni_str!("(II)I"),
+            //jni_sig!("(II)I"), TODO
+            &[jni::objects::JValue::Int(-5), jni::objects::JValue::Int(7)],
+        )?.i()?;
+        assert_eq!(result, 2);
+
+        Ok(())
+    }
+}
+
+// ====================================================================================
+// Test: Instance native method with void return and String arg
+// ====================================================================================
+
+native_method_test! {
+    test_name: test_instance_void_return_string_arg,
+    java_class: "com/example/TestNativeMethods.java",
+    methods: |class| &[
+        native_method! {
+            fn native_log(message: JString) -> void,
+            fn = native_log_impl,
+        },
+    ],
+    test_body: |env, class| {
+        let obj = new_object!(env, class)?;
+
+        let message = JString::from_str(env, "test log message")?;
+
+        use jni::{jni_sig, jni_str};
+        env.call_method(
+            &obj,
+            jni_str!("nativeLog"),
+            jni_str!("(Ljava/lang/String;)V"),
+            //jni_sig!("(Ljava/lang/String;)V"), TODO
+            &[jni::objects::JValue::Object(&message)],
+        )?;
+
+        Ok(())
+    }
+}
+
+// ====================================================================================
+// Test: Instance native method with primitive array arg and return
+// ====================================================================================
+
+native_method_test! {
+    test_name: test_instance_primitive_array_arg_and_return,
+    java_class: "com/example/TestNativeMethods.java",
+    methods: |class| &[
+        native_method! {
+            fn native_array_add(arr: jint[], value: jint) -> jint[],
+            fn = native_array_add_impl,
+        },
+    ],
+    test_body: |env, class| {
+        let obj = new_object!(env, class)?;
+
+        let arr = env.new_int_array(5)?;
+        let data = [1, 2, 3, 4, 5];
+        arr.set_region(env, 0, &data)?;
+
+        use jni::{jni_sig, jni_str};
+        let result = env.call_method(
+            &obj,
+            jni_str!("nativeArrayAdd"),
+            jni_str!("([II)[I"),
+            //jni_sig!("([II)[I"), TODO
+            &[jni::objects::JValue::Object(&arr), jni::objects::JValue::Int(10)],
+        )?.l()?;
+        // Use cast_local to safely convert JObject to JPrimitiveArray
+        let result = JPrimitiveArray::<jint>::cast_local(env, result)?;
+
+        let mut result_data = [0; 5];
+        result.get_region(env, 0, &mut result_data)?;
+        assert_eq!(result_data, [11, 12, 13, 14, 15]);
+
+        Ok(())
+    }
+}
+
+// ====================================================================================
+// Test: Instance native method with 2D primitive array
+// ====================================================================================
+
+native_method_test! {
+    test_name: test_instance_2d_primitive_array,
+    java_class: "com/example/TestNativeMethods.java",
+    methods: |class| &[
+        native_method! {
+            static fn native_2d_array_invert(arr: jboolean[][]) -> jboolean[][],
+            fn = native_2d_array_invert_impl,
+        },
+    ],
+    test_body: |env, class| {
+        // Create a 2D boolean array [[true, false], [false, true]]
+        let inner1 = env.new_boolean_array(2)?;
+        inner1.set_region(env, 0, &[true, false])?;
+        let inner2 = env.new_boolean_array(2)?;
+        inner2.set_region(env, 0, &[false, true])?;
+
+        let outer = JObjectArray::<JBooleanArray>::new(env, 2, inner1)?;
+        outer.set_element(env, 1, inner2)?;
+
+        // Invert the array
+        use jni::{jni_sig, jni_str};
+        let result = env.call_static_method(
+            class,
+            jni_str!("native2DArrayInvert"),
+            jni_str!("([[Z)[[Z"),
+            //jni_sig!("([[Z)[[Z"), TODO
+            &[jni::objects::JValue::Object(&outer)],
+        )?.l()?;
+        // Use cast_local to safely convert JObject to JObjectArray
+        let result = JObjectArray::<JBooleanArray>::cast_local(env, result)?;
+
+        // Check the result [[false, true], [true, false]]
+        let row1: JBooleanArray = result.get_element(env, 0)?;
+        let mut row1_data = [false; 2];
+        row1.get_region(env, 0, &mut row1_data)?;
+        assert_eq!(row1_data, [false, true]);
+
+        let row2: JBooleanArray = result.get_element(env, 1)?;
+        let mut row2_data = [false; 2];
+        row2.get_region(env, 0, &mut row2_data)?;
+        assert_eq!(row2_data, [true, false]);
+
+        Ok(())
+    }
+}
+
+// ====================================================================================
+// Test: Instance native method can call Java methods
+// ====================================================================================
+
+native_method_test! {
+    test_name: test_instance_call_java_methods,
+    java_class: "com/example/TestNativeMethods.java",
+    methods: |class| &[
+        native_method! {
+            fn native_set_counter(value: jint) -> void,
+            fn = native_set_counter_impl,
+        },
+        native_method! {
+            fn native_get_message() -> JString,
+            fn = native_get_message_impl,
+        },
+    ],
+    test_body: |env, class| {
+        let obj = new_object!(env, class)?;
+
+        // Test native method can call Java setter (via method call)
+        use jni::{jni_sig, jni_str};
+        env.call_method(
+            &obj,
+            jni_str!("nativeSetCounter"),
+            jni_str!("(I)V"),
+            //jni_sig!("(I)V"), TODO
+            &[jni::objects::JValue::Int(42)],
+        )?;
+
+        let counter = env.call_method(&obj, jni_str!("getCounter"), jni_str!("()I"), &[])?.i()?;
+        //let counter = env.call_method(&obj, jni_str!("getCounter"), jni_sig!("()I"), &[])?.i()?;
+        assert_eq!(counter, 42);
+
+        // Test native method can call Java getter (via method call)
+        let message = env.call_method(
+            &obj,
+            jni_str!("nativeGetMessage"),
+            jni_str!("()Ljava/lang/String;"),
+            //jni_sig!("()Ljava/lang/String;"), TODO
+            &[],
+        )?.l()?;
+        // Use cast_local to safely convert JObject to JString
+        let message = JString::cast_local(message, env)?;
+        assert_eq!(message.to_string(), "initial");
+
+        Ok(())
+    }
+}
+
+// ====================================================================================
+// Test: Static native method with no args and primitive return
+// ====================================================================================
+
+native_method_test! {
+    test_name: test_static_no_args_primitive_return,
+    java_class: "com/example/TestNativeMethods.java",
+    methods: |class| &[
+        native_method! {
+            static fn native_get_version() -> jint,
+            fn = native_get_version_impl,
+        },
+    ],
+    test_body: |env, class| {
+        use jni::{jni_sig, jni_str};
+        let version = env.call_static_method(
+            class,
+            jni_str!("callNativeGetVersion"),
+            jni_str!("()I"),
+            //jni_sig!("()I"), TODO
+            &[],
+        )?.i()?;
+        assert_eq!(version, 100);
+
+        Ok(())
+    }
+}
+
+// ====================================================================================
+// Test: Static native method with String array arg and return
+// ====================================================================================
+
+native_method_test! {
+    test_name: test_static_string_array_arg_and_return,
+    java_class: "com/example/TestNativeMethods.java",
+    methods: |class| &[
+        native_method! {
+            static fn native_string_array_echo(arr: JString[]) -> JString[],
+            fn = native_string_array_echo_impl,
+        },
+    ],
+    test_body: |env, class| {
+        let str1 = JString::from_str(env, "hello")?;
+        let str2 = JString::from_str(env, "world")?;
+
+        let arr = JObjectArray::<JString>::new(env, 2, &str1)?;
+        arr.set_element(env, 1, &str2)?;
+
+        use jni::{jni_sig, jni_str};
+        let result = env.call_static_method(
+            class,
+            jni_str!("nativeStringArrayEcho"),
+            jni_str!("([Ljava/lang/String;)[Ljava/lang/String;"),
+            //jni_sig!("([Ljava/lang/String;)[Ljava/lang/String;"), TODO
+            &[jni::objects::JValue::Object(&arr)],
+        )?.l()?;
+        // Use cast_local to safely convert JObject to JObjectArray
+        let result = JObjectArray::<JString>::cast_local(env, result)?;
+
+        let result1: JString = result.get_element(env, 0)?;
+        assert_eq!(result1.to_string(), "hello");
+
+        let result2: JString = result.get_element(env, 1)?;
+        assert_eq!(result2.to_string(), "world");
+
+        Ok(())
+    }
+}
+
+// ====================================================================================
+// Test: Static native method with 2D String array
+// ====================================================================================
+
+native_method_test! {
+    test_name: test_static_2d_string_array,
+    java_class: "com/example/TestNativeMethods.java",
+    methods: |class| &[
+        native_method! {
+            static fn native_2d_string_array_echo(arr: JString[][]) -> JString[][],
+            fn = native_2d_string_array_echo_impl,
+        },
+    ],
+    test_body: |env, class| {
+        let str1 = JString::from_str(env, "foo")?;
+        let str2 = JString::from_str(env, "bar")?;
+        let str3 = JString::from_str(env, "baz")?;
+        let str4 = JString::from_str(env, "qux")?;
+
+        let row1 = JObjectArray::<JString>::new(env, 2, &str1)?;
+        row1.set_element(env, 1, &str2)?;
+
+        let row2 = JObjectArray::<JString>::new(env, 2, &str3)?;
+        row2.set_element(env, 1, &str4)?;
+
+        let arr = JObjectArray::<JObjectArray<JString>>::new(env, 2, &row1)?;
+        arr.set_element(env, 1, &row2)?;
+
+        // Call native method
+        use jni::{jni_sig, jni_str};
+        let result = env.call_static_method(
+            class,
+            jni_str!("native2DStringArrayEcho"),
+            jni_str!("([[Ljava/lang/String;)[[Ljava/lang/String;"),
+            //jni_sig!("([[Ljava/lang/String;)[[Ljava/lang/String;"), TODO
+            &[jni::objects::JValue::Object(&arr)],
+        )?.l()?;
+        let result = JObjectArray::<JObjectArray<JString>>::cast_local(env, result)?;
+
+        let result_row1 = result.get_element(env, 0)?;
+        let r1c1 = result_row1.get_element(env, 0)?;
+        let r1c2 = result_row1.get_element(env, 1)?;
+        assert_eq!(r1c1.to_string(), "foo");
+        assert_eq!(r1c2.to_string(), "bar");
+
+        let result_row2 = result.get_element(env, 1)?;
+        let r2c1 = result_row2.get_element(env, 0)?;
+        let r2c2 = result_row2.get_element(env, 1)?;
+        assert_eq!(r2c1.to_string(), "baz");
+        assert_eq!(r2c2.to_string(), "qux");
+
+        Ok(())
+    }
+}

--- a/jni-macros/tests/native_methods_abi_check.rs
+++ b/jni-macros/tests/native_methods_abi_check.rs
@@ -1,0 +1,299 @@
+//! Tests for native method ABI checking functionality.
+//!
+//! These tests verify that the `abi_check` parameter correctly detects
+//! mismatches between Java method declarations (static vs instance) and Rust registrations.
+
+mod native_methods_utils;
+mod util;
+
+use jni::errors::Error;
+use jni::objects::JClass;
+use jni::sys::jint;
+use jni::{Env, native_method};
+use rusty_fork::rusty_fork_test;
+
+// ====================================================================================
+// Test: Instance method registered as static (Always mode)
+// ====================================================================================
+
+native_method_test! {
+    test_name: test_abi_instance_registered_as_static_wrapped,
+    java_class: "com/example/TestNativeAbiCheck.java",
+    methods: |class| &[
+        native_method! {
+            static fn native_method(value: jint) -> jint,
+            fn = native_method_registered_as_static,
+            abi_check = Always,
+        },
+    ],
+    expect_exception: "ABI check detected instance method called with static registration",
+    test_body: |env, class| {
+        let obj = new_object!(env, class)?;
+        let _result = call_int_method!(env, &obj, "callMethod", 42)?;
+        Ok(())
+    }
+}
+
+fn native_method_registered_as_static<'local>(
+    _env: &mut Env<'local>,
+    _class: JClass<'local>, // Static registration expects JClass
+    value: jint,
+) -> Result<jint, Error> {
+    Ok(value * 2)
+}
+
+// ====================================================================================
+// Test: Static method registered as instance (Always mode)
+// ====================================================================================
+
+native_method_test! {
+    test_name: test_abi_static_registered_as_instance_wrapped,
+    java_class: "com/example/TestNativeAbiCheck.java",
+    methods: |class| &[
+        native_method! {
+            fn native_static_method(value: jint) -> jint,
+            fn = native_static_method_registered_as_instance,
+            abi_check = Always,
+        },
+    ],
+    expect_exception: "ABI check detected static method called with instance registration",
+    test_body: |env, class| {
+        let _result = call_static_int_method!(env, class, "callStaticMethod", 42)?;
+        Ok(())
+    }
+}
+
+fn native_static_method_registered_as_instance<'local>(
+    _env: &mut Env<'local>,
+    _this: jni::objects::JObject<'local>, // Instance registration expects JObject
+    value: jint,
+) -> Result<jint, Error> {
+    Ok(value * 3)
+}
+
+// ====================================================================================
+// Test: Correct instance and static methods work (Always mode)
+// ====================================================================================
+
+native_method_test! {
+    test_name: test_abi_correct_registration_wrapped,
+    java_class: "com/example/TestNativeAbiCheck.java",
+    methods: |class| &[
+        native_method! {
+            fn native_method(value: jint) -> jint,
+            fn = native_method_correct,
+            abi_check = Always,
+        },
+        native_method! {
+            static fn native_static_method(value: jint) -> jint,
+            fn = native_static_method_correct,
+            abi_check = Always,
+        },
+    ],
+    test_body: |env, class| {
+        // Correctly declared instance method
+        let obj = new_object!(env, class)?;
+        let result = call_int_method!(env, &obj, "callMethod", 5)?;
+        assert_eq!(result, 10);
+
+        // Correctly declared static method
+        let result = call_static_int_method!(env, class, "callStaticMethod", 7)?;
+        assert_eq!(result, 21);
+
+        Ok(())
+    }
+}
+
+fn native_method_correct<'local>(
+    _env: &mut Env<'local>,
+    _this: jni::objects::JObject<'local>,
+    value: jint,
+) -> Result<jint, Error> {
+    Ok(value * 2)
+}
+
+fn native_static_method_correct<'local>(
+    _env: &mut Env<'local>,
+    _class: JClass<'local>,
+    value: jint,
+) -> Result<jint, Error> {
+    Ok(value * 3)
+}
+
+// ====================================================================================
+// Test: Per-method ABI check override (UnsafeNever disables check)
+// ====================================================================================
+
+native_method_test! {
+    test_name: test_abi_unsafe_never_wrapped,
+    java_class: "com/example/TestNativeAbiCheck.java",
+    methods: |class| &[
+        native_method! {
+            // Incorrectly registered as an instance method
+            fn native_static_method(value: jint) -> jint,
+            fn = native_static_method_registered_as_instance,
+            abi_check = UnsafeNever,  // But check is disabled
+        },
+    ],
+    test_body: |env, class| {
+        // Call static method - should NOT panic because check is disabled
+        // Note: This is unsafe and wrong, but we're testing that the check is disabled
+        let result = call_static_int_method!(env, class, "callStaticMethod", 42)?;
+        assert_eq!(result, 126);
+        Ok(())
+    }
+}
+
+// ====================================================================================
+// Test: UnsafeDebugOnly mode (checks only in debug builds)
+// ====================================================================================
+
+#[cfg(debug_assertions)]
+native_method_test! {
+    test_name: test_abi_debug_only_in_debug_mode_wrapped,
+    java_class: "com/example/TestNativeAbiCheck.java",
+    methods: |class| &[
+        native_method! {
+            // Incorrectly registered as a static method
+            static fn native_method(value: jint) -> jint,
+            fn = native_method_registered_as_static,
+            abi_check = UnsafeDebugOnly,
+        },
+    ],
+    expect_exception: "UnsafeDebugOnly correctly detected ABI mismatch in debug build",
+    test_body: |env, class| {
+        let obj = new_object!(env, class)?;
+        let _result = call_int_method!(env, &obj, "callMethod", 42)?;
+        Ok(())
+    }
+}
+
+#[cfg(not(debug_assertions))]
+native_method_test! {
+    test_name: test_abi_debug_only_in_release_mode_wrapped,
+    java_class: "com/example/TestNativeAbiCheck.java",
+    methods: |class| &[
+        native_method! {
+            // Incorrectly registered as a static method
+            static fn native_method(value: jint) -> jint,
+            fn = native_method_registered_as_static,
+            abi_check = UnsafeDebugOnly,  // But disabled in release builds
+        },
+    ],
+    test_body: |env, class| {
+        // Try to call instance method - should NOT panic in release mode
+        let obj = new_object!(env, class)?;
+        let result = call_int_method!(env, &obj, "callMethod", 42)?;
+        assert_eq!(result, 84);
+        Ok(())
+    }
+}
+
+// ====================================================================================
+// Test: UnsafeDebugOnly mode (checks only in debug builds, raw)
+// ====================================================================================
+
+// This fixture test is designed to abort when run in debug mode
+#[cfg(debug_assertions)]
+native_method_test! {
+    #[ignore = "This is run in a separate cargo process by test_abi_debug_only_in_debug_mode_raw"]
+    test_name: test_abi_debug_only_in_debug_mode_raw_impl,
+    java_class: "com/example/TestNativeAbiCheck.java",
+    methods: |class| &[
+        native_method! {
+            // Incorrectly registered as a static method
+            static raw fn native_method(value: jint) -> jint,
+            fn = raw_native_method_registered_as_static,
+            abi_check = UnsafeDebugOnly,
+        },
+    ],
+    test_body: |env, class| {
+        let obj = new_object!(env, class)?;
+        // This will trigger ABI check and abort because it's a raw function
+        let _result = call_int_method!(env, &obj, "callMethod", 42)?;
+
+        // We should never reach here
+        eprintln!("ERROR: Should have aborted!");
+        std::process::exit(1);
+        #[allow(unreachable_code)]
+        Ok(())
+    }
+}
+
+#[cfg(debug_assertions)]
+#[test]
+fn test_abi_debug_only_in_debug_mode_raw() {
+    // Run the fixture test that has UnsafeDebugOnly ABI check on a raw function.
+    // The ABI check should detect the mismatch and abort the process in debug builds.
+
+    // Use cargo test to run the specific fixture test
+    let mut cmd = std::process::Command::new(env!("CARGO"));
+    cmd.arg("test")
+        .arg("--test")
+        .arg("native_methods_abi_check")
+        .arg("--")
+        .arg("--include-ignored")
+        .arg("--exact")
+        .arg("test_abi_debug_only_in_debug_mode_raw_impl")
+        .arg("--nocapture");
+
+    let output = cmd.output().expect("Failed to execute fixture test");
+
+    // The process should have failed (non-zero exit code)
+    assert!(
+        !output.status.success(),
+        "Expected process to abort/fail due to ABI check"
+    );
+
+    // Check the combined output (stderr and stdout) for the ABI check message
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let combined = format!("{}{}", stdout, stderr);
+
+    // The ABI check assertion message should appear in the output
+    assert!(
+        combined.contains("was registered as static but called as instance method")
+            || combined.contains("nativeMethod"),
+        "Expected ABI check error message in output, got stdout: {}\nstderr: {}",
+        stdout,
+        stderr
+    );
+
+    // The test should have failed
+    assert!(
+        combined.contains("test test_abi_debug_only_in_debug_mode_raw_impl ... FAILED"),
+        "Expected test failure in output, got: {}",
+        combined
+    );
+}
+
+#[cfg(not(debug_assertions))]
+native_method_test! {
+    test_name: test_abi_debug_only_in_release_mode_raw,
+    java_class: "com/example/TestNativeAbiCheck.java",
+    methods: |class| &[
+        native_method! {
+            name = "nativeMethod",
+            sig = (value: jint) -> jint,
+            fn = raw_native_method_registered_as_static,
+            static = true,  // Mismatched: Rust says static, Java says instance
+            raw = true,
+            abi_check = UnsafeDebugOnly,  // But disabled in release builds
+        },
+    ],
+    test_body: |env, class| {
+        // Try to call instance method - should NOT panic in release mode
+        let obj = new_object!(env, class)?;
+        let result = call_int_method!(env, &obj, "callMethod", 42)?;
+        assert_eq!(result, 84);
+        Ok(())
+    }
+}
+
+fn raw_native_method_registered_as_static<'local>(
+    _env: jni::EnvUnowned<'local>,
+    _class: JClass<'local>,
+    value: jint,
+) -> jint {
+    value * 2
+}

--- a/jni-macros/tests/native_methods_catch_unwind.rs
+++ b/jni-macros/tests/native_methods_catch_unwind.rs
@@ -1,0 +1,168 @@
+//! Tests for `catch_unwind = false` behavior.
+//!
+//! This test file verifies the behavior difference between `catch_unwind =
+//! false` and `catch_unwind = true` (the default).
+//!
+//! When `catch_unwind = false`:
+//! - Native method implementations use `EnvUnowned::with_env_no_catch`
+//! - Panics are NOT caught and converted to Java exceptions
+//!
+//! When `catch_unwind = true` (default):
+//! - Native method wrappers use `EnvUnowned::with_env` (including catch_unwind)
+//! - Panics are converted to Java exceptions via the error policy
+//!
+//! Testing `catch_unwind = false` is tricky because the native method
+//! represents an extern "system" FFI boundary which panics cannot cross without
+//! aborting the process. To work around this, we spawn a separate `cargo test`
+//! process to run the code that can abort so we can check the exit status.
+
+mod native_methods_utils;
+mod util;
+
+use jni::errors::Error;
+use jni::sys::jint;
+use jni::{Env, native_method};
+use rusty_fork::rusty_fork_test;
+use std::panic;
+
+// ====================================================================================
+// Test: catch_unwind = false (panics are NOT caught by error policy)
+// ====================================================================================
+
+// This test is designed to abort when run
+native_method_test! {
+    #[ignore = "This is run in a separate cargo process by test_catch_unwind_false_causes_abort"]
+    test_name: test_catch_unwind_false_causes_abort_impl,
+    java_class: "com/example/TestNativeCatchUnwind.java",
+    methods: |class| &[
+        native_method! {
+            extern fn method_that_panics0() -> jint,
+            fn = method_that_panics_no_catch,
+            java_type = "com.example.TestNativeCatchUnwind",
+            catch_unwind = false,  // This will cause abort when panic tries to escape
+        },
+    ],
+    test_body: |env, class| {
+        let obj = new_object!(env, class)?;
+
+        // Call the method - this will panic and abort because catch_unwind = false
+        unsafe {
+            let unowned = jni::EnvUnowned::from_raw(env.get_raw());
+            let _ret = Java_com_example_TestNativeCatchUnwind_methodThatPanics0__(unowned, obj.as_raw());
+        }
+
+        // We should never reach here
+        eprintln!("ERROR: Should have aborted!");
+        std::process::exit(1);
+        #[allow(unreachable_code)]
+        Ok(())
+    }
+}
+
+fn method_that_panics_no_catch<'local>(
+    _env: &mut Env<'local>,
+    _this: jni::objects::JObject<'local>,
+) -> Result<jint, Error> {
+    panic!("This panic should cause abort because catch_unwind = false");
+}
+
+// Declare the exported symbol so we can call it from Rust
+unsafe extern "system" {
+    fn Java_com_example_TestNativeCatchUnwind_methodThatPanics0__(
+        env: jni::EnvUnowned,
+        this: jni::sys::jobject,
+    ) -> jint;
+}
+
+#[test]
+fn test_catch_unwind_false_causes_abort() {
+    // Run the fixture test that has catch_unwind = false and panics.
+    // The panic should cause the process to abort because it tries to
+    // escape through an extern "system" FFI boundary that cannot unwind.
+
+    // Use cargo test to run the specific fixture test
+    let mut cmd = std::process::Command::new(env!("CARGO"));
+    cmd.arg("test")
+        .arg("--test")
+        .arg("native_methods_catch_unwind")
+        .arg("--")
+        .arg("--include-ignored")
+        .arg("--exact")
+        .arg("test_catch_unwind_false_causes_abort_impl")
+        .arg("--nocapture");
+
+    let output = cmd.output().expect("Failed to execute fixture test");
+
+    // The process should have failed (non-zero exit code)
+    assert!(!output.status.success(), "Expected process to abort/fail");
+
+    // Check the combined output (stderr and stdout) for the panic message
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let combined = format!("{}{}", stdout, stderr);
+
+    assert!(
+        combined.contains("This panic should cause abort because catch_unwind = false"),
+        "Expected panic message in output, got stdout: {}\nstderr: {}",
+        stdout,
+        stderr
+    );
+
+    // The test should have failed
+    assert!(
+        combined.contains("test test_catch_unwind_false_causes_abort_impl ... FAILED"),
+        "Expected test failure in output, got: {}",
+        combined
+    );
+}
+
+// ====================================================================================
+// Test: catch_unwind = true (default - panics ARE caught by error policy)
+// ====================================================================================
+
+native_method_test! {
+    test_name: test_catch_unwind_true_catches_panic,
+    java_class: "com/example/TestNativeCatchUnwind.java",
+    methods: |class| &[
+        native_method! {
+            extern fn method_that_panics1() -> jint,
+            fn = method_that_panics_with_catch,
+            java_type = "com.example.TestNativeCatchUnwind",
+            catch_unwind = true,  // Explicit, but this is the default
+        },
+    ],
+    test_body: |env, class| {
+        let obj = new_object!(env, class)?;
+
+        // Call the exported symbol directly from Rust with our own catch_unwind.
+        // With catch_unwind = true (default), the panic should be caught by the
+        // error policy inside the native method wrapper and converted to a Java exception.
+        // Since we're calling from Rust (not Java), we won't see the Java exception,
+        // but the important thing is that it doesn't panic.
+        let result = panic::catch_unwind(panic::AssertUnwindSafe(|| unsafe {
+            let unowned = jni::EnvUnowned::from_raw(env.get_raw());
+            Java_com_example_TestNativeCatchUnwind_methodThatPanics1__(unowned, obj.as_raw())
+        }));
+
+        // The panic should have been caught by the error policy, so our catch_unwind
+        // should NOT catch a panic (result should be Ok)
+        assert!(result.is_ok(), "Expected panic to be caught by error policy when catch_unwind = true");
+
+        Ok(())
+    }
+}
+
+fn method_that_panics_with_catch<'local>(
+    _env: &mut Env<'local>,
+    _this: jni::objects::JObject<'local>,
+) -> Result<jint, Error> {
+    panic!("This panic SHOULD be caught by error policy");
+}
+
+// Declare the exported symbol so we can call it from Rust
+unsafe extern "system" {
+    fn Java_com_example_TestNativeCatchUnwind_methodThatPanics1__(
+        env: jni::EnvUnowned,
+        this: jni::sys::jobject,
+    ) -> jint;
+}

--- a/jni-macros/tests/native_methods_export.rs
+++ b/jni-macros/tests/native_methods_export.rs
@@ -1,0 +1,348 @@
+//! Tests for native method export symbol generation.
+//!
+//! These tests verify that the `native_method!` macro correctly generates
+//! exported JNI symbols with proper name mangling for various scenarios.
+//!
+//! Note: This is a representative subset of export tests. Most name mangling
+//! variations are not included since they're handled by the same underlying
+//! code used by both bind_java_type! and native_method! macros.
+
+#[macro_use]
+mod native_methods_utils;
+mod util;
+
+use jni::objects::{JObject, JString};
+use jni::sys::{jboolean, jint, jlong};
+use jni::{Env, EnvUnowned, native_method};
+use rusty_fork::rusty_fork_test;
+
+// Declare the exported JNI symbols that the native_method! macro creates
+// These use EnvUnowned and JNI reference types which are FFI-safe
+unsafe extern "system" {
+    fn Java_com_example_TestNativeExports_noArgs__<'local>(
+        env: EnvUnowned<'local>,
+        this: JObject<'local>,
+    ) -> jint;
+    fn Java_com_example_TestNativeExports_primitiveArgs__IJZ<'local>(
+        env: EnvUnowned<'local>,
+        this: JObject<'local>,
+        a: jint,
+        b: jlong,
+        c: jboolean,
+    ) -> jint;
+    fn Java_com_example_TestNativeExports_objectArgs__Ljava_lang_String_2Ljava_lang_Object_2<
+        'local,
+    >(
+        env: EnvUnowned<'local>,
+        this: JObject<'local>,
+        str: JString<'local>,
+        obj: JObject<'local>,
+    ) -> JString<'local>;
+    fn Java_com_example_TestNativeExports_overloaded__<'local>(
+        env: EnvUnowned<'local>,
+        this: JObject<'local>,
+    ) -> jint;
+    fn Java_com_example_TestNativeExports_overloaded__I<'local>(
+        env: EnvUnowned<'local>,
+        this: JObject<'local>,
+        x: jint,
+    ) -> jint;
+    fn Java_com_example_TestNativeExports_overloaded__Ljava_lang_String_2<'local>(
+        env: EnvUnowned<'local>,
+        this: JObject<'local>,
+        s: JString<'local>,
+    ) -> jint;
+    fn Java_com_example_TestNativeExports_method_1with_1underscore__<'local>(
+        env: EnvUnowned<'local>,
+        this: JObject<'local>,
+    );
+    fn Java_com_example_TestNativeExports_manualExport<'local>(
+        env: EnvUnowned<'local>,
+        this: JObject<'local>,
+    );
+}
+
+// ====================================================================================
+// Test: No arguments with extern keyword (implicit export)
+// ====================================================================================
+
+native_method_test! {
+    test_name: test_export_no_args,
+    java_class: "com/example/TestNativeExports.java",
+    methods: |class| &[
+        native_method! {
+            extern fn no_args() -> jint,
+            fn = no_args_impl,
+            java_type = "com.example.TestNativeExports",
+        },
+    ],
+    test_body: |env, class| {
+        let obj = new_object!(env, class)?;
+
+        // Call through Java to ensure the native implementation is linked
+        use jni::jni_str;
+        let result_via_java = env.call_method(&obj, jni_str!("noArgs"), jni_str!("()I"), &[])?.i()?;
+        //let result_via_java = env.call_method(&obj, jni_str!("noArgs"), jni_sig!("()I"), &[])?.i()?; TODO
+        assert_eq!(result_via_java, 1234);
+
+        // Also test calling the exported symbol directly
+        unsafe {
+            let unowned = EnvUnowned::from_raw(env.get_raw());
+            let ret = Java_com_example_TestNativeExports_noArgs__(unowned, obj);
+            assert_eq!(ret, 1234);
+        }
+        Ok(())
+    }
+}
+
+fn no_args_impl<'local>(
+    _env: &mut Env<'local>,
+    _this: JObject<'local>,
+) -> Result<jint, jni::errors::Error> {
+    Ok(1234)
+}
+
+// ====================================================================================
+// Test: Primitive arguments with explicit export = true
+// ====================================================================================
+
+native_method_test! {
+    test_name: test_export_primitive_args,
+    java_class: "com/example/TestNativeExports.java",
+    methods: |class| &[
+        native_method! {
+            fn primitive_args(a: jint, b: jlong, c: jboolean) -> jint,
+            fn = primitive_args_impl,
+            export = true,
+            java_type = "com.example.TestNativeExports",
+        },
+    ],
+    test_body: |env, class| {
+        let obj = new_object!(env, class)?;
+
+        unsafe {
+            let unowned = EnvUnowned::from_raw(env.get_raw());
+            let ret = Java_com_example_TestNativeExports_primitiveArgs__IJZ(
+                unowned, obj, 10, 20, true as jboolean
+            );
+            assert_eq!(ret, 31);
+        }
+        Ok(())
+    }
+}
+
+fn primitive_args_impl<'local>(
+    _env: &mut Env<'local>,
+    _this: JObject<'local>,
+    a: jint,
+    b: jlong,
+    c: jboolean,
+) -> Result<jint, jni::errors::Error> {
+    Ok(a + b as jint + c as jint)
+}
+
+// ====================================================================================
+// Test: Object arguments
+// ====================================================================================
+
+native_method_test! {
+    test_name: test_export_object_args,
+    java_class: "com/example/TestNativeExports.java",
+    methods: |class| &[
+        native_method! {
+            fn object_args(str: JString, obj: JObject) -> JString,
+            fn = object_args_impl,
+            export = true,
+            java_type = "com.example.TestNativeExports",
+        },
+    ],
+    test_body: |env, class| {
+        let obj = new_object!(env, class)?;
+        let str_arg = env.new_string("test")?;
+        let obj_arg = env.new_string("object")?;
+
+        unsafe {
+            let unowned = EnvUnowned::from_raw(env.get_raw());
+            let result = Java_com_example_TestNativeExports_objectArgs__Ljava_lang_String_2Ljava_lang_Object_2(
+                unowned, obj, str_arg, obj_arg.into()
+            );
+            assert!(!result.as_raw().is_null());
+        }
+        Ok(())
+    }
+}
+
+fn object_args_impl<'local>(
+    _env: &mut Env<'local>,
+    _this: JObject<'local>,
+    str: JString<'local>,
+    _obj: JObject<'local>,
+) -> Result<JString<'local>, jni::errors::Error> {
+    Ok(str)
+}
+
+// ====================================================================================
+// Test: Overloaded methods with different signatures
+// ====================================================================================
+
+native_method_test! {
+    test_name: test_export_overloaded_no_args,
+    java_class: "com/example/TestNativeExports.java",
+    methods: |class| &[
+        native_method! {
+            fn overloaded() -> jint,
+            fn = overloaded_no_args_impl,
+            export = true,
+            java_type = "com.example.TestNativeExports",
+        },
+    ],
+    test_body: |env, class| {
+        let obj = new_object!(env, class)?;
+
+        unsafe {
+            let unowned = EnvUnowned::from_raw(env.get_raw());
+            let result = Java_com_example_TestNativeExports_overloaded__(unowned, obj);
+            assert_eq!(result, 1);
+        }
+        Ok(())
+    }
+}
+
+fn overloaded_no_args_impl<'local>(
+    _env: &mut Env<'local>,
+    _this: JObject<'local>,
+) -> Result<jint, jni::errors::Error> {
+    Ok(1)
+}
+
+native_method_test! {
+    test_name: test_export_overloaded_int,
+    java_class: "com/example/TestNativeExports.java",
+    methods: |class| &[
+        native_method! {
+            extern fn overloaded(x: jint) -> jint,
+            fn = overloaded_int_impl,
+            java_type = "com.example.TestNativeExports",
+        },
+    ],
+    test_body: |env, class| {
+        let obj = new_object!(env, class)?;
+
+        unsafe {
+            let unowned = EnvUnowned::from_raw(env.get_raw());
+            let result = Java_com_example_TestNativeExports_overloaded__I(unowned, obj, 5);
+            assert_eq!(result, 10);
+        }
+        Ok(())
+    }
+}
+
+fn overloaded_int_impl<'local>(
+    _env: &mut Env<'local>,
+    _this: JObject<'local>,
+    x: jint,
+) -> Result<jint, jni::errors::Error> {
+    Ok(x * 2)
+}
+
+native_method_test! {
+    test_name: test_export_overloaded_string,
+    java_class: "com/example/TestNativeExports.java",
+    methods: |class| &[
+        native_method! {
+            fn overloaded(s: JString) -> jint,
+            fn = overloaded_string_impl,
+            export = true,
+            java_type = "com.example.TestNativeExports",
+        },
+    ],
+    test_body: |env, class| {
+        let obj = new_object!(env, class)?;
+        let input = env.new_string("hello")?;
+
+        unsafe {
+            let unowned = EnvUnowned::from_raw(env.get_raw());
+            let result = Java_com_example_TestNativeExports_overloaded__Ljava_lang_String_2(
+                unowned, obj, input
+            );
+            assert_eq!(result, 5);
+        }
+        Ok(())
+    }
+}
+
+fn overloaded_string_impl<'local>(
+    _env: &mut Env<'local>,
+    _this: JObject<'local>,
+    _s: JString<'local>,
+) -> Result<jint, jni::errors::Error> {
+    // Just return a fixed value - we're testing exports, not string handling
+    Ok(5)
+}
+
+// ====================================================================================
+// Test: Underscore in method name (needs mangling)
+// ====================================================================================
+
+native_method_test! {
+    test_name: test_export_underscore_method_name,
+    java_class: "com/example/TestNativeExports.java",
+    methods: |class| &[
+        native_method! {
+            fn method_with_underscore() -> (),
+            fn = method_with_underscore_impl,
+            name = "method_with_underscore",  // Explicit name needed since Java method has underscores
+            export = true,
+            java_type = "com.example.TestNativeExports",
+        },
+    ],
+    test_body: |env, class| {
+        let obj = new_object!(env, class)?;
+
+        unsafe {
+            let unowned = EnvUnowned::from_raw(env.get_raw());
+            Java_com_example_TestNativeExports_method_1with_1underscore__(unowned, obj);
+        }
+        Ok(())
+    }
+}
+
+fn method_with_underscore_impl<'local>(
+    _env: &mut Env<'local>,
+    _this: JObject<'local>,
+) -> Result<(), jni::errors::Error> {
+    Ok(())
+}
+
+// ====================================================================================
+// Test: Manual export symbol
+// ====================================================================================
+
+native_method_test! {
+    test_name: test_export_manual_symbol,
+    java_class: "com/example/TestNativeExports.java",
+    methods: |class| &[
+        native_method! {
+            fn manual_export() -> (),
+            fn = manual_export_impl,
+            export = "Java_com_example_TestNativeExports_manualExport",
+            java_type = "com.example.TestNativeExports",
+        },
+    ],
+    test_body: |env, class| {
+        let obj = new_object!(env, class)?;
+
+        unsafe {
+            let unowned = EnvUnowned::from_raw(env.get_raw());
+            Java_com_example_TestNativeExports_manualExport(unowned, obj);
+        }
+        Ok(())
+    }
+}
+
+fn manual_export_impl<'local>(
+    _env: &mut Env<'local>,
+    _this: JObject<'local>,
+) -> Result<(), jni::errors::Error> {
+    Ok(())
+}

--- a/jni-macros/tests/native_methods_export_x_raw_x_fn.rs
+++ b/jni-macros/tests/native_methods_export_x_raw_x_fn.rs
@@ -1,0 +1,485 @@
+//! Tests for the interaction matrix between `raw`, `export`, and `fn=` features.
+//!
+//! This test file focuses on verifying that different combinations of:
+//! - `raw = true` (property syntax) and `raw` qualifier syntax
+//! - `export = true` (property syntax) and `extern` qualifier syntax
+//! - `fn = path` (direct function pointer)
+//!
+//! work correctly together.
+//!
+//! ## Test Matrix
+//!
+//! | Test | Method Type | Raw | Export | Implementation | Syntax Style | Notes |
+//! |------|-------------|-----|--------|----------------|--------------|-------|
+//! | 1    | Instance    | ✓   | ✓      | fn=            | Property     | |
+//! | 2    | Instance    | ✓   | ✓      | fn=            | Qualifier    | |
+//! | 3    | Instance    | ✓   | ✓      | fn=            | Property     | |
+//! | 4    | Instance    | ✗   | ✓      | fn=            | Property     | |
+//! | 5    | Static      | ✓   | ✓      | fn=            | Property     | |
+//! | 6    | Static      | ✓   | ✓      | fn=            | Qualifier    | |
+//! | 7    | Static      | ✗   | ✓      | fn=            | Qualifier    | |
+//! | 8    | Static      | ✗   | ✗      | fn=            | Property     | |
+//! | 9    | Instance    | ✗   | ✗      | fn=            | Default      | |
+//! | 10   | Static      | ✗   | ✗      | fn=            | Default      | |
+//! | 11   | Mixed       | ✗   | ✗      | fn=            | Mixed        | Both not raw |
+//! | 12   | Mixed       | ✓   | ✗      | fn=            | Mixed        | Both raw |
+//! | 13   | -           | -   | -      | -              | Symbol check | Verifies exports |
+
+mod native_methods_utils;
+mod util;
+
+use jni::errors::Error;
+use jni::objects::JClass;
+use jni::sys::jint;
+use jni::{Env, EnvUnowned, native_method};
+use rusty_fork::rusty_fork_test;
+
+// ====================================================================================
+// Test 1: fn= + Raw (property syntax) + Export (property syntax)
+// ====================================================================================
+
+fn method1_impl<'local>(
+    _env: EnvUnowned<'local>,
+    _this: jni::objects::JObject<'local>,
+    value: jint,
+) -> jint {
+    value * 2
+}
+
+native_method_test! {
+    test_name: test_inline_raw_prop_export_prop,
+    java_class: "com/example/TestNativeCombinations.java",
+    methods: |class| &[
+        native_method! {
+            raw extern fn method1(value: jint) -> jint,
+            fn = method1_impl,
+            java_type = "com.example.TestNativeCombinations",
+        },
+    ],
+    test_body: |env, class| {
+        let obj = new_object!(env, class)?;
+        let result = call_int_method!(env, obj, "method1", 10)?;
+        assert_eq!(result, 20);
+        Ok(())
+    }
+}
+
+// ====================================================================================
+// Test 2: fn= + Raw (qualifier syntax) + Export (qualifier syntax)
+// ====================================================================================
+
+fn method2_impl<'local>(
+    _env: EnvUnowned<'local>,
+    _this: jni::objects::JObject<'local>,
+    value: jint,
+) -> jint {
+    value * 3
+}
+
+native_method_test! {
+    test_name: test_fn_raw_qual_export_qual,
+    java_class: "com/example/TestNativeCombinations.java",
+    methods: |class| &[
+        native_method! {
+            raw extern fn method2(value: jint) -> jint,
+            fn = method2_impl,
+            java_type = "com.example.TestNativeCombinations",
+        },
+    ],
+    test_body: |env, class| {
+        let obj = new_object!(env, class)?;
+        let result = call_int_method!(env, obj, "method2", 10)?;
+        assert_eq!(result, 30);
+        Ok(())
+    }
+}
+
+// ====================================================================================
+// Test 3: fn= + Raw (property syntax) + Export (property syntax)
+// ====================================================================================
+
+fn method3_impl<'local>(
+    _env: EnvUnowned<'local>,
+    _this: jni::objects::JObject<'local>,
+    value: jint,
+) -> jint {
+    value * 4
+}
+
+native_method_test! {
+    test_name: test_fn_raw_prop_export_prop,
+    java_class: "com/example/TestNativeCombinations.java",
+    methods: |class| &[
+        native_method! {
+            raw extern fn method3(value: jint) -> jint,
+            fn = method3_impl,
+            java_type = "com.example.TestNativeCombinations",
+        },
+    ],
+    test_body: |env, class| {
+        let obj = new_object!(env, class)?;
+        let result = call_int_method!(env, obj, "method3", 10)?;
+        assert_eq!(result, 40);
+        Ok(())
+    }
+}
+
+// ====================================================================================
+// Test 4: fn= + Not Raw + Export (property syntax)
+// ====================================================================================
+
+fn method4_impl<'local>(
+    _env: &mut Env<'local>,
+    _this: jni::objects::JObject<'local>,
+    value: jint,
+) -> Result<jint, Error> {
+    // Non-raw with fn= takes &mut Env and returns Result
+    Ok(value * 5)
+}
+
+native_method_test! {
+    test_name: test_fn_not_raw_export_prop,
+    java_class: "com/example/TestNativeCombinations.java",
+    methods: |class| &[
+        native_method! {
+            extern fn method4(value: jint) -> jint,
+            fn = method4_impl,
+            java_type = "com.example.TestNativeCombinations",
+        },
+    ],
+    test_body: |env, class| {
+        let obj = new_object!(env, class)?;
+        let result = call_int_method!(env, obj, "method4", 10)?;
+        assert_eq!(result, 50);
+        Ok(())
+    }
+}
+
+// ====================================================================================
+// Test 5: Static fn= + Raw + Export (mixed syntax)
+// ====================================================================================
+
+fn static_method1_impl<'local>(
+    _env: EnvUnowned<'local>,
+    _class: JClass<'local>,
+    value: jint,
+) -> jint {
+    value * 10
+}
+
+native_method_test! {
+    test_name: test_static_fn_raw_export,
+    java_class: "com/example/TestNativeCombinations.java",
+    methods: |class| &[
+        native_method! {
+            static raw extern fn static_method1(value: jint) -> jint,
+            fn = static_method1_impl,
+            java_type = "com.example.TestNativeCombinations",
+        },
+    ],
+    test_body: |env, class| {
+        let result = call_static_int_method!(env, class, "staticMethod1", 10)?;
+        assert_eq!(result, 100);
+        Ok(())
+    }
+}
+
+// ====================================================================================
+// Test 6: Static fn= + Raw (qualifier) + Export (qualifier)
+// ====================================================================================
+
+fn static_method2_impl<'local>(
+    _env: EnvUnowned<'local>,
+    _class: JClass<'local>,
+    value: jint,
+) -> jint {
+    value * 20
+}
+
+native_method_test! {
+    test_name: test_static_fn_raw_qual_export_qual,
+    java_class: "com/example/TestNativeCombinations.java",
+    methods: |class| &[
+        native_method! {
+            static raw extern fn staticMethod2(value: jint) -> jint,
+            fn = static_method2_impl,
+            java_type = "com.example.TestNativeCombinations",
+        },
+    ],
+    test_body: |env, class| {
+        let result = call_static_int_method!(env, class, "staticMethod2", 10)?;
+        assert_eq!(result, 200);
+        Ok(())
+    }
+}
+
+// ====================================================================================
+// Test 7: fn= + Not Raw + Export (qualifier syntax)
+// ====================================================================================
+
+fn static_method3_impl<'local>(
+    _env: &mut Env<'local>,
+    _class: JClass<'local>,
+    value: jint,
+) -> Result<jint, Error> {
+    Ok(value * 30)
+}
+
+native_method_test! {
+    test_name: test_static_fn_not_raw_export_qual,
+    java_class: "com/example/TestNativeCombinations.java",
+    methods: |class| &[
+        native_method! {
+            static extern fn staticMethod3(value: jint) -> jint,
+            fn = static_method3_impl,
+            java_type = "com.example.TestNativeCombinations",
+        },
+    ],
+    test_body: |env, class| {
+        let result = call_static_int_method!(env, class, "staticMethod3", 10)?;
+        assert_eq!(result, 300);
+        Ok(())
+    }
+}
+
+// ====================================================================================
+// Test 8: fn= + Not Raw + Not Exported
+// ====================================================================================
+
+fn static_method_non_exported_impl<'local>(
+    _env: &mut Env<'local>,
+    _class: JClass<'local>,
+    value: jint,
+) -> Result<jint, Error> {
+    // Non-raw with fn= takes &mut Env and returns Result
+    Ok(value * 40)
+}
+
+native_method_test! {
+    test_name: test_static_fn_not_raw_not_exported,
+    java_class: "com/example/TestNativeCombinations.java",
+    methods: |class| &[
+        native_method! {
+            static fn staticMethodNonExported(value: jint) -> jint,
+            fn = static_method_non_exported_impl,
+        },
+    ],
+    test_body: |env, class| {
+        let result = call_static_int_method!(env, class, "staticMethodNonExported", 10)?;
+        assert_eq!(result, 400);
+        Ok(())
+    }
+}
+
+// ====================================================================================
+// Test 9: Instance fn= + Not Raw + Not Exported
+// ====================================================================================
+
+fn method_non_exported_impl<'local>(
+    _env: &mut Env<'local>,
+    _this: jni::objects::JObject<'local>,
+    value: jint,
+) -> Result<jint, Error> {
+    Ok(value * 50)
+}
+
+native_method_test! {
+    test_name: test_instance_fn_not_raw_not_exported,
+    java_class: "com/example/TestNativeCombinations.java",
+    methods: |class| &[
+        native_method! {
+            fn methodNonExported(value: jint) -> jint,
+            fn = method_non_exported_impl,
+        },
+    ],
+    test_body: |env, class| {
+        let obj = new_object!(env, class)?;
+        let result = call_int_method!(env, obj, "methodNonExported", 10)?;
+        assert_eq!(result, 500);
+        Ok(())
+    }
+}
+
+// ====================================================================================
+// Test 10: Static fn= + Not Raw + Not Exported
+// ====================================================================================
+
+fn static_method_non_exported2_impl<'local>(
+    _env: &mut Env<'local>,
+    _class: JClass<'local>,
+    value: jint,
+) -> Result<jint, Error> {
+    Ok(value * 60)
+}
+
+native_method_test! {
+    test_name: test_static_fn_not_raw_not_exported2,
+    java_class: "com/example/TestNativeCombinations.java",
+    methods: |class| &[
+        native_method! {
+            static fn staticMethodNonExported2(value: jint) -> jint,
+            fn = static_method_non_exported2_impl,
+        },
+    ],
+    test_body: |env, class| {
+        let result = call_static_int_method!(env, class, "staticMethodNonExported2", 10)?;
+        assert_eq!(result, 600);
+        Ok(())
+    }
+}
+
+// ====================================================================================
+// Test 11: Mixed - fn= (not raw) + fn= (not raw) in one test
+// ====================================================================================
+
+fn method_non_exported_fn_impl<'local>(
+    _env: &mut Env<'local>,
+    _this: jni::objects::JObject<'local>,
+    value: jint,
+) -> Result<jint, Error> {
+    Ok(value * 70)
+}
+
+fn method_non_exported2_impl<'local>(
+    _env: &mut Env<'local>,
+    _this: jni::objects::JObject<'local>,
+    value: jint,
+) -> Result<jint, Error> {
+    Ok(value * 80)
+}
+
+native_method_test! {
+    test_name: test_mixed_fn_not_raw,
+    java_class: "com/example/TestNativeCombinations.java",
+    methods: |class| &[
+        // First fn= implementation
+        native_method! {
+            fn methodNonExported(value: jint) -> jint,
+            fn = method_non_exported_fn_impl,
+        },
+        // Second fn= implementation
+        native_method! {
+            fn methodNonExported2(value: jint) -> jint,
+            fn = method_non_exported2_impl,
+        },
+    ],
+    test_body: |env, class| {
+        let obj = new_object!(env, class)?;
+
+        // Test first fn= method
+        let result = call_int_method!(env, &obj, "methodNonExported", 10)?;
+        assert_eq!(result, 700);
+
+        // Test second fn= method
+        let result = call_int_method!(env, &obj, "methodNonExported2", 10)?;
+        assert_eq!(result, 800);
+
+        Ok(())
+    }
+}
+
+// ====================================================================================
+// Test 12: Mixed - fn= (raw) + fn= (raw) in one test
+// ====================================================================================
+
+fn static_method_non_exported_fn_impl<'local>(
+    _env: EnvUnowned<'local>,
+    _class: JClass<'local>,
+    value: jint,
+) -> jint {
+    value * 90
+}
+
+fn static_method_non_exported2_fn_impl<'local>(
+    _env: EnvUnowned<'local>,
+    _class: JClass<'local>,
+    value: jint,
+) -> jint {
+    value * 100
+}
+
+native_method_test! {
+    test_name: test_mixed_fn_raw,
+    java_class: "com/example/TestNativeCombinations.java",
+    methods: |class| &[
+        // fn= implementation with raw
+        native_method! {
+            static fn staticMethodNonExported(value: jint) -> jint,
+            fn = static_method_non_exported_fn_impl,
+            raw = true,
+        },
+        // fn= implementation with raw
+        native_method! {
+            static raw fn staticMethodNonExported2(value: jint) -> jint,
+            fn = static_method_non_exported2_fn_impl,
+        },
+    ],
+    test_body: |env, class| {
+        // Test first fn= raw method
+        let result = call_static_int_method!(env, &class, "staticMethodNonExported", 10)?;
+        assert_eq!(result, 900);
+
+        // Test second fn= raw method
+        let result = call_static_int_method!(env, &class, "staticMethodNonExported2", 10)?;
+        assert_eq!(result, 1000);
+
+        Ok(())
+    }
+}
+
+// ====================================================================================
+// Test 13: Verify exported symbols exist
+// ====================================================================================
+
+// Declare the exported symbols so we can verify they exist
+unsafe extern "system" {
+    fn Java_com_example_TestNativeCombinations_method1__I(
+        env: EnvUnowned,
+        this: jni::sys::jobject,
+        value: jint,
+    ) -> jint;
+    fn Java_com_example_TestNativeCombinations_method2__I(
+        env: EnvUnowned,
+        this: jni::sys::jobject,
+        value: jint,
+    ) -> jint;
+    fn Java_com_example_TestNativeCombinations_method3__I(
+        env: EnvUnowned,
+        this: jni::sys::jobject,
+        value: jint,
+    ) -> jint;
+    fn Java_com_example_TestNativeCombinations_method4__I(
+        env: EnvUnowned,
+        this: jni::sys::jobject,
+        value: jint,
+    ) -> jint;
+    fn Java_com_example_TestNativeCombinations_staticMethod1__I(
+        env: EnvUnowned,
+        class: JClass,
+        value: jint,
+    ) -> jint;
+    fn Java_com_example_TestNativeCombinations_staticMethod2__I(
+        env: EnvUnowned,
+        class: JClass,
+        value: jint,
+    ) -> jint;
+    fn Java_com_example_TestNativeCombinations_staticMethod3__I(
+        env: EnvUnowned,
+        class: JClass,
+        value: jint,
+    ) -> jint;
+}
+
+#[test]
+fn test_exported_symbols_exist() {
+    // Just referencing the functions verifies they were exported at link time
+    let _fn1 = Java_com_example_TestNativeCombinations_method1__I;
+    let _fn2 = Java_com_example_TestNativeCombinations_method2__I;
+    let _fn3 = Java_com_example_TestNativeCombinations_method3__I;
+    let _fn4 = Java_com_example_TestNativeCombinations_method4__I;
+    let _fn5 = Java_com_example_TestNativeCombinations_staticMethod1__I;
+    let _fn6 = Java_com_example_TestNativeCombinations_staticMethod2__I;
+    let _fn7 = Java_com_example_TestNativeCombinations_staticMethod3__I;
+
+    println!("All exported symbols verified!");
+}

--- a/jni-macros/tests/native_methods_register.rs
+++ b/jni-macros/tests/native_methods_register.rs
@@ -1,0 +1,88 @@
+// Example showing native_method! used in an array for register_native_methods
+
+use jni::errors::Error;
+use jni::objects::{JClass, JObject};
+use jni::sys::{jint, jlong};
+use jni::{Env, NativeMethod, native_method};
+
+// Instance method implementations
+fn add_impl<'local>(
+    _env: &mut Env<'local>,
+    _this: JObject<'local>,
+    a: jint,
+    b: jint,
+) -> Result<jint, Error> {
+    Ok(a + b)
+}
+
+fn multiply_impl<'local>(
+    _env: &mut Env<'local>,
+    _this: JObject<'local>,
+    a: jint,
+    b: jint,
+) -> Result<jint, Error> {
+    Ok(a * b)
+}
+
+// Static method implementations
+fn static_add_impl<'local>(
+    _env: &mut Env<'local>,
+    _class: JClass<'local>,
+    a: jlong,
+    b: jlong,
+) -> Result<jlong, Error> {
+    Ok(a + b)
+}
+
+fn static_multiply_impl<'local>(
+    _env: &mut Env<'local>,
+    _class: JClass<'local>,
+    a: jlong,
+    b: jlong,
+) -> Result<jlong, Error> {
+    Ok(a * b)
+}
+
+const ADD_METHOD: NativeMethod = native_method! {
+    name = "staticAdd",
+    sig = (a: jlong, b: jlong) -> jlong,
+    fn = static_add_impl,
+    static = true,
+};
+
+// This is an example of how you would use these macros with register_native_methods
+#[allow(dead_code)]
+fn register_my_methods(env: &mut Env, class: JClass) -> jni::errors::Result<()> {
+    // Create an array of NativeMethods using the macros
+    const METHODS: &[NativeMethod] = &[
+        ADD_METHOD,
+        native_method! {
+            name = "staticMultiply",
+            sig = (a: jlong, b: jlong) -> jlong,
+            fn = static_multiply_impl,
+            static = true,
+        },
+        native_method! {
+            name = "add",
+            sig = (a: jint, b: jint) -> jint,
+            fn = add_impl
+        },
+        native_method! {
+            name = "multiply",
+            sig = (a: jint, b: jint) -> jint,
+            fn = multiply_impl
+        },
+    ];
+
+    // Register all the methods at once
+    unsafe {
+        env.register_native_methods(class, METHODS)?;
+    }
+
+    Ok(())
+}
+
+#[test]
+fn test_example_compiles() {
+    // This test just verifies the example compiles
+}

--- a/jni-macros/tests/native_methods_utils.rs
+++ b/jni-macros/tests/native_methods_utils.rs
@@ -1,0 +1,270 @@
+//! Utilities for testing the `native_method!` macro.
+//!
+//! This module provides helper functions and macros to simplify writing tests for
+//! the `native_method!` macro, particularly for runtime tests that need to compile
+//! Java classes, register native methods, and call them through JNI.
+
+/// Compile a test Java class and return the output directory.
+///
+/// This helper compiles the specified Java file and returns the path to the
+/// output directory containing the compiled .class files.
+#[allow(dead_code)]
+pub fn compile_test_class(test_name: &str, java_file: &str) -> std::path::PathBuf {
+    let out_dir = std::path::PathBuf::from(env!("CARGO_TARGET_TMPDIR"))
+        .join("jni_macros_tests")
+        .join(test_name);
+
+    // Clean up any existing output
+    let _ = std::fs::remove_dir_all(&out_dir);
+    std::fs::create_dir_all(&out_dir).expect("Failed to create test output directory");
+
+    javac::Build::new()
+        .file(java_file)
+        .output_dir(&out_dir)
+        .compile();
+
+    out_dir
+}
+
+/// Load a test class from the output directory into the JVM.
+///
+/// This helper loads a compiled Java class file into the JVM using a system class loader.
+/// The class should be in the package `com.example`.
+#[allow(dead_code)]
+pub fn load_test_class<'local>(
+    env: &mut jni::Env<'local>,
+    out_dir: &std::path::Path,
+    class_name: &str,
+) -> jni::errors::Result<jni::objects::JClass<'local>> {
+    let class_path = out_dir.join(format!("com/example/{}.class", class_name));
+    assert!(
+        class_path.exists(),
+        "{}.class not found at {:?}",
+        class_name,
+        class_path
+    );
+
+    let class_bytes = std::fs::read(&class_path)
+        .unwrap_or_else(|_| panic!("Failed to read {}.class", class_name));
+
+    let class_loader = jni::objects::JClassLoader::get_system_class_loader(env)
+        .expect("Failed to get system class loader");
+
+    let class_internal_name = format!("com/example/{}", class_name);
+    let class_jni = jni::strings::JNIString::new(class_internal_name.as_str());
+
+    env.define_class(Some(&class_jni), &class_loader, &class_bytes)
+}
+
+/// Macro to simplify native method tests that manually register methods.
+///
+/// This macro reduces boilerplate for tests that need to:
+/// 1. Compile a Java class
+/// 2. Set up the JVM
+/// 3. Load the class
+/// 4. Register native methods
+/// 5. Execute test code
+/// 6. Optionally handle expected exceptions
+///
+/// # Examples
+///
+/// Basic test that expects success:
+/// ```ignore
+/// native_method_test! {
+///     test_name: test_my_native_method,
+///     java_class: "com/example/TestClass.java",
+///     methods: |class| &[
+///         native_method! {
+///             name = "myMethod",
+///             sig = (value: jint) -> jint,
+///             fn = my_method_impl,
+///         },
+///     ],
+///     test_body: |env, class| {
+///         let result = env.call_static_method(class, "myMethod", "(I)I", &[jni::objects::JValue::Int(42)])?;
+///         assert_eq!(result.i()?, 84);
+///         Ok(())
+///     }
+/// }
+/// ```
+///
+/// Test that expects an exception:
+/// ```ignore
+/// native_method_test! {
+///     test_name: test_expected_exception,
+///     java_class: "com/example/TestClass.java",
+///     methods: |class| &[
+///         native_method! {
+///             name = "badMethod",
+///             sig = () -> void,
+///             fn = bad_method_impl,
+///         },
+///     ],
+///     expect_exception: "Method should throw",
+///     test_body: |env, class| {
+///         env.call_static_method(class, "badMethod", "()V", &[])?;
+///         Ok(())
+///     }
+/// }
+/// ```
+#[macro_export]
+macro_rules! native_method_test {
+    // Variant that expects the test to succeed
+    (
+        $(#[$attribute:meta])*
+        test_name: $test_name:ident,
+        java_class: $java_class:literal,
+        methods: |$class_param:ident| $methods:expr,
+        test_body: |$env:ident, $class:ident| $body:block
+    ) => {
+        rusty_fork::rusty_fork_test! {
+            #[test]
+            $(#[$attribute])*
+            fn $test_name() {
+                #[allow(clippy::crate_in_macro_def)]
+                let out_dir = $crate::native_methods_utils::compile_test_class(
+                    stringify!($test_name),
+                    concat!("tests/java/", $java_class)
+                );
+
+                #[allow(clippy::crate_in_macro_def)]
+                $crate::util::attach_current_thread(|$env| {
+                    let class_name = $java_class
+                        .trim_end_matches(".java")
+                        .split('/')
+                        .last()
+                        .expect("Invalid Java class path");
+
+                    #[allow(clippy::crate_in_macro_def)]
+                    let $class = $crate::native_methods_utils::load_test_class($env, &out_dir, class_name)?;
+
+                    // Register native methods
+                    let methods: &[jni::NativeMethod] = $methods;
+                    unsafe {
+                        $env.register_native_methods(&$class, methods)?;
+                    }
+
+                    // Run test body
+                    $body
+                })
+                .expect(concat!(stringify!($test_name), " failed"));
+            }
+        }
+    };
+
+    // Variant that expects the test to fail with a JavaException
+    (
+        $(#[$attribute:meta])*
+        test_name: $test_name:ident,
+        java_class: $java_class:literal,
+        methods: |$class_param:ident| $methods:expr,
+        expect_exception: $expected_msg:expr,
+        test_body: |$env:ident, $class:ident| $body:block
+    ) => {
+        rusty_fork::rusty_fork_test! {
+            #[test]
+            $(#[$attribute])*
+            fn $test_name() {
+                #[allow(clippy::crate_in_macro_def)]
+                let out_dir = $crate::native_methods_utils::compile_test_class(
+                    stringify!($test_name),
+                    concat!("tests/java/", $java_class)
+                );
+
+                #[allow(clippy::crate_in_macro_def)]
+                let result = $crate::util::attach_current_thread(|$env| {
+                    let class_name = $java_class
+                        .trim_end_matches(".java")
+                        .split('/')
+                        .last()
+                        .expect("Invalid Java class path");
+
+                    #[allow(clippy::crate_in_macro_def)]
+                    let $class = $crate::native_methods_utils::load_test_class($env, &out_dir, class_name)?;
+
+                    // Register native methods
+                    let methods: &[jni::NativeMethod] = $methods;
+                    unsafe {
+                        $env.register_native_methods(&$class, methods)?;
+                    }
+
+                    // Run test body
+                    $body
+                });
+
+                match result {
+                    Err(jni::errors::Error::JavaException) => {
+                        println!("✓ {}", $expected_msg);
+                    }
+                    _ => panic!("Expected JavaException: {}, got: {:?}", $expected_msg, result),
+                }
+            }
+        }
+    };
+}
+
+/// Macro to call an instance method with integer argument.
+///
+/// Simplified wrapper around `call_method` for the common case of calling
+/// a method that takes a single `jint` and returns a `jint`.
+///
+/// # Example
+/// ```ignore
+/// let result = call_int_method!(env, &obj, "callMethod", 42)?;
+/// ```
+#[macro_export]
+macro_rules! call_int_method {
+    ($env:expr, $obj:expr, $method_name:literal, $arg:expr) => {{
+        use jni::jni_str;
+        let result = $env.call_method(
+            $obj,
+            jni_str!($method_name),
+            jni_str!("(I)I"),
+            //jni_sig!("(I)I"), TODO
+            &[jni::objects::JValue::Int($arg)],
+        )?;
+        result.i()
+    }};
+}
+
+/// Macro to call a static method with integer argument.
+///
+/// Simplified wrapper around `call_static_method` for the common case of calling
+/// a static method that takes a single `jint` and returns a `jint`.
+///
+/// # Example
+/// ```ignore
+/// let result = call_static_int_method!(env, class, "callStaticMethod", 42)?;
+/// ```
+#[macro_export]
+macro_rules! call_static_int_method {
+    ($env:expr, $class:expr, $method_name:literal, $arg:expr) => {{
+        use jni::jni_str;
+        let result = $env.call_static_method(
+            $class,
+            jni_str!($method_name),
+            jni_str!("(I)I"),
+            //jni_sig!("(I)I"), TODO
+            &[jni::objects::JValue::Int($arg)],
+        )?;
+        result.i()
+    }};
+}
+
+/// Macro to create a new object with default constructor.
+///
+/// Simplified wrapper around `new_object` for the common case of creating
+/// an object with a no-argument constructor.
+///
+/// # Example
+/// ```ignore
+/// let obj = new_object!(env, class)?;
+/// ```
+#[macro_export]
+macro_rules! new_object {
+    ($env:expr, $class:expr) => {{
+        use jni::jni_str;
+        $env.new_object(&$class, jni_str!("()V"), &[])
+        //$env.new_object(&$class, jni_sig!("()V"), &[]) TODO
+    }};
+}

--- a/jni-macros/tests/trybuild.rs
+++ b/jni-macros/tests/trybuild.rs
@@ -1,0 +1,8 @@
+#[test]
+fn ui() {
+    let t = trybuild::TestCases::new();
+    t.compile_fail("tests/ui/fail/*.rs");
+    t.compile_fail("tests/ui/bind_java_type/fail/*.rs");
+    t.pass("tests/ui/bind_java_type/pass/*.rs");
+    t.compile_fail("tests/ui/native_method/fail/*.rs");
+}

--- a/jni-macros/tests/ui/native_method/fail/raw_shorthand_wrong_parameter_type.rs
+++ b/jni-macros/tests/ui/native_method/fail/raw_shorthand_wrong_parameter_type.rs
@@ -1,0 +1,22 @@
+use jni::EnvUnowned;
+use jni::objects::JObject;
+use jni::sys::jlong;
+use jni_macros::native_method;
+
+// This should fail with shorthand syntax - raw function takes jlong instead of jint
+
+type MyClass<'local> = JObject<'local>;
+
+extern "system" fn my_method_impl<'local>(
+    _env: EnvUnowned<'local>,
+    _this: JObject<'local>,
+    _value: jlong, // Wrong! Should be jint
+) {
+}
+
+fn main() {
+    let _method = native_method! {
+        raw fn MyClass::myMethod(value: jint) -> void,
+        fn = my_method_impl
+    };
+}

--- a/jni-macros/tests/ui/native_method/fail/raw_shorthand_wrong_parameter_type.stderr
+++ b/jni-macros/tests/ui/native_method/fail/raw_shorthand_wrong_parameter_type.stderr
@@ -1,0 +1,20 @@
+error[E0308]: mismatched types
+  --> tests/ui/native_method/fail/raw_shorthand_wrong_parameter_type.rs:19:34
+   |
+19 |         raw fn MyClass::myMethod(value: jint) -> void,
+   |                                  ^^^^^ expected `i64`, found `i32`
+20 |         fn = my_method_impl
+   |              -------------- arguments to this function are incorrect
+   |
+note: function defined here
+  --> tests/ui/native_method/fail/raw_shorthand_wrong_parameter_type.rs:10:20
+   |
+10 | extern "system" fn my_method_impl<'local>(
+   |                    ^^^^^^^^^^^^^^
+...
+13 |     _value: jlong, // Wrong! Should be jint
+   |     -------------
+help: you can convert an `i32` to an `i64`
+   |
+19 |         raw fn MyClass::myMethod(value.into(): jint) -> void,
+   |                                       +++++++

--- a/jni-macros/tests/ui/native_method/fail/raw_shorthand_wrong_return_type.rs
+++ b/jni-macros/tests/ui/native_method/fail/raw_shorthand_wrong_return_type.rs
@@ -1,0 +1,23 @@
+use jni::EnvUnowned;
+use jni::objects::JObject;
+use jni::sys::jlong;
+use jni_macros::native_method;
+
+// This should fail with shorthand syntax - raw function returns jlong instead of jint
+
+type MyClass<'local> = JObject<'local>;
+
+extern "system" fn my_method_impl<'local>(
+    _env: EnvUnowned<'local>,
+    _this: JObject<'local>,
+) -> jlong {
+    // Wrong! Should return jint
+    0
+}
+
+fn main() {
+    let _method = native_method! {
+        raw fn MyClass::myMethod() -> jint,
+        fn = my_method_impl
+    };
+}

--- a/jni-macros/tests/ui/native_method/fail/raw_shorthand_wrong_return_type.stderr
+++ b/jni-macros/tests/ui/native_method/fail/raw_shorthand_wrong_return_type.stderr
@@ -1,0 +1,18 @@
+error[E0308]: mismatched types
+  --> tests/ui/native_method/fail/raw_shorthand_wrong_return_type.rs:19:19
+   |
+19 |       let _method = native_method! {
+   |  ___________________^
+20 | |         raw fn MyClass::myMethod() -> jint,
+21 | |         fn = my_method_impl
+22 | |     };
+   | |     ^
+   | |     |
+   | |_____expected `i32`, found `i64`
+   |       expected `i32` because of return type
+   |
+   = note: this error originates in the macro `native_method` (in Nightly builds, run with -Z macro-backtrace for more info)
+help: you can convert an `i64` to an `i32` and panic if the converted value doesn't fit
+   |
+22 |     }.try_into().unwrap();
+   |      ++++++++++++++++++++

--- a/jni-macros/tests/ui/native_method/fail/raw_wrong_parameter_count.rs
+++ b/jni-macros/tests/ui/native_method/fail/raw_wrong_parameter_count.rs
@@ -1,0 +1,22 @@
+use jni::EnvUnowned;
+use jni::objects::JObject;
+use jni::sys::jint;
+use jni_macros::native_method;
+
+// This should fail because the raw function has 1 param but signature expects 2
+
+extern "system" fn my_method_impl<'local>(
+    _env: EnvUnowned<'local>,
+    _this: JObject<'local>,
+    _value: jint, // Missing second parameter!
+) {
+}
+
+fn main() {
+    let _method = native_method! {
+        name = "myMethod",
+        sig = (a: jint, b: jint) -> void,
+        fn = my_method_impl,
+        raw = true,
+    };
+}

--- a/jni-macros/tests/ui/native_method/fail/raw_wrong_parameter_count.stderr
+++ b/jni-macros/tests/ui/native_method/fail/raw_wrong_parameter_count.stderr
@@ -1,0 +1,13 @@
+error[E0061]: this function takes 3 arguments but 4 arguments were supplied
+  --> tests/ui/native_method/fail/raw_wrong_parameter_count.rs:19:14
+   |
+18 |         sig = (a: jint, b: jint) -> void,
+   |                         - unexpected argument #4 of type `i32`
+19 |         fn = my_method_impl,
+   |              ^^^^^^^^^^^^^^
+   |
+note: function defined here
+  --> tests/ui/native_method/fail/raw_wrong_parameter_count.rs:8:20
+   |
+ 8 | extern "system" fn my_method_impl<'local>(
+   |                    ^^^^^^^^^^^^^^

--- a/jni-macros/tests/ui/native_method/fail/raw_wrong_parameter_type.rs
+++ b/jni-macros/tests/ui/native_method/fail/raw_wrong_parameter_type.rs
@@ -1,0 +1,22 @@
+use jni::EnvUnowned;
+use jni::objects::JObject;
+use jni::sys::jlong;
+use jni_macros::native_method;
+
+// This should fail because the raw function takes jlong but signature expects jint
+
+extern "system" fn my_method_impl<'local>(
+    _env: EnvUnowned<'local>,
+    _this: JObject<'local>,
+    _value: jlong, // Wrong! Should be jint
+) {
+}
+
+fn main() {
+    let _method = native_method! {
+        name = "myMethod",
+        sig = (value: jint) -> void,
+        fn = my_method_impl,
+        raw = true,
+    };
+}

--- a/jni-macros/tests/ui/native_method/fail/raw_wrong_parameter_type.stderr
+++ b/jni-macros/tests/ui/native_method/fail/raw_wrong_parameter_type.stderr
@@ -1,0 +1,20 @@
+error[E0308]: mismatched types
+  --> tests/ui/native_method/fail/raw_wrong_parameter_type.rs:18:16
+   |
+18 |         sig = (value: jint) -> void,
+   |                ^^^^^ expected `i64`, found `i32`
+19 |         fn = my_method_impl,
+   |              -------------- arguments to this function are incorrect
+   |
+note: function defined here
+  --> tests/ui/native_method/fail/raw_wrong_parameter_type.rs:8:20
+   |
+ 8 | extern "system" fn my_method_impl<'local>(
+   |                    ^^^^^^^^^^^^^^
+...
+11 |     _value: jlong, // Wrong! Should be jint
+   |     -------------
+help: you can convert an `i32` to an `i64`
+   |
+18 |         sig = (value.into(): jint) -> void,
+   |                     +++++++

--- a/jni-macros/tests/ui/native_method/fail/raw_wrong_return_type.rs
+++ b/jni-macros/tests/ui/native_method/fail/raw_wrong_return_type.rs
@@ -1,0 +1,23 @@
+use jni::EnvUnowned;
+use jni::objects::JObject;
+use jni::sys::jlong;
+use jni_macros::native_method;
+
+// This should fail because the raw function returns jlong but signature expects jint
+
+extern "system" fn my_method_impl<'local>(
+    _env: EnvUnowned<'local>,
+    _this: JObject<'local>,
+) -> jlong {
+    // Wrong! Should return jint
+    0
+}
+
+fn main() {
+    let _method = native_method! {
+        name = "myMethod",
+        sig = () -> jint,
+        fn = my_method_impl,
+        raw = true,
+    };
+}

--- a/jni-macros/tests/ui/native_method/fail/raw_wrong_return_type.stderr
+++ b/jni-macros/tests/ui/native_method/fail/raw_wrong_return_type.stderr
@@ -1,0 +1,20 @@
+error[E0308]: mismatched types
+  --> tests/ui/native_method/fail/raw_wrong_return_type.rs:17:19
+   |
+17 |       let _method = native_method! {
+   |  ___________________^
+18 | |         name = "myMethod",
+19 | |         sig = () -> jint,
+20 | |         fn = my_method_impl,
+21 | |         raw = true,
+22 | |     };
+   | |     ^
+   | |     |
+   | |_____expected `i32`, found `i64`
+   |       expected `i32` because of return type
+   |
+   = note: this error originates in the macro `native_method` (in Nightly builds, run with -Z macro-backtrace for more info)
+help: you can convert an `i64` to an `i32` and panic if the converted value doesn't fit
+   |
+22 |     }.try_into().unwrap();
+   |      ++++++++++++++++++++

--- a/jni-macros/tests/ui/native_method/fail/shorthand_wrong_parameter_type.rs
+++ b/jni-macros/tests/ui/native_method/fail/shorthand_wrong_parameter_type.rs
@@ -1,0 +1,24 @@
+use jni::Env;
+use jni::errors::Error;
+use jni::objects::JObject;
+use jni::sys::{jint, jlong};
+use jni_macros::native_method;
+
+// This should fail with shorthand syntax - jlong instead of jint
+
+type MyClass<'local> = JObject<'local>;
+
+fn my_method_impl<'local>(
+    _env: &mut Env<'local>,
+    _this: JObject<'local>,
+    _value: jlong, // Wrong! Should be jint
+) -> Result<(), Error> {
+    Ok(())
+}
+
+fn main() {
+    let _method = native_method! {
+        fn MyClass::myMethod(value: jint) -> void,
+        fn = my_method_impl
+    };
+}

--- a/jni-macros/tests/ui/native_method/fail/shorthand_wrong_parameter_type.stderr
+++ b/jni-macros/tests/ui/native_method/fail/shorthand_wrong_parameter_type.stderr
@@ -1,0 +1,28 @@
+warning: unused import: `jint`
+ --> tests/ui/native_method/fail/shorthand_wrong_parameter_type.rs:4:16
+  |
+4 | use jni::sys::{jint, jlong};
+  |                ^^^^
+  |
+  = note: `#[warn(unused_imports)]` (part of `#[warn(unused)]`) on by default
+
+error[E0308]: mismatched types
+  --> tests/ui/native_method/fail/shorthand_wrong_parameter_type.rs:21:30
+   |
+21 |         fn MyClass::myMethod(value: jint) -> void,
+   |                              ^^^^^ expected `i64`, found `i32`
+22 |         fn = my_method_impl
+   |              -------------- arguments to this function are incorrect
+   |
+note: function defined here
+  --> tests/ui/native_method/fail/shorthand_wrong_parameter_type.rs:11:4
+   |
+11 | fn my_method_impl<'local>(
+   |    ^^^^^^^^^^^^^^
+...
+14 |     _value: jlong, // Wrong! Should be jint
+   |     -------------
+help: you can convert an `i32` to an `i64`
+   |
+21 |         fn MyClass::myMethod(value.into(): jint) -> void,
+   |                                   +++++++

--- a/jni-macros/tests/ui/native_method/fail/shorthand_wrong_return_type.rs
+++ b/jni-macros/tests/ui/native_method/fail/shorthand_wrong_return_type.rs
@@ -1,0 +1,21 @@
+use jni::Env;
+use jni::errors::Error;
+use jni::objects::JObject;
+use jni::sys::{jint, jlong};
+use jni_macros::native_method;
+
+// This should fail with shorthand syntax - returns jlong instead of jint
+
+type MyClass<'local> = JObject<'local>;
+
+fn my_method_impl<'local>(_env: &mut Env<'local>, _this: JObject<'local>) -> Result<jlong, Error> {
+    // Wrong! Should return jint
+    Ok(0)
+}
+
+fn main() {
+    let _method = native_method! {
+        fn MyClass::myMethod() -> jint,
+        fn = my_method_impl
+    };
+}

--- a/jni-macros/tests/ui/native_method/fail/shorthand_wrong_return_type.stderr
+++ b/jni-macros/tests/ui/native_method/fail/shorthand_wrong_return_type.stderr
@@ -1,0 +1,26 @@
+warning: unused import: `jint`
+ --> tests/ui/native_method/fail/shorthand_wrong_return_type.rs:4:16
+  |
+4 | use jni::sys::{jint, jlong};
+  |                ^^^^
+  |
+  = note: `#[warn(unused_imports)]` (part of `#[warn(unused)]`) on by default
+
+error[E0308]: mismatched types
+  --> tests/ui/native_method/fail/shorthand_wrong_return_type.rs:17:19
+   |
+17 |       let _method = native_method! {
+   |  ___________________^
+18 | |         fn MyClass::myMethod() -> jint,
+19 | |         fn = my_method_impl
+20 | |     };
+   | |     ^
+   | |     |
+   | |_____expected `i32`, found `i64`
+   |       expected `i32` because of return type
+   |
+   = note: this error originates in the macro `native_method` (in Nightly builds, run with -Z macro-backtrace for more info)
+help: you can convert an `i64` to an `i32` and panic if the converted value doesn't fit
+   |
+20 |     }.try_into().unwrap();
+   |      ++++++++++++++++++++

--- a/jni-macros/tests/ui/native_method/fail/wrong_parameter_count.rs
+++ b/jni-macros/tests/ui/native_method/fail/wrong_parameter_count.rs
@@ -1,0 +1,23 @@
+use jni::Env;
+use jni::errors::Error;
+use jni::objects::JObject;
+use jni::sys::jint;
+use jni_macros::native_method;
+
+// This should fail because the function has 1 param but signature expects 2
+
+fn my_method_impl<'local>(
+    _env: &mut Env<'local>,
+    _this: JObject<'local>,
+    _value: jint, // Missing second parameter!
+) -> Result<(), Error> {
+    Ok(())
+}
+
+fn main() {
+    let _method = native_method! {
+        name = "myMethod",
+        sig = (a: jint, b: jint) -> void,
+        fn = my_method_impl
+    };
+}

--- a/jni-macros/tests/ui/native_method/fail/wrong_parameter_count.stderr
+++ b/jni-macros/tests/ui/native_method/fail/wrong_parameter_count.stderr
@@ -1,0 +1,13 @@
+error[E0061]: this function takes 3 arguments but 4 arguments were supplied
+  --> tests/ui/native_method/fail/wrong_parameter_count.rs:21:14
+   |
+20 |         sig = (a: jint, b: jint) -> void,
+   |                         - unexpected argument #4 of type `i32`
+21 |         fn = my_method_impl
+   |              ^^^^^^^^^^^^^^
+   |
+note: function defined here
+  --> tests/ui/native_method/fail/wrong_parameter_count.rs:9:4
+   |
+ 9 | fn my_method_impl<'local>(
+   |    ^^^^^^^^^^^^^^

--- a/jni-macros/tests/ui/native_method/fail/wrong_parameter_type.rs
+++ b/jni-macros/tests/ui/native_method/fail/wrong_parameter_type.rs
@@ -1,0 +1,23 @@
+use jni::Env;
+use jni::errors::Error;
+use jni::objects::JObject;
+use jni::sys::{jint, jlong};
+use jni_macros::native_method;
+
+// This should fail because the function takes jlong but signature expects jint
+
+fn my_method_impl<'local>(
+    _env: &mut Env<'local>,
+    _this: JObject<'local>,
+    _value: jlong, // Wrong! Should be jint
+) -> Result<(), Error> {
+    Ok(())
+}
+
+fn main() {
+    let _method = native_method! {
+        name = "myMethod",
+        sig = (value: jint) -> void,
+        fn = my_method_impl
+    };
+}

--- a/jni-macros/tests/ui/native_method/fail/wrong_parameter_type.stderr
+++ b/jni-macros/tests/ui/native_method/fail/wrong_parameter_type.stderr
@@ -1,0 +1,28 @@
+warning: unused import: `jint`
+ --> tests/ui/native_method/fail/wrong_parameter_type.rs:4:16
+  |
+4 | use jni::sys::{jint, jlong};
+  |                ^^^^
+  |
+  = note: `#[warn(unused_imports)]` (part of `#[warn(unused)]`) on by default
+
+error[E0308]: mismatched types
+  --> tests/ui/native_method/fail/wrong_parameter_type.rs:20:16
+   |
+20 |         sig = (value: jint) -> void,
+   |                ^^^^^ expected `i64`, found `i32`
+21 |         fn = my_method_impl
+   |              -------------- arguments to this function are incorrect
+   |
+note: function defined here
+  --> tests/ui/native_method/fail/wrong_parameter_type.rs:9:4
+   |
+ 9 | fn my_method_impl<'local>(
+   |    ^^^^^^^^^^^^^^
+...
+12 |     _value: jlong, // Wrong! Should be jint
+   |     -------------
+help: you can convert an `i32` to an `i64`
+   |
+20 |         sig = (value.into(): jint) -> void,
+   |                     +++++++

--- a/jni-macros/tests/ui/native_method/fail/wrong_return_type.rs
+++ b/jni-macros/tests/ui/native_method/fail/wrong_return_type.rs
@@ -1,0 +1,20 @@
+use jni::Env;
+use jni::errors::Error;
+use jni::objects::JObject;
+use jni::sys::jlong;
+use jni_macros::native_method;
+
+// This should fail because the function returns jlong but signature expects jint
+
+fn my_method_impl<'local>(_env: &mut Env<'local>, _this: JObject<'local>) -> Result<jlong, Error> {
+    // Wrong! Should return jint
+    Ok(0)
+}
+
+fn main() {
+    let _method = native_method! {
+        name = "myMethod",
+        sig = () -> jint,
+        fn = my_method_impl
+    };
+}

--- a/jni-macros/tests/ui/native_method/fail/wrong_return_type.stderr
+++ b/jni-macros/tests/ui/native_method/fail/wrong_return_type.stderr
@@ -1,0 +1,19 @@
+error[E0308]: mismatched types
+  --> tests/ui/native_method/fail/wrong_return_type.rs:15:19
+   |
+15 |       let _method = native_method! {
+   |  ___________________^
+16 | |         name = "myMethod",
+17 | |         sig = () -> jint,
+18 | |         fn = my_method_impl
+19 | |     };
+   | |     ^
+   | |     |
+   | |_____expected `i32`, found `i64`
+   |       expected `i32` because of return type
+   |
+   = note: this error originates in the macro `native_method` (in Nightly builds, run with -Z macro-backtrace for more info)
+help: you can convert an `i64` to an `i32` and panic if the converted value doesn't fit
+   |
+19 |     }.try_into().unwrap();
+   |      ++++++++++++++++++++

--- a/jni-macros/tests/util/mod.rs
+++ b/jni-macros/tests/util/mod.rs
@@ -1,0 +1,114 @@
+use std::sync::{Arc, Once};
+
+use jni::{Env, InitArgsBuilder, JNIVersion, JavaVM, errors::Result};
+
+pub fn jvm() -> &'static Arc<JavaVM> {
+    static mut JVM: Option<Arc<JavaVM>> = None;
+    static INIT: Once = Once::new();
+
+    INIT.call_once(|| {
+        let jvm_args = InitArgsBuilder::new()
+            .version(JNIVersion::V1_8)
+            .option("-Xcheck:jni")
+            .build()
+            .unwrap_or_else(|e| panic!("{:#?}", e));
+
+        let jvm = JavaVM::new(jvm_args).unwrap_or_else(|e| panic!("{:#?}", e));
+
+        unsafe {
+            JVM = Some(Arc::new(jvm));
+        }
+    });
+
+    #[allow(static_mut_refs)]
+    unsafe {
+        JVM.as_ref().unwrap()
+    }
+}
+
+#[allow(dead_code)]
+pub fn attach_current_thread<F, T>(callback: F) -> jni::errors::Result<T>
+where
+    F: FnOnce(&mut Env) -> jni::errors::Result<T>,
+{
+    jvm().attach_current_thread(|env| callback(env))
+}
+
+#[allow(dead_code)]
+pub fn attach_current_thread_for_scope<F, T>(callback: F) -> jni::errors::Result<T>
+where
+    F: FnOnce(&mut Env) -> jni::errors::Result<T>,
+{
+    jvm().attach_current_thread_for_scope(|env| callback(env))
+}
+
+#[allow(dead_code)]
+pub fn is_thread_attached() -> bool {
+    jvm()
+        .is_thread_attached()
+        .expect("An unexpected JNI error occurred")
+}
+
+#[allow(dead_code)]
+pub fn detach_current_thread() -> Result<()> {
+    jvm().detach_current_thread()
+}
+
+pub fn print_exception(env: &Env) {
+    let exception_occurred = env.exception_check();
+    if exception_occurred {
+        env.exception_describe();
+    }
+}
+
+#[allow(dead_code)]
+pub fn unwrap<T>(res: Result<T>, env: &Env) -> T {
+    res.unwrap_or_else(|e| {
+        print_exception(env);
+        panic!("{:#?}", e);
+    })
+}
+
+// Generic helper function to load any test class
+#[allow(dead_code)]
+pub fn load_test_class(
+    env: &mut Env,
+    out_dir: &std::path::Path,
+    class_name: &str,
+) -> jni::errors::Result<()> {
+    let class_path = out_dir.join(format!("com/example/{}.class", class_name));
+    assert!(
+        class_path.exists(),
+        "{}.class not found at {:?}",
+        class_name,
+        class_path
+    );
+
+    let class_bytes = std::fs::read(&class_path)
+        .unwrap_or_else(|_| panic!("Failed to read {}.class", class_name));
+
+    let class_loader = jni::objects::JClassLoader::get_system_class_loader(env)
+        .expect("Failed to get system class loader");
+
+    let class_internal_name = format!("com/example/{}", class_name);
+    let class_jni = jni::strings::JNIString::new(class_internal_name.as_str());
+
+    env.define_class(Some(&class_jni), &class_loader, &class_bytes)
+        .unwrap_or_else(|_| panic!("Failed to define {} class", class_name));
+
+    Ok(())
+}
+
+// Helper function to set up test output directory
+#[allow(dead_code)]
+pub fn setup_test_output(test_name: &str) -> std::path::PathBuf {
+    let out_dir = std::path::PathBuf::from(env!("CARGO_TARGET_TMPDIR"))
+        .join("jni_macros_tests")
+        .join(test_name);
+
+    // Clean up any existing output
+    let _ = std::fs::remove_dir_all(&out_dir);
+    std::fs::create_dir_all(&out_dir).expect("Failed to create test output directory");
+
+    out_dir
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -352,3 +352,5 @@ pub use jni_macros::jni_sig;
 pub use jni_macros::jni_sig_cstr;
 pub use jni_macros::jni_sig_jstr;
 pub use jni_macros::jni_sig_str;
+
+pub use jni_macros::native_method;


### PR DESCRIPTION
This makes it possible to construct an `env::NativeMethod` with a guarantee that the function pointer matches the JNI signature.

The macro has a long-form `prop = <val>,` config syntax and a short-form signature syntax for common cases.

The signature parsing is based on the syntax introduced for `jni_sig!`

For example:

```
let method = native_method! {
    static extern fn MyRustType::my_native_method(arg: jint) -> bool
};
```

In this case `my_native_method` is mapped to "myNativeMethod" as the Java method name. The signature would be "(I)Z" and the implementation function would be `MyRustType::my_native_method`. If it was an instance method then `MyRustType` would also be used for the `this` argument.

**Note** Although this initially looks like a pretty large PR, the majority of the additions are documentation, examples and tests and it wouldn't really make much sense to split those out into separate PRs.

### Definition of Done

- [x] There are no TODOs left in the code
    (actually there are some TODO comments for examples/tests that should use `jni_sig!()` instead of `jni_str!()` after landing planned changes for method call APIs to require a pre-parsed signature instead of a string literal - but these aren't TODOs for _this_ feature)
- [x] Change is covered by [automated tests](https://github.com/jni-rs/jni-rs/blob/master/CONTRIBUTING.md#tests)
- [x] The [coding guidelines](https://github.com/jni-rs/jni-rs/blob/master/CONTRIBUTING.md#the-code-style) are followed
- [x] Public API has documentation
- [x] User-visible changes are mentioned in the Changelog
- [x] The continuous integration build passes
