### PR TITLE
NativeMethod: impl Copy/Clone + const ::from_raw_parts

### DIFF
--- a/src/env.rs
+++ b/src/env.rs
@@ -4497,7 +4497,7 @@ impl<'local> EnvUnowned<'local> {
 }
 
 #[repr(transparent)]
-#[derive(Debug)]
+#[derive(Debug, Clone, Copy)]
 /// Native method descriptor for use with [`Env::register_native_methods`].
 ///
 /// This is a `#[repr(transparent)]` / `repr(C)` wrapper around the [`crate::sys::JNINativeMethod`]
@@ -4530,7 +4530,7 @@ impl<'desc> NativeMethod<'desc> {
     /// or some specific `this` type like:
     ///
     /// `fn<'local>(unowned_env: EnvUnowned<'local>, this: MyType<'local>, arg0: jint) -> JString<'local>`.
-    pub unsafe fn from_raw_parts(
+    pub const unsafe fn from_raw_parts(
         name: &'desc JNIStr,
         sig: &'desc JNIStr,
         fn_ptr: *mut c_void,

--- a/src/strings/ffi_str.rs
+++ b/src/strings/ffi_str.rs
@@ -318,7 +318,7 @@ impl JNIStr {
     /// <code>self.[as_cstr][JNIStr::as_cstr]().[as_ptr][CStr::as_ptr]()</code>.
     ///
     /// [modified UTF-8]: https://en.wikipedia.org/wiki/UTF-8#Modified_UTF-8
-    pub fn as_ptr(&self) -> *const c_char {
+    pub const fn as_ptr(&self) -> *const c_char {
         self.as_cstr().as_ptr()
     }
 
@@ -377,7 +377,7 @@ impl JNIStr {
     /// To convert to a Rust string, use the [`JNIStr::to_str`] method instead.
     ///
     /// [modified UTF-8]: https://en.wikipedia.org/wiki/UTF-8#Modified_UTF-8
-    pub fn as_cstr(&self) -> &CStr {
+    pub const fn as_cstr(&self) -> &CStr {
         &self.internal
     }
 


### PR DESCRIPTION
This makes it possible to define `const` `NativeMethods` at compile time which can also be copied into an array for `env.register_native_methods`

