### PR TITLE
javac: show formatted err on compile() failure

### DIFF
--- a/javac/src/lib.rs
+++ b/javac/src/lib.rs
@@ -949,7 +949,7 @@ impl JavaCompiler {
     /// # }
     /// ```
     pub fn compile(&self) -> Vec<PathBuf> {
-        self.try_compile().expect("javac compilation failed")
+        self.try_compile().unwrap_or_else(|err| panic!("{err}"))
     }
 
     /// Try to compile the Java sources, returning a `Result`.


### PR DESCRIPTION
Instead of using `.expect()` to unwrap a `.compile()` failure, use `.unwrap_or_else(|err| panic!("{err}")` so we see the Display formatted Error, otherwise compilation failures show the Debug formatted CompilationFailed enum variant where the strings have escape codes for new lines.
