### PR TITLE
Require pre-parsed JNI signatures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -190,6 +190,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `AutoElements[Critical]::discard()` now takes ownership of the elements and drops them to release the pointer after setting the mode to `NoCopyBack` ([#645](https://github.com/jni-rs/jni-rs/pull/645))
 - Mark `MonitorGuard` with `#[must_use]` to warn when the guard is dropped accidentally ([#676](https://github.com/jni-rs/jni-rs/pull/676))
 - `NativeMethod` (used with `Env::register_native_methods`) is a now a transparent `jni::sys::JNINativeWrapper` wrapper with an `unsafe` `::from_raw_parts` constructor.
+- All APIs that require a JNI signature (like `Env::get_method_id`, `Env::call_method` etc) now require a pre-parsed `MethodSignature` or `FieldSignature` type instead of a raw string. This enables compile-time signature parsing via the `jni_sig!` macro, and avoids runtime signature parsing costs. ([#714](https://github.com/jni-rs/jni-rs/pull/714))
 
 ### Fixed
 - `Env::get_string` no longer leaks local references. ([#528](https://github.com/jni-rs/jni-rs/pull/528), [#557](https://github.com/jni-rs/jni-rs/pull/557))

--- a/jni-macros/examples/native_method.rs
+++ b/jni-macros/examples/native_method.rs
@@ -8,7 +8,7 @@
 use jni::errors::LogErrorAndDefault;
 use jni::objects::{JClass, JIntArray, JObject, JString};
 use jni::sys::jint;
-use jni::{Env, EnvUnowned, NativeMethod, jni_str, native_method};
+use jni::{Env, EnvUnowned, NativeMethod, jni_sig, jni_str, native_method};
 
 #[path = "utils/lib.rs"]
 mod utils;
@@ -208,8 +208,7 @@ fn main() {
 
         // Create an instance
         println!("\n--- Creating Instance ---");
-        let obj = env.new_object(&class, jni_str!("()V"), &[])?;
-        //let obj = env.new_object(&class, &jni_sig!(()->void), &[])?; TODO
+        let obj = env.new_object(&class, &jni_sig!(()->void), &[])?;
         println!("Created NativeMethodOverview instance");
 
         // Call the test method that exercises all native methods
@@ -217,8 +216,7 @@ fn main() {
         let test_method = env.get_method_id(
             &class,
             jni_str!("testAllNativeMethods"),
-            jni_str!("()Ljava/lang/String;"),
-            //&jni_sig!(()->JString), TODO
+            &jni_sig!(()->JString),
         )?;
         let result = unsafe {
             env.call_method_unchecked(&obj, test_method, jni::signature::ReturnType::Object, &[])?
@@ -239,8 +237,7 @@ fn main() {
         let handle_method = env.get_method_id(
             &class,
             jni_str!("nativeProcessHandle"),
-            jni_str!("(J)Ljava/lang/String;"),
-            //&jni_sig!((jlong)->JString), TODO
+            &jni_sig!((jlong)->JString),
         )?;
         let response = unsafe {
             env.call_method_unchecked(

--- a/jni-macros/examples/native_method_wrapper.rs
+++ b/jni-macros/examples/native_method_wrapper.rs
@@ -66,7 +66,6 @@ macro_rules! my_native_method {
     };
 }
 // For consistency, do the same for jni_sig! macro which we'll use to call the methods
-/* TODO: uncomment after landing JNI signature changes for method call APIs
 macro_rules! my_jni_sig {
     ($($tt:tt)*) => {
         ::jni2::jni_sig!(
@@ -79,8 +78,6 @@ macro_rules! my_jni_sig {
         )
     };
 }
-*/
-
 // and, for consistency, also rename the jni crate for the jni_str macro
 macro_rules! my_jni_str {
     ($($tt:tt)*) => {
@@ -160,8 +157,7 @@ fn main() {
             .call_method(
                 &obj,
                 my_jni_str!("processResource"),
-                my_jni_str!("(J)Ljava/lang/String;"),
-                //my_jni_sig!((jlong)->JString), TODO
+                my_jni_sig!((jlong)->JString),
                 &[JValue::Long(resource_handle.into())],
             )?
             .l()?;
@@ -178,10 +174,7 @@ fn main() {
             .call_static_method(
                 class,
                 my_jni_str!("mixTypes"),
-                my_jni_str!(
-                    "(Lcom/example/CommonBuiltinType;Lcom/example/CustomType;)Ljava/lang/String;"
-                ),
-                //my_jni_sig!((builtin: JBuiltinType, custom: com.example.CustomType)->JString), TODO
+                my_jni_sig!((builtin: JBuiltinType, custom: com.example.CustomType)->JString),
                 &[
                     JValue::Object(&builtin_obj.into()),
                     JValue::Object(&custom_obj.into()),

--- a/jni-macros/examples/utils/lib.rs
+++ b/jni-macros/examples/utils/lib.rs
@@ -170,8 +170,7 @@ macro_rules! define_stub_type {
             pub fn new(env: &mut Env<'local>) -> jni2::errors::Result<Self> {
                 let class = Self::lookup_class(env, &jni2::refs::LoaderContext::default())?;
                 let class: &JClass = class.as_ref();
-                let obj = env.new_object(class, jni::jni_str!("()V"), &[])?;
-                //let obj = env.new_object(class, jni::jni_sig!("()V"), &[])?;
+                let obj = env.new_object(class, jni::jni_sig!("()V"), &[])?;
                 Ok(Self(obj))
             }
         }

--- a/jni-macros/src/bind_java_type.rs
+++ b/jni-macros/src/bind_java_type.rs
@@ -2001,7 +2001,6 @@ fn generate_id_fields_and_inits(
 
         // Create CStr literals for both the name and signature
         let name_cstr = lit_cstr_mutf8(java_name);
-        let sig_cstr = lit_cstr_mutf8(signature);
 
         // Add field to API struct
         fields.push(quote! {
@@ -2010,7 +2009,7 @@ fn generate_id_fields_and_inits(
 
         // Add initialization
         inits.push(quote! {
-            #field_name: env.#lookup_fn(class, #jni::strings::JNIStr::from_cstr_unchecked(#name_cstr), #jni::strings::JNIStr::from_cstr_unchecked(#sig_cstr))?,
+            #field_name: env.#lookup_fn(class, #jni::strings::JNIStr::from_cstr_unchecked(#name_cstr), #jni::jni_sig!(jni=#jni, #signature))?,
         });
     }
 

--- a/jni-macros/tests/native_methods.rs
+++ b/jni-macros/tests/native_methods.rs
@@ -1,4 +1,3 @@
-#![allow(unused)]
 mod native_methods_utils;
 mod util;
 
@@ -75,8 +74,7 @@ fn native_set_counter_impl<'local>(
     env.call_method(
         this,
         jni_str!("setCounter"),
-        jni_str!("(I)V"),
-        //jni_sig!("(I)V"), TODO
+        jni_sig!("(I)V"),
         &[jni::objects::JValue::Int(value)],
     )?;
     Ok(())
@@ -90,8 +88,7 @@ fn native_get_message_impl<'local>(
     let result = env.call_method(
         this,
         jni_str!("getMessage"),
-        jni_str!("()Ljava/lang/String;"),
-        //jni_sig!("()Ljava/lang/String;"), TODO
+        jni_sig!("()Ljava/lang/String;"),
         &[],
     )?;
     // Use cast_local to safely convert JObject to JString
@@ -143,8 +140,7 @@ native_method_test! {
         let result = env.call_method(
             &obj,
             jni_str!("callNativeAdd"),
-            jni_str!("(II)I"),
-            //jni_sig!("(II)I"), TODO
+            jni_sig!("(II)I"),
             &[jni::objects::JValue::Int(10), jni::objects::JValue::Int(20)],
         )?.i()?;
         assert_eq!(result, 30);
@@ -152,8 +148,7 @@ native_method_test! {
         let result = env.call_method(
             &obj,
             jni_str!("callNativeAdd"),
-            jni_str!("(II)I"),
-            //jni_sig!("(II)I"), TODO
+            jni_sig!("(II)I"),
             &[jni::objects::JValue::Int(-5), jni::objects::JValue::Int(7)],
         )?.i()?;
         assert_eq!(result, 2);
@@ -184,8 +179,7 @@ native_method_test! {
         env.call_method(
             &obj,
             jni_str!("nativeLog"),
-            jni_str!("(Ljava/lang/String;)V"),
-            //jni_sig!("(Ljava/lang/String;)V"), TODO
+            jni_sig!("(Ljava/lang/String;)V"),
             &[jni::objects::JValue::Object(&message)],
         )?;
 
@@ -217,8 +211,7 @@ native_method_test! {
         let result = env.call_method(
             &obj,
             jni_str!("nativeArrayAdd"),
-            jni_str!("([II)[I"),
-            //jni_sig!("([II)[I"), TODO
+            jni_sig!("([II)[I"),
             &[jni::objects::JValue::Object(&arr), jni::objects::JValue::Int(10)],
         )?.l()?;
         // Use cast_local to safely convert JObject to JPrimitiveArray
@@ -260,8 +253,7 @@ native_method_test! {
         let result = env.call_static_method(
             class,
             jni_str!("native2DArrayInvert"),
-            jni_str!("([[Z)[[Z"),
-            //jni_sig!("([[Z)[[Z"), TODO
+            jni_sig!("([[Z)[[Z"),
             &[jni::objects::JValue::Object(&outer)],
         )?.l()?;
         // Use cast_local to safely convert JObject to JObjectArray
@@ -307,21 +299,18 @@ native_method_test! {
         env.call_method(
             &obj,
             jni_str!("nativeSetCounter"),
-            jni_str!("(I)V"),
-            //jni_sig!("(I)V"), TODO
+            jni_sig!("(I)V"),
             &[jni::objects::JValue::Int(42)],
         )?;
 
-        let counter = env.call_method(&obj, jni_str!("getCounter"), jni_str!("()I"), &[])?.i()?;
-        //let counter = env.call_method(&obj, jni_str!("getCounter"), jni_sig!("()I"), &[])?.i()?;
+        let counter = env.call_method(&obj, jni_str!("getCounter"), jni_sig!("()I"), &[])?.i()?;
         assert_eq!(counter, 42);
 
         // Test native method can call Java getter (via method call)
         let message = env.call_method(
             &obj,
             jni_str!("nativeGetMessage"),
-            jni_str!("()Ljava/lang/String;"),
-            //jni_sig!("()Ljava/lang/String;"), TODO
+            jni_sig!("()Ljava/lang/String;"),
             &[],
         )?.l()?;
         // Use cast_local to safely convert JObject to JString
@@ -350,8 +339,7 @@ native_method_test! {
         let version = env.call_static_method(
             class,
             jni_str!("callNativeGetVersion"),
-            jni_str!("()I"),
-            //jni_sig!("()I"), TODO
+            jni_sig!("()I"),
             &[],
         )?.i()?;
         assert_eq!(version, 100);
@@ -384,8 +372,7 @@ native_method_test! {
         let result = env.call_static_method(
             class,
             jni_str!("nativeStringArrayEcho"),
-            jni_str!("([Ljava/lang/String;)[Ljava/lang/String;"),
-            //jni_sig!("([Ljava/lang/String;)[Ljava/lang/String;"), TODO
+            jni_sig!("([Ljava/lang/String;)[Ljava/lang/String;"),
             &[jni::objects::JValue::Object(&arr)],
         )?.l()?;
         // Use cast_local to safely convert JObject to JObjectArray
@@ -434,8 +421,7 @@ native_method_test! {
         let result = env.call_static_method(
             class,
             jni_str!("native2DStringArrayEcho"),
-            jni_str!("([[Ljava/lang/String;)[[Ljava/lang/String;"),
-            //jni_sig!("([[Ljava/lang/String;)[[Ljava/lang/String;"), TODO
+            jni_sig!("([[Ljava/lang/String;)[[Ljava/lang/String;"),
             &[jni::objects::JValue::Object(&arr)],
         )?.l()?;
         let result = JObjectArray::<JObjectArray<JString>>::cast_local(env, result)?;

--- a/jni-macros/tests/native_methods_export.rs
+++ b/jni-macros/tests/native_methods_export.rs
@@ -80,9 +80,8 @@ native_method_test! {
         let obj = new_object!(env, class)?;
 
         // Call through Java to ensure the native implementation is linked
-        use jni::jni_str;
-        let result_via_java = env.call_method(&obj, jni_str!("noArgs"), jni_str!("()I"), &[])?.i()?;
-        //let result_via_java = env.call_method(&obj, jni_str!("noArgs"), jni_sig!("()I"), &[])?.i()?; TODO
+        use jni::{jni_sig, jni_str};
+        let result_via_java = env.call_method(&obj, jni_str!("noArgs"), jni_sig!("()I"), &[])?.i()?;
         assert_eq!(result_via_java, 1234);
 
         // Also test calling the exported symbol directly

--- a/jni-macros/tests/native_methods_utils.rs
+++ b/jni-macros/tests/native_methods_utils.rs
@@ -215,12 +215,11 @@ macro_rules! native_method_test {
 #[macro_export]
 macro_rules! call_int_method {
     ($env:expr, $obj:expr, $method_name:literal, $arg:expr) => {{
-        use jni::jni_str;
+        use jni::{jni_sig, jni_str};
         let result = $env.call_method(
             $obj,
             jni_str!($method_name),
-            jni_str!("(I)I"),
-            //jni_sig!("(I)I"), TODO
+            jni_sig!("(I)I"),
             &[jni::objects::JValue::Int($arg)],
         )?;
         result.i()
@@ -239,12 +238,11 @@ macro_rules! call_int_method {
 #[macro_export]
 macro_rules! call_static_int_method {
     ($env:expr, $class:expr, $method_name:literal, $arg:expr) => {{
-        use jni::jni_str;
+        use jni::{jni_sig, jni_str};
         let result = $env.call_static_method(
             $class,
             jni_str!($method_name),
-            jni_str!("(I)I"),
-            //jni_sig!("(I)I"), TODO
+            jni_sig!("(I)I"),
             &[jni::objects::JValue::Int($arg)],
         )?;
         result.i()
@@ -263,8 +261,7 @@ macro_rules! call_static_int_method {
 #[macro_export]
 macro_rules! new_object {
     ($env:expr, $class:expr) => {{
-        use jni::jni_str;
-        $env.new_object(&$class, jni_str!("()V"), &[])
-        //$env.new_object(&$class, jni_sig!("()V"), &[]) TODO
+        use jni::jni_sig;
+        $env.new_object(&$class, jni_sig!("()V"), &[])
     }};
 }

--- a/src/descriptors/field_desc.rs
+++ b/src/descriptors/field_desc.rs
@@ -3,14 +3,15 @@ use crate::{
     env::Env,
     errors::*,
     objects::{JClass, JFieldID, JStaticFieldID},
+    signature::FieldSignature,
     strings::JNIStr,
 };
 
-unsafe impl<'local, 'other_local, T, U, V> Desc<'local, JFieldID> for (T, U, V)
+unsafe impl<'local, 'other_local, 'sig, T, U, V> Desc<'local, JFieldID> for (T, U, V)
 where
     T: Desc<'local, JClass<'other_local>>,
     U: AsRef<JNIStr>,
-    V: AsRef<JNIStr>,
+    V: AsRef<FieldSignature<'sig>>,
 {
     type Output = JFieldID;
 
@@ -19,11 +20,11 @@ where
     }
 }
 
-unsafe impl<'local, 'other_local, T, U, V> Desc<'local, JStaticFieldID> for (T, U, V)
+unsafe impl<'local, 'other_local, 'sig, T, U, V> Desc<'local, JStaticFieldID> for (T, U, V)
 where
     T: Desc<'local, JClass<'other_local>>,
     U: AsRef<JNIStr>,
-    V: AsRef<JNIStr>,
+    V: AsRef<FieldSignature<'sig>>,
 {
     type Output = JStaticFieldID;
 

--- a/src/descriptors/method_desc.rs
+++ b/src/descriptors/method_desc.rs
@@ -3,14 +3,15 @@ use crate::{
     env::Env,
     errors::*,
     objects::{JClass, JMethodID, JStaticMethodID},
+    signature::MethodSignature,
     strings::JNIStr,
 };
 
-unsafe impl<'local, 'other_local, T, U, V> Desc<'local, JMethodID> for (T, U, V)
+unsafe impl<'local, 'other_local, 'sig, 'sig_args, T, U, V> Desc<'local, JMethodID> for (T, U, V)
 where
     T: Desc<'local, JClass<'other_local>>,
     U: AsRef<JNIStr>,
-    V: AsRef<JNIStr>,
+    V: AsRef<MethodSignature<'sig, 'sig_args>>,
 {
     type Output = JMethodID;
 
@@ -19,10 +20,11 @@ where
     }
 }
 
-unsafe impl<'local, 'other_local, T, Signature> Desc<'local, JMethodID> for (T, Signature)
+unsafe impl<'local, 'other_local, 'sig, 'sig_args, T, Signature> Desc<'local, JMethodID>
+    for (T, Signature)
 where
     T: Desc<'local, JClass<'other_local>>,
-    Signature: AsRef<JNIStr>,
+    Signature: AsRef<MethodSignature<'sig, 'sig_args>>,
 {
     type Output = JMethodID;
 
@@ -31,11 +33,12 @@ where
     }
 }
 
-unsafe impl<'local, 'other_local, T, U, V> Desc<'local, JStaticMethodID> for (T, U, V)
+unsafe impl<'local, 'other_local, 'sig, 'sig_args, T, U, V> Desc<'local, JStaticMethodID>
+    for (T, U, V)
 where
     T: Desc<'local, JClass<'other_local>>,
     U: AsRef<JNIStr>,
-    V: AsRef<JNIStr>,
+    V: AsRef<MethodSignature<'sig, 'sig_args>>,
 {
     type Output = JStaticMethodID;
 

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -4,7 +4,7 @@ use std::char::{CharTryFromError, DecodeUtf16Error};
 
 use thiserror::Error;
 
-use crate::signature::TypeSignature;
+use crate::signature::RuntimeMethodSignature;
 use crate::sys;
 
 pub type Result<T> = std::result::Result<T, Error>;
@@ -31,7 +31,7 @@ pub enum Error {
     #[error("Invalid constructor return type (must be void)")]
     InvalidCtorReturn,
     #[error("Invalid number or type of arguments passed to java method: {0}")]
-    InvalidArgList(TypeSignature),
+    InvalidArgList(RuntimeMethodSignature),
     #[error("Object behind weak reference freed")]
     ObjectFreed,
     #[error("Class not found: {name:?}")]

--- a/src/refs/reference.rs
+++ b/src/refs/reference.rs
@@ -64,7 +64,7 @@ use crate::objects::Auto;
 ///
 /// ```rust,no_run
 /// # use std::borrow::Cow;
-/// # use jni::jni_str;
+/// # use jni::{jni_str, jni_sig};
 /// # use jni::objects::{JObject, JClass, JString, Global};
 /// # use jni::refs::{Reference, LoaderContext};
 /// # use jni::Env;
@@ -102,7 +102,7 @@ use crate::objects::Auto;
 ///             Ok(Self {
 ///                 class: env.new_global_ref(&class)?,
 ///                 my_method_id: env.get_method_id(
-///                     &class, jni_str!("myMethod"), jni_str!("(Ljava/lang/String;)Ljava/lang/String;"))?,
+///                     &class, jni_str!("myMethod"), jni_sig!((JString) -> JString))?,
 ///             })
 ///         })?;
 ///         let _ = API.set(api);
@@ -113,7 +113,7 @@ use crate::objects::Auto;
 /// impl<'local> MyType<'local> {
 ///     pub fn new(env: &mut Env<'local>) -> Result<Self> {
 ///         let api = MyTypeAPI::get(env, &LoaderContext::default())?;
-///         let obj = env.new_object(&api.class, jni_str!("()V"), &[])?;
+///         let obj = env.new_object(&api.class, jni_sig!("()V"), &[])?;
 ///         Ok(MyType(obj))
 ///     }
 ///     pub unsafe fn from_raw<'env>(env: &Env<'env>, raw: jobject) -> MyType<'env> {

--- a/src/strings/ffi_str.rs
+++ b/src/strings/ffi_str.rs
@@ -175,7 +175,7 @@ impl JNIString {
     /// The `string` must be in [modified UTF-8] encoding.
     ///
     /// [modified UTF-8]: https://en.wikipedia.org/wiki/UTF-8#Modified_UTF-8
-    pub unsafe fn from_cstring(string: CString) -> Self {
+    pub const unsafe fn from_cstring(string: CString) -> Self {
         Self { internal: string }
     }
 

--- a/src/vm/java_vm.rs
+++ b/src/vm/java_vm.rs
@@ -121,7 +121,7 @@ static JAVA_VM_SINGLETON: std::sync::OnceLock<JavaVM> = std::sync::OnceLock::new
 /// # // Ignore this test without invocation feature, so that simple `cargo test` works
 /// # #[cfg(feature = "invocation")]
 /// # fn main() -> errors::StartJvmResult<()> {
-/// # use jni::{AttachGuard, objects::JValue, InitArgsBuilder, Env, JNIVersion, JavaVM, sys::jint};
+/// # use jni::{jni_sig, AttachGuard, objects::JValue, InitArgsBuilder, Env, JNIVersion, JavaVM, sys::jint};
 /// # //
 /// // Build the VM properties
 /// let jvm_args = InitArgsBuilder::new()
@@ -141,7 +141,7 @@ static JAVA_VM_SINGLETON: std::sync::OnceLock<JavaVM> = std::sync::OnceLock::new
 /// jvm.attach_current_thread(|env| -> errors::Result<()> {
 ///     // Call Java Math#abs(-10)
 ///     let x = JValue::from(-10);
-///     let val: jint = env.call_static_method(c"java/lang/Math", c"abs", c"(I)I", &[x])?
+///     let val: jint = env.call_static_method(c"java/lang/Math", c"abs", jni_sig!("(I)I"), &[x])?
 ///         .i()?;
 ///
 ///     assert_eq!(val, 10);

--- a/tests/invocation_character_encoding.rs
+++ b/tests/invocation_character_encoding.rs
@@ -4,7 +4,7 @@
 
 use std::borrow::Cow;
 
-use jni::{objects::JString, InitArgsBuilder, JavaVM};
+use jni::{jni_sig, objects::JString, InitArgsBuilder, JavaVM};
 
 #[test]
 fn invocation_character_encoding() {
@@ -31,7 +31,7 @@ fn invocation_character_encoding() {
             .call_static_method(
                 c"java/lang/System",
                 c"getProperty",
-                c"(Ljava/lang/String;)Ljava/lang/String;",
+                jni_sig!("(Ljava/lang/String;)Ljava/lang/String;"),
                 &[(&prop_name).into()],
             )
             .unwrap()

--- a/tests/java_integers.rs
+++ b/tests/java_integers.rs
@@ -1,6 +1,6 @@
 #![cfg(feature = "invocation")]
 
-use jni::{errors::Result, objects::JValue};
+use jni::{errors::Result, jni_sig, objects::JValue};
 
 mod util;
 use util::{attach_current_thread, print_exception};
@@ -12,8 +12,11 @@ fn test_java_integers() {
 
         for value in -10..10 {
             env.with_local_frame(16, |env| -> Result<()> {
-                let integer_value =
-                    env.new_object(c"java/lang/Integer", c"(I)V", &[JValue::Int(value)])?;
+                let integer_value = env.new_object(
+                    c"java/lang/Integer",
+                    jni_sig!("(I)V"),
+                    &[JValue::Int(value)],
+                )?;
 
                 let values_array =
                     env.new_object_array(array_length, c"java/lang/Integer", &integer_value)?;
@@ -22,7 +25,7 @@ fn test_java_integers() {
                     .call_static_method(
                         c"java/util/Arrays",
                         c"binarySearch",
-                        c"([Ljava/lang/Object;Ljava/lang/Object;)I",
+                        jni_sig!("([Ljava/lang/Object;Ljava/lang/Object;)I"),
                         &[
                             JValue::Object(&values_array),
                             JValue::Object(&integer_value),

--- a/tests/jlist.rs
+++ b/tests/jlist.rs
@@ -1,6 +1,7 @@
 #![cfg(feature = "invocation")]
 
 use jni::{
+    jni_sig,
     objects::{IntoAuto, JList, JString},
     strings::JNIStr,
     sys::jint,
@@ -21,7 +22,10 @@ pub fn jlist_push_and_iterate() {
         ];
 
         // Create a new ArrayList
-        let list_object = unwrap(env.new_object(c"java/util/ArrayList", c"()V", &[]), env);
+        let list_object = unwrap(
+            env.new_object(c"java/util/ArrayList", jni_sig!("()V"), &[]),
+            env,
+        );
         let list = unwrap(JList::cast_local(env, list_object), env);
 
         // Add all strings to the list
@@ -64,7 +68,10 @@ pub fn jlist_push_and_iterate() {
 pub fn jlist_get_and_set() {
     attach_current_thread(|env| {
         // Create a new ArrayList
-        let list_object = unwrap(env.new_object(c"java/util/ArrayList", c"()V", &[]), env);
+        let list_object = unwrap(
+            env.new_object(c"java/util/ArrayList", jni_sig!("()V"), &[]),
+            env,
+        );
         let list = unwrap(JList::cast_local(env, list_object), env);
 
         // Add some initial elements
@@ -100,7 +107,10 @@ pub fn jlist_get_and_set() {
 pub fn jlist_insert_and_remove() {
     attach_current_thread(|env| {
         // Create a new ArrayList
-        let list_object = unwrap(env.new_object(c"java/util/ArrayList", c"()V", &[]), env);
+        let list_object = unwrap(
+            env.new_object(c"java/util/ArrayList", jni_sig!("()V"), &[]),
+            env,
+        );
         let list = unwrap(JList::cast_local(env, list_object), env);
 
         // Add initial elements
@@ -159,7 +169,10 @@ pub fn jlist_insert_and_remove() {
 pub fn jlist_size_and_remove() {
     attach_current_thread(|env| {
         // Create a new ArrayList
-        let list_object = unwrap(env.new_object(c"java/util/ArrayList", c"()V", &[]), env);
+        let list_object = unwrap(
+            env.new_object(c"java/util/ArrayList", jni_sig!("()V"), &[]),
+            env,
+        );
         let list = unwrap(JList::cast_local(env, list_object), env);
 
         // Test size on empty list
@@ -218,7 +231,10 @@ pub fn jlist_size_and_remove() {
 pub fn jlist_iterator_empty() {
     attach_current_thread(|env| {
         // Create an empty ArrayList
-        let list_object = unwrap(env.new_object(c"java/util/ArrayList", c"()V", &[]), env);
+        let list_object = unwrap(
+            env.new_object(c"java/util/ArrayList", jni_sig!("()V"), &[]),
+            env,
+        );
         let list = unwrap(JList::cast_local(env, list_object), env);
 
         // Test iterator on empty list
@@ -251,7 +267,10 @@ pub fn jlist_iterator_with_auto() {
         ];
 
         // Create a new ArrayList
-        let list_object = unwrap(env.new_object(c"java/util/ArrayList", c"()V", &[]), env);
+        let list_object = unwrap(
+            env.new_object(c"java/util/ArrayList", jni_sig!("()V"), &[]),
+            env,
+        );
         let list = unwrap(JList::cast_local(env, list_object), env);
 
         // Add all strings to the list

--- a/tests/jmap.rs
+++ b/tests/jmap.rs
@@ -1,6 +1,7 @@
 #![cfg(feature = "invocation")]
 
 use jni::{
+    jni_sig,
     objects::{JMap, JObject, JString},
     strings::JNIStr,
 };
@@ -19,7 +20,10 @@ pub fn jmap_push_and_iterate() {
         ];
 
         // Create a new map. Use LinkedHashMap to have predictable iteration order
-        let map_object = unwrap(env.new_object(c"java/util/LinkedHashMap", c"()V", &[]), env);
+        let map_object = unwrap(
+            env.new_object(c"java/util/LinkedHashMap", jni_sig!("()V"), &[]),
+            env,
+        );
         let map = unwrap(JMap::cast_local(env, map_object), env);
 
         // Push all strings

--- a/tests/jni_global_refs.rs
+++ b/tests/jni_global_refs.rs
@@ -6,6 +6,7 @@ use std::{
 };
 
 use jni::{
+    jni_sig,
     objects::{Global, IntoAuto as _, JObject, JValue},
     sys::jint,
 };
@@ -21,7 +22,7 @@ pub fn global_ref_works_in_other_threads() {
         let local_ref = unwrap(
             env.new_object(
                 c"java/util/concurrent/atomic/AtomicInteger",
-                c"(I)V",
+                jni_sig!("(I)V"),
                 &[JValue::from(0)],
             ),
             env,
@@ -50,7 +51,12 @@ pub fn global_ref_works_in_other_threads() {
                     for _ in 0..ITERS_PER_THREAD {
                         unwrap(
                             unwrap(
-                                env.call_method(atomic_integer, c"incrementAndGet", c"()I", &[]),
+                                env.call_method(
+                                    atomic_integer,
+                                    c"incrementAndGet",
+                                    jni_sig!("()I"),
+                                    &[],
+                                ),
                                 env,
                             )
                             .i(),
@@ -75,7 +81,12 @@ pub fn global_ref_works_in_other_threads() {
                 expected,
                 unwrap(
                     unwrap(
-                        env.call_method(atomic_integer, c"getAndSet", c"(I)I", &[JValue::from(0)]),
+                        env.call_method(
+                            atomic_integer,
+                            c"getAndSet",
+                            jni_sig!("(I)I"),
+                            &[JValue::from(0)]
+                        ),
                         env,
                     )
                     .i(),

--- a/tests/jni_weak_refs.rs
+++ b/tests/jni_weak_refs.rs
@@ -6,6 +6,7 @@ use std::{
 };
 
 use jni::{
+    jni_sig,
     objects::{IntoAuto as _, JObject, JValue, Weak},
     sys::jint,
     Env,
@@ -22,7 +23,7 @@ pub fn weak_ref_works_in_other_threads() {
         let atomic_integer_local = unwrap(
             env.new_object(
                 c"java/util/concurrent/atomic/AtomicInteger",
-                c"(I)V",
+                jni_sig!("(I)V"),
                 &[JValue::from(0)],
             ),
             env,
@@ -55,7 +56,7 @@ pub fn weak_ref_works_in_other_threads() {
                                     env.call_method(
                                         &atomic_integer,
                                         c"incrementAndGet",
-                                        c"()I",
+                                        jni_sig!("()I"),
                                         &[],
                                     ),
                                     env,
@@ -83,7 +84,7 @@ pub fn weak_ref_works_in_other_threads() {
                         env.call_method(
                             &atomic_integer_local,
                             c"getAndSet",
-                            c"(I)I",
+                            jni_sig!("(I)I"),
                             &[JValue::from(0)]
                         ),
                         env,
@@ -107,7 +108,7 @@ fn weak_ref_is_actually_weak() {
         fn run_gc(env: &mut Env) {
             unwrap(
                 env.with_local_frame(1, |env| {
-                    env.call_static_method(c"java/lang/System", c"gc", c"()V", &[])?;
+                    env.call_static_method(c"java/lang/System", c"gc", jni_sig!("()V"), &[])?;
                     Ok(())
                 }),
                 env,
@@ -117,7 +118,7 @@ fn weak_ref_is_actually_weak() {
         for _ in 0..100 {
             let obj_local = unwrap(
                 env.with_local_frame_returning_local::<_, JObject, _>(2, |env| {
-                    env.new_object(c"java/lang/Object", c"()V", &[])
+                    env.new_object(c"java/lang/Object", jni_sig!("()V"), &[])
                 }),
                 env,
             )

--- a/tests/test_generated_aliases.rs
+++ b/tests/test_generated_aliases.rs
@@ -1,6 +1,9 @@
 #![cfg(feature = "invocation")]
 
-use jni::objects::{JCollection, JList, JSet};
+use jni::{
+    jni_sig,
+    objects::{JCollection, JList, JSet},
+};
 
 mod util;
 use util::{attach_current_thread, unwrap};
@@ -10,25 +13,37 @@ pub fn test_generated_alias_methods() {
     use jni::errors::Result;
     let _: Result<()> = attach_current_thread(|env| {
         // Test JList as_collection method
-        let list_object = unwrap(env.new_object(c"java/util/ArrayList", c"()V", &[]), env);
+        let list_object = unwrap(
+            env.new_object(c"java/util/ArrayList", jni_sig!("()V"), &[]),
+            env,
+        );
         let list = unwrap(JList::cast_local(env, list_object), env);
         let collection_via_method = list.as_collection();
         let _size1 = unwrap(collection_via_method.size(env), env);
 
         // Test JList From implementation (using a fresh instance)
-        let list_object2 = unwrap(env.new_object(c"java/util/ArrayList", c"()V", &[]), env);
+        let list_object2 = unwrap(
+            env.new_object(c"java/util/ArrayList", jni_sig!("()V"), &[]),
+            env,
+        );
         let list2 = unwrap(JList::cast_local(env, list_object2), env);
         let collection_via_from: JCollection = list2.into();
         let _size2 = unwrap(collection_via_from.size(env), env);
 
         // Test JSet as_collection method
-        let set_object = unwrap(env.new_object(c"java/util/HashSet", c"()V", &[]), env);
+        let set_object = unwrap(
+            env.new_object(c"java/util/HashSet", jni_sig!("()V"), &[]),
+            env,
+        );
         let set = unwrap(JSet::cast_local(env, set_object), env);
         let set_collection_via_method = set.as_collection();
         let _size3 = unwrap(set_collection_via_method.size(env), env);
 
         // Test JSet From implementation (using a fresh instance)
-        let set_object2 = unwrap(env.new_object(c"java/util/HashSet", c"()V", &[]), env);
+        let set_object2 = unwrap(
+            env.new_object(c"java/util/HashSet", jni_sig!("()V"), &[]),
+            env,
+        );
         let set2 = unwrap(JSet::cast_local(env, set_object2), env);
         let set_collection_via_from: JCollection = set2.into();
         let _size4 = unwrap(set_collection_via_from.size(env), env);

--- a/tests/threads_attach_config.rs
+++ b/tests/threads_attach_config.rs
@@ -2,7 +2,7 @@
 
 use std::thread::spawn;
 
-use jni::{objects::JString, AttachConfig};
+use jni::{jni_sig, objects::JString, AttachConfig};
 
 mod util;
 use util::jvm;
@@ -23,14 +23,14 @@ fn attach_config() {
                         .call_static_method(
                             c"java/lang/Thread",
                             c"currentThread",
-                            c"()Ljava/lang/Thread;",
+                            jni_sig!("()Ljava/lang/Thread;"),
                             &[],
                         )
                         .unwrap()
                         .l()
                         .unwrap();
                     let name = env
-                        .call_method(thread, c"getName", c"()Ljava/lang/String;", &[])?
+                        .call_method(thread, c"getName", jni_sig!("()Ljava/lang/String;"), &[])?
                         .l()?;
                     let name = env.cast_local::<JString>(name).unwrap();
                     let name = name.mutf8_chars(env)?;

--- a/tests/util/example_proxy.rs
+++ b/tests/util/example_proxy.rs
@@ -4,6 +4,7 @@ use std::{ops::Deref, sync::Arc};
 
 use jni::{
     errors::*,
+    jni_sig,
     objects::{Global, JObject, JValue},
     sys::jint,
     JavaVM, DEFAULT_LOCAL_FRAME_CAPACITY,
@@ -33,7 +34,7 @@ impl AtomicIntegerProxy {
             let obj = env.with_local_frame(DEFAULT_LOCAL_FRAME_CAPACITY, |env| {
                 let i = env.new_object(
                     c"java/util/concurrent/atomic/AtomicInteger",
-                    c"(I)V",
+                    jni_sig!("(I)V"),
                     &[JValue::from(init_value)],
                 )?;
                 env.new_global_ref(i)
@@ -47,14 +48,17 @@ impl AtomicIntegerProxy {
     /// Gets a current value from java object
     pub fn get(&mut self) -> Result<jint> {
         let vm = JavaVM::singleton()?;
-        vm.attach_current_thread(|env| env.call_method(&*self.obj, c"get", c"()I", &[])?.i())
+        vm.attach_current_thread(|env| {
+            env.call_method(&*self.obj, c"get", jni_sig!("()I"), &[])?
+                .i()
+        })
     }
 
     /// Increments a value of java object and then gets it
     pub fn increment_and_get(&mut self) -> Result<jint> {
         let vm = JavaVM::singleton()?;
         vm.attach_current_thread(|env| {
-            env.call_method(&*self.obj, c"incrementAndGet", c"()I", &[])?
+            env.call_method(&*self.obj, c"incrementAndGet", jni_sig!("()I"), &[])?
                 .i()
         })
     }
@@ -64,7 +68,7 @@ impl AtomicIntegerProxy {
         let vm = JavaVM::singleton()?;
         vm.attach_current_thread(|env| {
             let delta = JValue::from(delta);
-            env.call_method(&*self.obj, c"addAndGet", c"(I)I", &[delta])?
+            env.call_method(&*self.obj, c"addAndGet", jni_sig!("(I)I"), &[delta])?
                 .i()
         })
     }

--- a/tests/util/mod.rs
+++ b/tests/util/mod.rs
@@ -1,6 +1,8 @@
 use std::sync::{Arc, Once};
 
-use jni::{errors::Result, objects::JValue, sys::jint, Env, InitArgsBuilder, JNIVersion, JavaVM};
+use jni::{
+    errors::Result, jni_sig, objects::JValue, sys::jint, Env, InitArgsBuilder, JNIVersion, JavaVM,
+};
 
 mod example_proxy;
 
@@ -36,7 +38,7 @@ pub fn call_java_abs(env: &mut Env, value: i32) -> i32 {
     env.call_static_method(
         c"java/lang/Math",
         c"abs",
-        c"(I)I",
+        jni_sig!("(I)I"),
         &[JValue::from(value as jint)],
     )
     .unwrap()


### PR DESCRIPTION
JNI signatures are now expected to be pre-parsed into a `MethodSignature` or `FieldSignature` before being used to make method calls or get/set fields.

In the common case the `jni_sig!()` macro can be used to parse a JNI signature at compile time and emit the appropriate `*Signature` struct.

In the unlikely case that a signature needs to be parsed at runtime then `RuntimeMethodSignature/RuntimeFieldSignature::from_str` can be used and it's then possible to borrow a `MethodSignature` or `FieldSignature` from these runtime structs.

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Change is covered by [automated tests](https://github.com/jni-rs/jni-rs/blob/master/CONTRIBUTING.md#tests)
- [x] The [coding guidelines](https://github.com/jni-rs/jni-rs/blob/master/CONTRIBUTING.md#the-code-style) are followed
- [x] Public API has documentation
- [x] User-visible changes are mentioned in the Changelog
- [x] The continuous integration build passes
