### PR TITLE
refs: Add `TransparentReference` marker trait

### DIFF
--- a/src/refs/reference.rs
+++ b/src/refs/reference.rs
@@ -409,6 +409,23 @@ pub unsafe trait Reference: Sized {
     }
 }
 
+mod transparent_reference {
+    pub trait True {}
+    #[derive(Debug)]
+    pub struct AssertEq<A, B>(std::marker::PhantomData<(A, B)>);
+    impl<T> True for AssertEq<T, T> {}
+}
+
+/// A marker trait for Reference types that are FFI-safe transparent wrappers that match their
+/// associated Kind type
+pub trait TransparentReference: Reference {}
+impl<'local, T> TransparentReference for T
+where
+    T: Reference + 'local,
+    transparent_reference::AssertEq<<T as Reference>::Kind<'local>, T>: transparent_reference::True,
+{
+}
+
 /// Represents the context that influences how a class may be loaded.
 #[derive(Debug, Default)]
 pub enum LoaderContext<'any_local, 'a> {


### PR DESCRIPTION
The `Reference` trait requires that the `Kind` and `GlobalKind` associated types are always transparent JNI reference wrappers but the Reference type itself isn't always required to be a transparent wrapper.

There are times though when it's useful to be able to assert that we have a Reference type that is itself a transparent JNI reference wrapper and so this adds a marker trait that is automatically implemented for all Reference types where `Self == Self::Kind`.

For example this can be useful to assert when implementing an `AsRef` cast into some Reference type in terms of an `unsafe` pointer cast.
