### PR TITLE
Make JNIStr::from_cstr fallible + remove 'From<CStr> for JNIStr'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,8 +77,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `JNIString` now implements `Debug`, `PartialEq`, `Eq`, `PartialOrd`, `Ord`, `Hash` and `Clone` ([#615](https://github.com/jni-rs/jni-rs/pull/615))
 - `PartialEq<&JNIStr> for JNIString` allows `JNIStr` and `JNIString` to be compared. ([#615](https://github.com/jni-rs/jni-rs/pull/615))
 - `From<&JNIStr>` and `From<MUTF8Chars>` implementations for `JNIString`. ([#615](https://github.com/jni-rs/jni-rs/pull/615))
-- `JNIStr::from_cstr` safely does a zero-copy cast of a `CStr` to a `JNIStr` after a `const` modified-utf8 encoding validation (with a panic on failure)
-- `AsRef<JNIStr>` is implemented for `CStr` (based on `JNIStr::from_cstr`) allows use of literals like `c"java/lang/Foo"` to be passed to JNI APIs without needing to be copied. ([#615](https://github.com/jni-rs/jni-rs/pull/615))
+- `JNIStr::from_cstr` safely does a zero-copy cast of a `CStr` to a `JNIStr` after a `const` modified-utf8 encoding validation ([#615](https://github.com/jni-rs/jni-rs/pull/615),[#617](https://github.com/jni-rs/jni-rs/pull/617), [#715](https://github.com/jni-rs/jni-rs/pull/715))
 - `JNIStr::to_bytes` gives access to a `&[u8]` slice over the bytes of a JNI string (like `CStr::to_bytes`) ([#615](https://github.com/jni-rs/jni-rs/pull/615))
 
 #### java.lang APIs
@@ -151,7 +150,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `JavaStr/MUTF8Chars::from_env` has been removed because it was unsound (it could cause undefined behavior and was not marked `unsafe`). Use `JString::mutf8_chars` instead. ([#510](https://github.com/jni-rs/jni-rs/issues/510) / [#512](https://github.com/jni-rs/jni-rs/pull/512))
 - `JavaStr/MUTF8Chars::get_raw` has been renamed to `as_ptr`. ([#510](https://github.com/jni-rs/jni-rs/issues/510) / [#512](https://github.com/jni-rs/jni-rs/pull/512))
 - `JavaStr/MUTF8Chars`, `JNIStr`, and `JNIString` no longer coerce to `CStr`, because using `CStr::to_str` will often have incorrect results. You can still get a `CStr`, but must use the new `as_cstr` method to do so. ([#510](https://github.com/jni-rs/jni-rs/issues/510) / [#512](https://github.com/jni-rs/jni-rs/pull/512))
-- All APIs that were accepting modified-utf8 string args via `Into<JNIString>`, now take `AsRef<JNIStr>` to avoid string copies every call. Considering that these strings are often literals for signatures or class names, most code can rely on `AsRef<JNIStr>` for `CStr` and pass `CStr` literals like `env.find_class(c"java/lang/Foo")`. ([#617](https://github.com/jni-rs/jni-rs/pull/617))
+- All APIs that were accepting modified-utf8 string args via `Into<JNIString>`, now take `AsRef<JNIStr>` to avoid string copies every call. Considering that these strings are often literals for signatures or class names, most code can use `jni_str!()` to encode string literals at compile time, like `env.find_class(jni_str!("java/lang/Foo"))`. ([#617](https://github.com/jni-rs/jni-rs/pull/617), [#696](https://github.com/jni-rs/jni-rs/pull/696))
 - `JavaStr/MUTF8Chars` and `JString` both implement `Display` and therefore `ToString`, making it even easier to get a Rust `String`.
 - `Env::get_string` performance was optimized by caching an expensive class lookup, and using a faster instanceof check. ([#531](https://github.com/jni-rs/jni-rs/pull/531))
 - `Env::get_string` performance was later further optimized to avoid the need for runtime type checking ([#612](https://github.com/jni-rs/jni-rs/pull/612))

--- a/benches/api_calls.rs
+++ b/benches/api_calls.rs
@@ -1,13 +1,13 @@
 #![cfg(feature = "invocation")]
 
-use jni::jni_sig;
 use jni::signature::MethodSignature;
 use jni::strings::JNIStr;
+use jni::{jni_sig, jni_str};
 use jni_sys::jvalue;
 use lazy_static::lazy_static;
 
 use criterion::{criterion_group, criterion_main, Criterion};
-use jni::objects::{Global, IntoAuto as _};
+use jni::objects::{Global, IntoAuto as _, JString};
 use jni::{
     descriptors::Desc,
     objects::{JClass, JMethodID, JObject, JStaticMethodID, JValue},
@@ -19,13 +19,13 @@ use std::hint::black_box;
 use std::rc::Rc;
 use std::sync::Arc;
 
-static CLASS_MATH: &JNIStr = JNIStr::from_cstr(c"java/lang/Math");
-static CLASS_OBJECT: &JNIStr = JNIStr::from_cstr(c"java/lang/Object");
-static CLASS_LOCAL_DATE_TIME: &JNIStr = JNIStr::from_cstr(c"java/time/LocalDateTime");
-static METHOD_MATH_ABS: &JNIStr = JNIStr::from_cstr(c"abs");
-static METHOD_OBJECT_HASH_CODE: &JNIStr = JNIStr::from_cstr(c"hashCode");
-static METHOD_CTOR: &JNIStr = JNIStr::from_cstr(c"<init>");
-static METHOD_LOCAL_DATE_TIME_OF: &JNIStr = JNIStr::from_cstr(c"of");
+static CLASS_MATH: &JNIStr = jni_str!("java/lang/Math");
+static CLASS_OBJECT: &JNIStr = jni_str!("java/lang/Object");
+static CLASS_LOCAL_DATE_TIME: &JNIStr = jni_str!("java/time/LocalDateTime");
+static METHOD_MATH_ABS: &JNIStr = jni_str!("abs");
+static METHOD_OBJECT_HASH_CODE: &JNIStr = jni_str!("hashCode");
+static METHOD_CTOR: &JNIStr = jni_str!("<init>");
+static METHOD_LOCAL_DATE_TIME_OF: &JNIStr = jni_str!("of");
 static SIG_OBJECT_CTOR: MethodSignature = jni_sig!("()V");
 static SIG_MATH_ABS: MethodSignature = jni_sig!("(I)I");
 static SIG_OBJECT_HASH_CODE: MethodSignature = jni_sig!("()I");
@@ -474,7 +474,7 @@ fn jni_new_string_within_single_thread_attachment(c: &mut Criterion) {
     VM.attach_current_thread_for_scope(|env| -> jni::errors::Result<()> {
         c.bench_function("jni_new_string_within_single_thread_attachment", |b| {
             b.iter(|| {
-                black_box(env.new_string("Test").unwrap().auto());
+                black_box(JString::from_jni_str(env, jni_str!("Test")).unwrap().auto());
             })
         });
         Ok(())
@@ -489,7 +489,7 @@ fn jni_new_string_with_repeat_scoped_thread_attachments(c: &mut Criterion) {
         |b| {
             b.iter(|| {
                 VM.attach_current_thread_for_scope(|env| -> jni::errors::Result<()> {
-                    black_box(env.new_string("Test").unwrap().auto());
+                    black_box(JString::from_jni_str(env, jni_str!("Test")).unwrap().auto());
                     Ok(())
                 })
                 .unwrap();
@@ -512,7 +512,7 @@ fn jni_new_string_with_repeat_permanent_thread_attachments(c: &mut Criterion) {
         |b| {
             b.iter(|| {
                 VM.attach_current_thread(|env| -> jni::errors::Result<()> {
-                    black_box(env.new_string("Test").unwrap().auto());
+                    black_box(JString::from_jni_str(env, jni_str!("Test")).unwrap().auto());
                     Ok(())
                 })
                 .unwrap();

--- a/src/descriptors/desc.rs
+++ b/src/descriptors/desc.rs
@@ -31,12 +31,12 @@ pub unsafe trait Desc<'local, T> {
     /// necessary to use turbofish syntax when calling this method:
     ///
     /// ```rust,no_run
-    /// # use jni::{descriptors::Desc, errors::Result, Env, objects::JClass};
+    /// # use jni::{jni_str, descriptors::Desc, errors::Result, Env, objects::JClass};
     /// #
     /// # fn example(env: &mut Env) -> Result<()> {
     /// // The value returned by `lookup` is not exactly `JClass`.
     /// let class/*: impl AsRef<JClass> */ =
-    ///     Desc::<JClass>::lookup(c"java/lang/Object", env)?;
+    ///     Desc::<JClass>::lookup(jni_str!("java/lang/Object"), env)?;
     ///
     /// // But `&JClass` can be borrowed from it.
     /// let class: &JClass = class.as_ref();
@@ -53,14 +53,14 @@ pub unsafe trait Desc<'local, T> {
     /// For example, don't do this:
     ///
     /// ```rust,no_run
-    /// # use jni::{descriptors::Desc, errors::Result, Env, objects::JClass};
+    /// # use jni::{jni_str, descriptors::Desc, errors::Result, Env, objects::JClass};
     /// #
     /// # fn some_function<T>(ptr: *mut T) {}
     /// #
     /// # fn example(env: &mut Env) -> Result<()> {
     /// // Undefined behavior: the `JClass` is dropped before the raw pointer
     /// // is passed to `some_function`!
-    /// some_function(Desc::<JClass>::lookup(c"java/lang/Object", env)?.as_raw());
+    /// some_function(Desc::<JClass>::lookup(jni_str!("java/lang/Object"), env)?.as_raw());
     /// # Ok(())
     /// # }
     /// ```
@@ -68,12 +68,12 @@ pub unsafe trait Desc<'local, T> {
     /// Instead, do this:
     ///
     /// ```rust,no_run
-    /// # use jni::{descriptors::Desc, errors::Result, Env, objects::JClass};
+    /// # use jni::{jni_str, descriptors::Desc, errors::Result, Env, objects::JClass};
     /// #
     /// # fn some_function<T>(ptr: *mut T) {}
     /// #
     /// # fn example(env: &mut Env) -> Result<()> {
-    /// let class = Desc::<JClass>::lookup(c"java/lang/Object", env)?;
+    /// let class = Desc::<JClass>::lookup(jni_str!("java/lang/Object"), env)?;
     ///
     /// some_function(class.as_raw());
     ///

--- a/src/descriptors/exception_desc.rs
+++ b/src/descriptors/exception_desc.rs
@@ -2,12 +2,13 @@ use crate::{
     descriptors::Desc,
     env::Env,
     errors::*,
+    jni_str,
     objects::{Auto, IntoAuto as _, JClass, JObject, JString, JThrowable, JValue},
     signature::{JavaType, MethodSignature, Primitive},
     strings::{JNIStr, JNIString},
 };
 
-const DEFAULT_EXCEPTION_CLASS: &JNIStr = JNIStr::from_cstr(c"java/lang/RuntimeException");
+const DEFAULT_EXCEPTION_CLASS: &JNIStr = jni_str!("java/lang/RuntimeException");
 
 unsafe impl<'local, 'other_local, C, M> Desc<'local, JThrowable<'local>> for (C, M)
 where
@@ -22,7 +23,7 @@ where
         // Safety: We are sure the arguments and return type are consistent with the signature string.
         let ctor_sig = unsafe {
             MethodSignature::from_raw_parts(
-                JNIStr::from_cstr(c"(Ljava/lang/String;)V"),
+                jni_str!("(Ljava/lang/String;)V"),
                 ctor_args,
                 JavaType::Primitive(Primitive::Void),
             )

--- a/src/descriptors/method_desc.rs
+++ b/src/descriptors/method_desc.rs
@@ -2,6 +2,7 @@ use crate::{
     descriptors::Desc,
     env::Env,
     errors::*,
+    jni_str,
     objects::{JClass, JMethodID, JStaticMethodID},
     signature::MethodSignature,
     strings::JNIStr,
@@ -29,7 +30,7 @@ where
     type Output = JMethodID;
 
     fn lookup(self, env: &mut Env<'local>) -> Result<Self::Output> {
-        Desc::<JMethodID>::lookup((self.0, c"<init>", self.1.as_ref()), env)
+        Desc::<JMethodID>::lookup((self.0, jni_str!("<init>"), self.1.as_ref()), env)
     }
 }
 

--- a/src/objects/jclass.rs
+++ b/src/objects/jclass.rs
@@ -1,4 +1,4 @@
-use crate::strings::JNIStr;
+use crate::jni_str;
 
 crate::bind_java_type! {
     rust_type = JClass,
@@ -10,7 +10,7 @@ crate::bind_java_type! {
             // As a special-case; we ignore loader_context and use `env.find_class` just to be clear
             // that there's no risk of recursion. (`LoaderContext::load_class` depends on the
             // `JClassAPI`)
-            env.find_class(const { JNIStr::from_cstr(c"java/lang/Class") })
+            env.find_class(const { jni_str!("java/lang/Class") })
         }
     },
     methods {

--- a/src/objects/jclass_loader.rs
+++ b/src/objects/jclass_loader.rs
@@ -1,4 +1,4 @@
-use crate::strings::JNIStr;
+use crate::jni_str;
 
 crate::bind_java_type! {
     rust_type = JClassLoader,
@@ -7,7 +7,7 @@ crate::bind_java_type! {
         load_class = |env, _loader_context, _initialize| {
             // As a special-case; we ignore loader_context and use `env.find_class` just to be clear that there's no risk of
             // recursion. (`LoaderContext::load_class` depends on the `JClassLoaderAPI`)
-            env.find_class(const { JNIStr::from_cstr(c"java/lang/ClassLoader") })
+            env.find_class(const { jni_str!("java/lang/ClassLoader") })
         }
     },
     methods {

--- a/src/objects/jobject.rs
+++ b/src/objects/jobject.rs
@@ -2,6 +2,7 @@ use std::{borrow::Cow, marker::PhantomData, ops::Deref};
 
 use crate::{
     errors::Result,
+    jni_str,
     objects::{Global, JClass, LoaderContext},
     strings::JNIStr,
     sys::jobject,
@@ -116,7 +117,7 @@ impl JObjectAPI {
         // threads race here.
 
         let api = env.with_local_frame(8, |env| -> crate::errors::Result<_> {
-            let class = env.find_class(JNIStr::from_cstr(c"java/lang/Object"))?;
+            let class = env.find_class(jni_str!("java/lang/Object"))?;
             let class = env.new_global_ref(class)?;
             Ok(JObjectAPI { class })
         })?;
@@ -176,7 +177,7 @@ unsafe impl Reference for JObject<'_> {
     }
 
     fn class_name() -> Cow<'static, JNIStr> {
-        Cow::Borrowed(JNIStr::from_cstr(c"java.lang.Object"))
+        Cow::Borrowed(jni_str!("java.lang.Object"))
     }
 
     fn lookup_class<'caller>(

--- a/src/objects/jprimitive_array.rs
+++ b/src/objects/jprimitive_array.rs
@@ -445,7 +445,7 @@ macro_rules! impl_ref_for_jprimitive_array {
                 }
 
                 fn class_name() -> Cow<'static, JNIStr> {
-                    Cow::Borrowed(JNIStr::from_cstr($class_name))
+                    Cow::Borrowed($crate::jni_str!($class_name))
                 }
 
                 fn lookup_class<'caller>(
@@ -474,11 +474,11 @@ macro_rules! impl_ref_for_jprimitive_array {
     };
 }
 
-impl_ref_for_jprimitive_array!(jboolean, c"[Z");
-impl_ref_for_jprimitive_array!(jbyte, c"[B");
-impl_ref_for_jprimitive_array!(jchar, c"[C");
-impl_ref_for_jprimitive_array!(jshort, c"[S");
-impl_ref_for_jprimitive_array!(jint, c"[I");
-impl_ref_for_jprimitive_array!(jlong, c"[J");
-impl_ref_for_jprimitive_array!(jfloat, c"[F");
-impl_ref_for_jprimitive_array!(jdouble, c"[D");
+impl_ref_for_jprimitive_array!(jboolean, "[Z");
+impl_ref_for_jprimitive_array!(jbyte, "[B");
+impl_ref_for_jprimitive_array!(jchar, "[C");
+impl_ref_for_jprimitive_array!(jshort, "[S");
+impl_ref_for_jprimitive_array!(jint, "[I");
+impl_ref_for_jprimitive_array!(jlong, "[J");
+impl_ref_for_jprimitive_array!(jfloat, "[F");
+impl_ref_for_jprimitive_array!(jdouble, "[D");

--- a/src/objects/jthread.rs
+++ b/src/objects/jthread.rs
@@ -1,4 +1,4 @@
-use crate::strings::JNIStr;
+use crate::jni_str;
 
 crate::bind_java_type! {
     rust_type = JThread,
@@ -7,7 +7,7 @@ crate::bind_java_type! {
         load_class = |env, _loader_context, _initialize| {
             // As a special-case; we ignore loader_context and use `env.find_class` just to be clear that there's no risk of
             // recursion. (`LoaderContext::load_class` depends on the `JThreadAPI`)
-            env.find_class(const { JNIStr::from_cstr(c"java/lang/Thread") })
+            env.find_class(const { jni_str!("java/lang/Thread") })
         }
     },
     methods {

--- a/src/vm/java_vm.rs
+++ b/src/vm/java_vm.rs
@@ -121,7 +121,7 @@ static JAVA_VM_SINGLETON: std::sync::OnceLock<JavaVM> = std::sync::OnceLock::new
 /// # // Ignore this test without invocation feature, so that simple `cargo test` works
 /// # #[cfg(feature = "invocation")]
 /// # fn main() -> errors::StartJvmResult<()> {
-/// # use jni::{jni_sig, AttachGuard, objects::JValue, InitArgsBuilder, Env, JNIVersion, JavaVM, sys::jint};
+/// # use jni::{jni_sig, jni_str, AttachGuard, objects::JValue, InitArgsBuilder, Env, JNIVersion, JavaVM, sys::jint};
 /// # //
 /// // Build the VM properties
 /// let jvm_args = InitArgsBuilder::new()
@@ -141,7 +141,7 @@ static JAVA_VM_SINGLETON: std::sync::OnceLock<JavaVM> = std::sync::OnceLock::new
 /// jvm.attach_current_thread(|env| -> errors::Result<()> {
 ///     // Call Java Math#abs(-10)
 ///     let x = JValue::from(-10);
-///     let val: jint = env.call_static_method(c"java/lang/Math", c"abs", jni_sig!("(I)I"), &[x])?
+///     let val: jint = env.call_static_method(jni_str!("java/lang/Math"), jni_str!("abs"), jni_sig!("(I)I"), &[x])?
 ///         .i()?;
 ///
 ///     assert_eq!(val, 10);

--- a/tests/descriptors.rs
+++ b/tests/descriptors.rs
@@ -5,17 +5,19 @@ use util::attach_current_thread;
 
 use jni::{
     descriptors::Desc,
+    jni_str,
     objects::{Auto, JClass},
 };
 
 #[test]
 fn test_descriptors() {
     attach_current_thread(|env| {
-        let class_local = env.find_class(c"java/lang/String").unwrap();
+        let class_local = env.find_class(jni_str!("java/lang/String")).unwrap();
         let class_as_ref = Desc::<JClass>::lookup(&class_local, env).unwrap();
         let class_global = env.new_global_ref(class_as_ref).unwrap();
         let _class_as_ref = Desc::<JClass>::lookup(&class_global, env).unwrap();
-        let class_auto: Auto<_> = Desc::<JClass>::lookup(c"java/lang/String", env).unwrap();
+        let class_auto: Auto<_> =
+            Desc::<JClass>::lookup(jni_str!("java/lang/String"), env).unwrap();
         let _class_as_ref = Desc::<JClass>::lookup(&class_auto, env).unwrap();
 
         Ok(())

--- a/tests/get_rust_field_ergonomics.rs
+++ b/tests/get_rust_field_ergonomics.rs
@@ -2,7 +2,7 @@
 // this checks the ergonomics of using get_rust_field to lock multiple fields
 // without losing access to any `&mut Env` reference you might have.
 
-use jni::{objects::JObject, EnvUnowned};
+use jni::{jni_str, objects::JObject, EnvUnowned};
 
 pub struct Renderer {
     // fields
@@ -27,8 +27,9 @@ pub extern "system" fn Java_Renderer_render<'local>(
     unowned_env
         .with_env(|env| -> jni::errors::Result<_> {
             let mut renderer =
-                unsafe { env.get_rust_field::<_, _, Renderer>(renderer, c"mNative")? };
-            let surface = unsafe { env.get_rust_field::<_, _, Surface>(surface, c"mNative")? };
+                unsafe { env.get_rust_field::<_, _, Renderer>(renderer, jni_str!("mNative"))? };
+            let surface =
+                unsafe { env.get_rust_field::<_, _, Surface>(surface, jni_str!("mNative"))? };
             renderer.render(&surface);
 
             // Check we can still call something requiring `&mut Env` after locking multiple fields

--- a/tests/invocation_character_encoding.rs
+++ b/tests/invocation_character_encoding.rs
@@ -4,7 +4,7 @@
 
 use std::borrow::Cow;
 
-use jni::{jni_sig, objects::JString, InitArgsBuilder, JavaVM};
+use jni::{jni_sig, jni_str, objects::JString, InitArgsBuilder, JavaVM};
 
 #[test]
 fn invocation_character_encoding() {
@@ -29,8 +29,8 @@ fn invocation_character_encoding() {
         println!("calling getProperty");
         let prop_value = env
             .call_static_method(
-                c"java/lang/System",
-                c"getProperty",
+                jni_str!("java/lang/System"),
+                jni_str!("getProperty"),
                 jni_sig!("(Ljava/lang/String;)Ljava/lang/String;"),
                 &[(&prop_name).into()],
             )

--- a/tests/java_integers.rs
+++ b/tests/java_integers.rs
@@ -1,6 +1,6 @@
 #![cfg(feature = "invocation")]
 
-use jni::{errors::Result, jni_sig, objects::JValue};
+use jni::{errors::Result, jni_sig, jni_str, objects::JValue};
 
 mod util;
 use util::{attach_current_thread, print_exception};
@@ -13,18 +13,21 @@ fn test_java_integers() {
         for value in -10..10 {
             env.with_local_frame(16, |env| -> Result<()> {
                 let integer_value = env.new_object(
-                    c"java/lang/Integer",
+                    jni_str!("java/lang/Integer"),
                     jni_sig!("(I)V"),
                     &[JValue::Int(value)],
                 )?;
 
-                let values_array =
-                    env.new_object_array(array_length, c"java/lang/Integer", &integer_value)?;
+                let values_array = env.new_object_array(
+                    array_length,
+                    jni_str!("java/lang/Integer"),
+                    &integer_value,
+                )?;
 
                 let result = env
                     .call_static_method(
-                        c"java/util/Arrays",
-                        c"binarySearch",
+                        jni_str!("java/util/Arrays"),
+                        jni_str!("binarySearch"),
                         jni_sig!("([Ljava/lang/Object;Ljava/lang/Object;)I"),
                         &[
                             JValue::Object(&values_array),

--- a/tests/jlist.rs
+++ b/tests/jlist.rs
@@ -1,9 +1,8 @@
 #![cfg(feature = "invocation")]
 
 use jni::{
-    jni_sig,
+    jni_sig, jni_str,
     objects::{IntoAuto, JList, JString},
-    strings::JNIStr,
     sys::jint,
 };
 
@@ -14,16 +13,16 @@ use util::{attach_current_thread, unwrap};
 pub fn jlist_push_and_iterate() {
     attach_current_thread(|env| {
         let data = &[
-            JNIStr::from_cstr(c"hello"),
-            JNIStr::from_cstr(c"world"),
-            JNIStr::from_cstr(c"from"),
-            JNIStr::from_cstr(c"jlist"),
-            JNIStr::from_cstr(c"test"),
+            jni_str!("hello"),
+            jni_str!("world"),
+            jni_str!("from"),
+            jni_str!("jlist"),
+            jni_str!("test"),
         ];
 
         // Create a new ArrayList
         let list_object = unwrap(
-            env.new_object(c"java/util/ArrayList", jni_sig!("()V"), &[]),
+            env.new_object(jni_str!("java/util/ArrayList"), jni_sig!("()V"), &[]),
             env,
         );
         let list = unwrap(JList::cast_local(env, list_object), env);
@@ -69,7 +68,7 @@ pub fn jlist_get_and_set() {
     attach_current_thread(|env| {
         // Create a new ArrayList
         let list_object = unwrap(
-            env.new_object(c"java/util/ArrayList", jni_sig!("()V"), &[]),
+            env.new_object(jni_str!("java/util/ArrayList"), jni_sig!("()V"), &[]),
             env,
         );
         let list = unwrap(JList::cast_local(env, list_object), env);
@@ -108,7 +107,7 @@ pub fn jlist_insert_and_remove() {
     attach_current_thread(|env| {
         // Create a new ArrayList
         let list_object = unwrap(
-            env.new_object(c"java/util/ArrayList", jni_sig!("()V"), &[]),
+            env.new_object(jni_str!("java/util/ArrayList"), jni_sig!("()V"), &[]),
             env,
         );
         let list = unwrap(JList::cast_local(env, list_object), env);
@@ -170,7 +169,7 @@ pub fn jlist_size_and_remove() {
     attach_current_thread(|env| {
         // Create a new ArrayList
         let list_object = unwrap(
-            env.new_object(c"java/util/ArrayList", jni_sig!("()V"), &[]),
+            env.new_object(jni_str!("java/util/ArrayList"), jni_sig!("()V"), &[]),
             env,
         );
         let list = unwrap(JList::cast_local(env, list_object), env);
@@ -232,7 +231,7 @@ pub fn jlist_iterator_empty() {
     attach_current_thread(|env| {
         // Create an empty ArrayList
         let list_object = unwrap(
-            env.new_object(c"java/util/ArrayList", jni_sig!("()V"), &[]),
+            env.new_object(jni_str!("java/util/ArrayList"), jni_sig!("()V"), &[]),
             env,
         );
         let list = unwrap(JList::cast_local(env, list_object), env);
@@ -260,15 +259,11 @@ pub fn jlist_iterator_empty() {
 #[test]
 pub fn jlist_iterator_with_auto() {
     attach_current_thread(|env| {
-        let data = &[
-            JNIStr::from_cstr(c"item1"),
-            JNIStr::from_cstr(c"item2"),
-            JNIStr::from_cstr(c"item3"),
-        ];
+        let data = &[jni_str!("item1"), jni_str!("item2"), jni_str!("item3")];
 
         // Create a new ArrayList
         let list_object = unwrap(
-            env.new_object(c"java/util/ArrayList", jni_sig!("()V"), &[]),
+            env.new_object(jni_str!("java/util/ArrayList"), jni_sig!("()V"), &[]),
             env,
         );
         let list = unwrap(JList::cast_local(env, list_object), env);

--- a/tests/jmap.rs
+++ b/tests/jmap.rs
@@ -1,9 +1,8 @@
 #![cfg(feature = "invocation")]
 
 use jni::{
-    jni_sig,
+    jni_sig, jni_str,
     objects::{JMap, JObject, JString},
-    strings::JNIStr,
 };
 
 mod util;
@@ -13,15 +12,15 @@ use util::{attach_current_thread, unwrap};
 pub fn jmap_push_and_iterate() {
     attach_current_thread(|env| {
         let data = &[
-            JNIStr::from_cstr(c"hello"),
-            JNIStr::from_cstr(c"world"),
-            JNIStr::from_cstr(c"from"),
-            JNIStr::from_cstr(c"test"),
+            jni_str!("hello"),
+            jni_str!("world"),
+            jni_str!("from"),
+            jni_str!("test"),
         ];
 
         // Create a new map. Use LinkedHashMap to have predictable iteration order
         let map_object = unwrap(
-            env.new_object(c"java/util/LinkedHashMap", jni_sig!("()V"), &[]),
+            env.new_object(jni_str!("java/util/LinkedHashMap"), jni_sig!("()V"), &[]),
             env,
         );
         let map = unwrap(JMap::cast_local(env, map_object), env);

--- a/tests/jni_api.rs
+++ b/tests/jni_api.rs
@@ -6,7 +6,7 @@ use assert_matches::assert_matches;
 use jni::{
     descriptors::Desc,
     errors::{CharToJavaError, Error},
-    jni_sig,
+    jni_sig, jni_str,
     objects::{
         AutoElements, IntoAuto as _, JByteBuffer, JList, JObject, JObjectArray, JStackTraceElement,
         JString, JThrowable, JValue, ReleaseMode, Weak,
@@ -25,19 +25,19 @@ use rusty_fork::rusty_fork_test;
 
 use crate::util::jvm;
 
-static ARRAYLIST_CLASS: &JNIStr = JNIStr::from_cstr(c"java/util/ArrayList");
-static EXCEPTION_CLASS: &JNIStr = JNIStr::from_cstr(c"java/lang/Exception");
-static ARITHMETIC_EXCEPTION_CLASS: &JNIStr = JNIStr::from_cstr(c"java/lang/ArithmeticException");
-static RUNTIME_EXCEPTION_CLASS: &JNIStr = JNIStr::from_cstr(c"java/lang/RuntimeException");
-static INTEGER_CLASS: &JNIStr = JNIStr::from_cstr(c"java/lang/Integer");
-static MATH_CLASS: &JNIStr = JNIStr::from_cstr(c"java/lang/Math");
-static STRING_CLASS: &JNIStr = JNIStr::from_cstr(c"java/lang/String");
-static MATH_ABS_METHOD_NAME: &JNIStr = JNIStr::from_cstr(c"abs");
-static MATH_TO_INT_METHOD_NAME: &JNIStr = JNIStr::from_cstr(c"toIntExact");
+static ARRAYLIST_CLASS: &JNIStr = jni_str!("java/util/ArrayList");
+static EXCEPTION_CLASS: &JNIStr = jni_str!("java/lang/Exception");
+static ARITHMETIC_EXCEPTION_CLASS: &JNIStr = jni_str!("java/lang/ArithmeticException");
+static RUNTIME_EXCEPTION_CLASS: &JNIStr = jni_str!("java/lang/RuntimeException");
+static INTEGER_CLASS: &JNIStr = jni_str!("java/lang/Integer");
+static MATH_CLASS: &JNIStr = jni_str!("java/lang/Math");
+static STRING_CLASS: &JNIStr = jni_str!("java/lang/String");
+static MATH_ABS_METHOD_NAME: &JNIStr = jni_str!("abs");
+static MATH_TO_INT_METHOD_NAME: &JNIStr = jni_str!("toIntExact");
 static MATH_ABS_SIGNATURE: &MethodSignature = &jni_sig!("(I)I");
 static MATH_TO_INT_SIGNATURE: &MethodSignature = &jni_sig!("(J)I");
-static TEST_EXCEPTION_MESSAGE: &JNIStr = JNIStr::from_cstr(c"Default exception thrown");
-static TESTING_OBJECT_STR: &JNIStr = JNIStr::from_cstr(c"TESTING OBJECT");
+static TEST_EXCEPTION_MESSAGE: &JNIStr = jni_str!("Default exception thrown");
+static TESTING_OBJECT_STR: &JNIStr = jni_str!("TESTING OBJECT");
 
 #[test]
 pub fn call_method_returning_null() {
@@ -46,7 +46,12 @@ pub fn call_method_returning_null() {
         let obj = unwrap(env.new_object(EXCEPTION_CLASS, jni_sig!("()V"), &[]), env).auto();
         // Call Throwable#getMessage must return null
         let message = unwrap(
-            env.call_method(&obj, c"getMessage", jni_sig!("()Ljava/lang/String;"), &[]),
+            env.call_method(
+                &obj,
+                jni_str!("getMessage"),
+                jni_sig!("()Ljava/lang/String;"),
+                &[],
+            ),
             env,
         );
         let message_ref = unwrap(message.l(), env).auto();
@@ -180,7 +185,7 @@ pub fn get_public_field() {
         // Create a new Point(5, 10)
         let point = unwrap(
             env.new_object(
-                c"java/awt/Point",
+                jni_str!("java/awt/Point"),
                 jni_sig!("(II)V"),
                 &[JValue::Int(5), JValue::Int(10)],
             ),
@@ -190,7 +195,7 @@ pub fn get_public_field() {
 
         // Get the x field value
         let x_value = env
-            .get_field(&point, c"x", jni_sig!("I"))
+            .get_field(&point, jni_str!("x"), jni_sig!("I"))
             .unwrap()
             .i()
             .unwrap();
@@ -199,7 +204,7 @@ pub fn get_public_field() {
 
         // Get the y field value
         let y_value = env
-            .get_field(&point, c"y", jni_sig!("I"))
+            .get_field(&point, jni_str!("y"), jni_sig!("I"))
             .unwrap()
             .i()
             .unwrap();
@@ -217,7 +222,7 @@ pub fn get_public_field_by_id() {
         // Create a new Point(5, 10)
         let point = unwrap(
             env.new_object(
-                c"java/awt/Point",
+                jni_str!("java/awt/Point"),
                 jni_sig!("(II)V"),
                 &[JValue::Int(5), JValue::Int(10)],
             ),
@@ -227,7 +232,7 @@ pub fn get_public_field_by_id() {
 
         // Get the field ID for x field
         let field_id = env
-            .get_field_id(c"java/awt/Point", c"x", jni_sig!("I"))
+            .get_field_id(jni_str!("java/awt/Point"), jni_str!("x"), jni_sig!("I"))
             .unwrap();
 
         let field_type = ReturnType::Primitive(Primitive::Int);
@@ -253,7 +258,7 @@ pub fn set_public_field() {
         // Create a new Point(5, 10)
         let point = unwrap(
             env.new_object(
-                c"java/awt/Point",
+                jni_str!("java/awt/Point"),
                 jni_sig!("(II)V"),
                 &[JValue::Int(5), JValue::Int(10)],
             ),
@@ -262,12 +267,12 @@ pub fn set_public_field() {
         .auto();
 
         // Set the x field to a new value
-        env.set_field(&point, c"x", jni_sig!("I"), JValue::Int(15))
+        env.set_field(&point, jni_str!("x"), jni_sig!("I"), JValue::Int(15))
             .unwrap();
 
         // Verify the field was set
         let x_value = env
-            .get_field(&point, c"x", jni_sig!("I"))
+            .get_field(&point, jni_str!("x"), jni_sig!("I"))
             .unwrap()
             .i()
             .unwrap();
@@ -275,12 +280,12 @@ pub fn set_public_field() {
         assert_eq!(x_value, 15);
 
         // Set the y field to a new value
-        env.set_field(&point, c"y", jni_sig!("I"), JValue::Int(25))
+        env.set_field(&point, jni_str!("y"), jni_sig!("I"), JValue::Int(25))
             .unwrap();
 
         // Verify the field was set
         let y_value = env
-            .get_field(&point, c"y", jni_sig!("I"))
+            .get_field(&point, jni_str!("y"), jni_sig!("I"))
             .unwrap()
             .i()
             .unwrap();
@@ -298,7 +303,7 @@ pub fn set_public_field_by_id() {
         // Create a new Point(5, 10)
         let point = unwrap(
             env.new_object(
-                c"java/awt/Point",
+                jni_str!("java/awt/Point"),
                 jni_sig!("(II)V"),
                 &[JValue::Int(5), JValue::Int(10)],
             ),
@@ -308,7 +313,7 @@ pub fn set_public_field_by_id() {
 
         // Get the field ID for x field
         let field_id = env
-            .get_field_id(c"java/awt/Point", c"x", jni_sig!("I"))
+            .get_field_id(jni_str!("java/awt/Point"), jni_str!("x"), jni_sig!("I"))
             .unwrap();
 
         // Set the x field using the field ID
@@ -320,7 +325,7 @@ pub fn set_public_field_by_id() {
 
         // Verify the field was set
         let x_value = env
-            .get_field(&point, c"x", jni_sig!("I"))
+            .get_field(&point, jni_str!("x"), jni_sig!("I"))
             .unwrap()
             .i()
             .unwrap();
@@ -336,7 +341,7 @@ pub fn set_public_field_by_id() {
 pub fn get_static_public_field() {
     attach_current_thread(|env| {
         let min_int_value = env
-            .get_static_field(INTEGER_CLASS, c"MIN_VALUE", jni_sig!("I"))
+            .get_static_field(INTEGER_CLASS, jni_str!("MIN_VALUE"), jni_sig!("I"))
             .unwrap()
             .i()
             .unwrap();
@@ -352,7 +357,7 @@ pub fn get_static_public_field() {
 pub fn get_static_public_field_by_id() {
     attach_current_thread(|env| {
         let field_id = env
-            .get_static_field_id(INTEGER_CLASS, c"MIN_VALUE", jni_sig!("I"))
+            .get_static_field_id(INTEGER_CLASS, jni_str!("MIN_VALUE"), jni_sig!("I"))
             .unwrap();
 
         let field_type = JavaType::Primitive(Primitive::Int);
@@ -380,7 +385,7 @@ fn set_static_public_field() {
 
         // Get the original System.in value
         let original_in = env
-            .get_static_field(c"java/lang/System", c"in", jni_sig!("Ljava/io/InputStream;"))
+            .get_static_field(jni_str!("java/lang/System"), jni_str!("in"), jni_sig!("Ljava/io/InputStream;"))
             .unwrap()
             .l()
             .unwrap();
@@ -389,7 +394,7 @@ fn set_static_public_field() {
         let byte_array = env.new_byte_array(10).unwrap();
         let new_input_stream = env
             .new_object(
-                c"java/io/ByteArrayInputStream",
+                jni_str!("java/io/ByteArrayInputStream"),
                 jni_sig!("([B)V"),
                 &[JValue::from(&byte_array)],
             )
@@ -397,8 +402,8 @@ fn set_static_public_field() {
 
         // Set System.in to our new ByteArrayInputStream
         env.set_static_field(
-            c"java/lang/System",
-            c"in",
+            jni_str!("java/lang/System"),
+            jni_str!("in"),
             jni_sig!("Ljava/io/InputStream;"),
             JValue::from(&new_input_stream),
         )
@@ -406,7 +411,7 @@ fn set_static_public_field() {
 
         // Verify the field was set by getting it again and checking it's no longer null
         let current_in = env
-            .get_static_field(c"java/lang/System", c"in", jni_sig!("Ljava/io/InputStream;"))
+            .get_static_field(jni_str!("java/lang/System"), jni_str!("in"), jni_sig!("Ljava/io/InputStream;"))
             .unwrap()
             .l()
             .unwrap();
@@ -416,8 +421,8 @@ fn set_static_public_field() {
 
         // Restore the original System.in
         env.set_static_field(
-            c"java/lang/System",
-            c"in",
+            jni_str!("java/lang/System"),
+            jni_str!("in"),
             jni_sig!("Ljava/io/InputStream;"),
             JValue::from(&original_in),
         )
@@ -425,7 +430,7 @@ fn set_static_public_field() {
 
         // Verify restoration worked - the field should still not be null
         let restored_in = env
-            .get_static_field(c"java/lang/System", c"in", jni_sig!("Ljava/io/InputStream;"))
+            .get_static_field(jni_str!("java/lang/System"), jni_str!("in"), jni_sig!("Ljava/io/InputStream;"))
             .unwrap()
             .l()
             .unwrap();
@@ -444,7 +449,7 @@ fn set_static_public_field_by_id() {
     attach_current_thread(|env| {
         // Get the original System.in value
         let original_in = env
-            .get_static_field(c"java/lang/System", c"in", jni_sig!("Ljava/io/InputStream;"))
+            .get_static_field(jni_str!("java/lang/System"), jni_str!("in"), jni_sig!("Ljava/io/InputStream;"))
             .unwrap()
             .l()
             .unwrap();
@@ -452,14 +457,14 @@ fn set_static_public_field_by_id() {
         // Get the field ID for System.in
         let field_type = jni_sig!("Ljava/io/InputStream;");
         let field_id = env
-            .get_static_field_id(c"java/lang/System", c"in", field_type)
+            .get_static_field_id(jni_str!("java/lang/System"), jni_str!("in"), field_type)
             .unwrap();
 
         // Create a new ByteArrayInputStream as a different InputStream
         let byte_array = env.new_byte_array(10).unwrap();
         let new_input_stream = env
             .new_object(
-                c"java/io/ByteArrayInputStream",
+                jni_str!("java/io/ByteArrayInputStream"),
                 jni_sig!("([B)V"),
                 &[JValue::from(&byte_array)],
             )
@@ -469,7 +474,7 @@ fn set_static_public_field_by_id() {
         // Safety: we have just looked up the field ID based on the given field name and type
         unsafe {
             env.set_static_field_unchecked(
-                c"java/lang/System",
+                jni_str!("java/lang/System"),
                 field_id,
                 JValue::from(&new_input_stream),
             )
@@ -478,7 +483,7 @@ fn set_static_public_field_by_id() {
 
         // Verify the field was set by getting it again (this ensures the set operation worked)
         let current_in = env
-            .get_static_field(c"java/lang/System", c"in", jni_sig!("Ljava/io/InputStream;"))
+            .get_static_field(jni_str!("java/lang/System"), jni_str!("in"), jni_sig!("Ljava/io/InputStream;"))
             .unwrap()
             .l()
             .unwrap();
@@ -490,7 +495,7 @@ fn set_static_public_field_by_id() {
         // Safety: we have the correct field ID and value type
         unsafe {
             env.set_static_field_unchecked(
-                c"java/lang/System",
+                jni_str!("java/lang/System"),
                 field_id,
                 JValue::from(&original_in),
             )
@@ -499,7 +504,7 @@ fn set_static_public_field_by_id() {
 
         // Verify restoration worked
         let restored_in = env
-            .get_static_field(c"java/lang/System", c"in", jni_sig!("Ljava/io/InputStream;"))
+            .get_static_field(jni_str!("java/lang/System"), jni_str!("in"), jni_sig!("Ljava/io/InputStream;"))
             .unwrap()
             .l()
             .unwrap();
@@ -633,7 +638,7 @@ pub fn with_local_frame_misuse_panic() {
 #[test]
 pub fn with_local_frame_pending_exception() {
     attach_current_thread(|env| {
-        env.throw_new(RUNTIME_EXCEPTION_CLASS, c"Test Exception")
+        env.throw_new(RUNTIME_EXCEPTION_CLASS, jni_str!("Test Exception"))
             .unwrap();
 
         // Try to allocate a frame of locals
@@ -653,7 +658,12 @@ pub fn call_method_ok() {
         let s = JString::from_jni_str(env, TESTING_OBJECT_STR).unwrap();
 
         let v: jint = env
-            .call_method(s, c"indexOf", jni_sig!("(I)I"), &[JValue::Int('S' as i32)])
+            .call_method(
+                s,
+                jni_str!("indexOf"),
+                jni_sig!("(I)I"),
+                &[JValue::Int('S' as i32)],
+            )
             .expect("Env#call_method should return JValue")
             .i()
             .unwrap();
@@ -673,7 +683,7 @@ pub fn call_method_with_bad_args_errs() {
         let is_bad_typ = env
             .call_method(
                 &s,
-                c"indexOf",
+                jni_str!("indexOf"),
                 jni_sig!("(I)I"),
                 &[JValue::Float(std::f32::consts::PI)],
             )
@@ -688,7 +698,7 @@ pub fn call_method_with_bad_args_errs() {
         let is_bad_len = env
             .call_method(
                 &s,
-                c"indexOf",
+                jni_str!("indexOf"),
                 jni_sig!("(I)I"),
                 &[JValue::Int('S' as i32), JValue::Long(3)],
             )
@@ -756,7 +766,11 @@ pub fn call_new_object_unchecked_ok() {
         let string_class = env.find_class(STRING_CLASS).unwrap();
 
         let ctor_method_id = env
-            .get_method_id(&string_class, c"<init>", jni_sig!("(Ljava/lang/String;)V"))
+            .get_method_id(
+                &string_class,
+                jni_str!("<init>"),
+                jni_sig!("(Ljava/lang/String;)V"),
+            )
             .unwrap();
         let val: JObject = unsafe {
             env.new_object_unchecked(
@@ -909,7 +923,11 @@ pub fn call_static_method_with_bad_args_errs() {
 pub fn get_reflected_method_from_id() {
     attach_current_thread(|env| {
         let ctor_method_id = env
-            .get_method_id(INTEGER_CLASS, c"<init>", jni_sig!("(Ljava/lang/String;)V"))
+            .get_method_id(
+                INTEGER_CLASS,
+                jni_str!("<init>"),
+                jni_sig!("(Ljava/lang/String;)V"),
+            )
             .expect("constructor from string exists");
         let ctor = env
             .to_reflected_method(INTEGER_CLASS, ctor_method_id)
@@ -918,12 +936,12 @@ pub fn get_reflected_method_from_id() {
         let value = {
             let jstr = env.new_string("55").unwrap();
             let vargs = env
-                .new_object_array(1, c"java/lang/Object", jstr)
+                .new_object_array(1, jni_str!("java/lang/Object"), jstr)
                 .expect("can create array");
 
             env.call_method(
                 ctor,
-                c"newInstance",
+                jni_str!("newInstance"),
                 jni_sig!("([Ljava/lang/Object;)Ljava/lang/Object;"),
                 &[JValue::from(&vargs)],
             )
@@ -933,7 +951,7 @@ pub fn get_reflected_method_from_id() {
         };
 
         let int_value = env
-            .call_method(value, c"intValue", jni_sig!("()I"), &[])
+            .call_method(value, jni_str!("intValue"), jni_sig!("()I"), &[])
             .unwrap()
             .i()
             .unwrap();
@@ -960,11 +978,13 @@ pub fn get_reflected_static_method_from_id() {
         let arg = env
             .new_object(INTEGER_CLASS, jni_sig!("(I)V"), &[x])
             .unwrap();
-        let vargs = env.new_object_array(1, c"java/lang/Object", arg).unwrap();
+        let vargs = env
+            .new_object_array(1, jni_str!("java/lang/Object"), arg)
+            .unwrap();
         let val = env
             .call_method(
                 abs_method,
-                c"invoke",
+                jni_str!("invoke"),
                 jni_sig!("(Ljava/lang/Object;[Ljava/lang/Object;)Ljava/lang/Object;"),
                 &[JValue::from(&JObject::null()), JValue::from(&vargs)],
             )
@@ -972,7 +992,7 @@ pub fn get_reflected_static_method_from_id() {
             .l()
             .expect("return value is an int");
         let val = env
-            .call_method(val, c"intValue", jni_sig!("()I"), &[])
+            .call_method(val, jni_str!("intValue"), jni_sig!("()I"), &[])
             .unwrap()
             .i()
             .unwrap();
@@ -1467,7 +1487,7 @@ fn get_super_class_ok() {
 #[test]
 fn get_super_class_null() {
     attach_current_thread(|env| {
-        let result = env.get_superclass(c"java/lang/Object");
+        let result = env.get_superclass(jni_str!("java/lang/Object"));
         assert!(result.is_ok());
         assert!(result.unwrap().is_none());
 
@@ -1552,12 +1572,12 @@ fn test_call_nonvirtual_method() {
         let another_string = JObject::from(env.new_string("test").unwrap());
 
         // The `equals` method in java/lang/Object will compare the reference
-        let obj_class = env.find_class(c"java/lang/Object").unwrap();
+        let obj_class = env.find_class(jni_str!("java/lang/Object")).unwrap();
         let object_result = env
             .call_nonvirtual_method(
                 &a_string,
                 &obj_class,
-                c"equals",
+                jni_str!("equals"),
                 jni_sig!("(Ljava/lang/Object;)Z"),
                 &[JValue::from(&another_string)],
             )
@@ -1567,12 +1587,12 @@ fn test_call_nonvirtual_method() {
         assert!(!object_result);
 
         // However, java/lang/String overrided it and it now compares the content.
-        let string_class = env.find_class(c"java/lang/String").unwrap();
+        let string_class = env.find_class(jni_str!("java/lang/String")).unwrap();
         let string_result = env
             .call_nonvirtual_method(
                 &a_string,
                 &string_class,
-                c"equals",
+                jni_str!("equals"),
                 jni_sig!("(Ljava/lang/Object;)Z"),
                 &[JValue::from(&another_string)],
             )
@@ -1609,7 +1629,12 @@ fn short_lifetime_with_local_frame_sub_fn<'local>(
 fn short_lifetime_list() {
     attach_current_thread(|env| {
         let first_list_object = short_lifetime_list_sub_fn(env).unwrap();
-        let value = env.call_method(first_list_object, c"intValue", jni_sig!("()I"), &[]);
+        let value = env.call_method(
+            first_list_object,
+            jni_str!("intValue"),
+            jni_sig!("()I"),
+            &[],
+        );
         assert_eq!(value.unwrap().i().unwrap(), 1);
 
         Ok(())
@@ -1654,12 +1679,12 @@ fn get_object_array_element() {
 #[test]
 pub fn throw_new() {
     attach_current_thread(|env| {
-        env.throw_new(RUNTIME_EXCEPTION_CLASS, c"Test Exception")
+        env.throw_new(RUNTIME_EXCEPTION_CLASS, jni_str!("Test Exception"))
             .unwrap();
         assert_pending_java_exception_detailed(
             env,
             Some(RUNTIME_EXCEPTION_CLASS),
-            Some(JNIStr::from_cstr(c"Test Exception")),
+            Some(jni_str!("Test Exception")),
         );
 
         Ok(())
@@ -1690,9 +1715,10 @@ pub fn throw_new_void() {
 #[should_panic(expected = "WrongObjectType")]
 pub fn throw_new_non_throwable_class() {
     attach_current_thread(|env| {
-        let string_class = env.find_class(c"java/lang/String").unwrap();
+        let string_class = env.find_class(jni_str!("java/lang/String")).unwrap();
 
-        env.throw_new(string_class, c"Test Exception").unwrap();
+        env.throw_new(string_class, jni_str!("Test Exception"))
+            .unwrap();
 
         Ok(())
     })
@@ -1702,7 +1728,10 @@ pub fn throw_new_non_throwable_class() {
 #[test]
 pub fn throw_new_fail() {
     attach_current_thread(|env| {
-        let result = env.throw_new(c"java/lang/NonexistentException", c"Test Exception");
+        let result = env.throw_new(
+            jni_str!("java/lang/NonexistentException"),
+            jni_str!("Test Exception"),
+        );
         assert!(result.is_err());
         // Just to clear the java.lang.NoClassDefFoundError
         assert_pending_java_exception(env);
@@ -1847,7 +1876,7 @@ fn test_java_char_conversion() {
     attach_current_thread(|env| {
         // Make a Java `StringBuilder`.
         let sb = unwrap(
-            env.new_object(c"java/lang/StringBuilder", jni_sig!("()V"), &[]),
+            env.new_object(jni_str!("java/lang/StringBuilder"), jni_sig!("()V"), &[]),
             env,
         );
 
@@ -1858,7 +1887,7 @@ fn test_java_char_conversion() {
         unwrap(
             env.call_method(
                 &sb,
-                c"appendCodePoint",
+                jni_str!("appendCodePoint"),
                 jni_sig!("(I)Ljava/lang/StringBuilder;"),
                 &[JValue::int_from_char('🤓')],
             ),
@@ -1869,7 +1898,7 @@ fn test_java_char_conversion() {
         unwrap(
             env.call_method(
                 &sb,
-                c"append",
+                jni_str!("append"),
                 jni_sig!("(C)Ljava/lang/StringBuilder;"),
                 &[JValue::try_from('☃').unwrap()],
             ),
@@ -1878,7 +1907,12 @@ fn test_java_char_conversion() {
 
         // Finish the `StringBuilder` and get a Java `String`.
         let s = unwrap(
-            env.call_method(&sb, c"toString", jni_sig!("()Ljava/lang/String;"), &[]),
+            env.call_method(
+                &sb,
+                jni_str!("toString"),
+                jni_sig!("()Ljava/lang/String;"),
+                &[],
+            ),
             env,
         )
         .l()
@@ -1891,7 +1925,7 @@ fn test_java_char_conversion() {
 
             // Get the first Java `char` and try to unwrap it to a Rust `char`.
             let c = unwrap(
-                env.call_method(&s, c"charAt", jni_sig!("(I)C"), &[JValue::Int(0)]),
+                env.call_method(&s, jni_str!("charAt"), jni_sig!("(I)C"), &[JValue::Int(0)]),
                 env,
             )
             .c_char();
@@ -1912,7 +1946,12 @@ fn test_java_char_conversion() {
 
             // Get the UTF-32 unit and unwrap it.
             let c = unwrap(
-                env.call_method(&s, c"codePointAt", jni_sig!("(I)I"), &[JValue::Int(0)]),
+                env.call_method(
+                    &s,
+                    jni_str!("codePointAt"),
+                    jni_sig!("(I)I"),
+                    &[JValue::Int(0)],
+                ),
                 env,
             )
             .i_char()
@@ -1929,7 +1968,7 @@ fn test_java_char_conversion() {
             let c = unwrap(
                 env.call_method(
                     &s,
-                    c"charAt",
+                    jni_str!("charAt"),
                     jni_sig!("(I)C"),
                     // The first character is represented in UTF-16 as a surrogate pair, so the second character occurs at index 2 instead of 1.
                     &[JValue::Int(2)],

--- a/tests/jni_global_refs.rs
+++ b/tests/jni_global_refs.rs
@@ -6,7 +6,7 @@ use std::{
 };
 
 use jni::{
-    jni_sig,
+    jni_sig, jni_str,
     objects::{Global, IntoAuto as _, JObject, JValue},
     sys::jint,
 };
@@ -21,7 +21,7 @@ pub fn global_ref_works_in_other_threads() {
     let atomic_integer = attach_current_thread(|env| {
         let local_ref = unwrap(
             env.new_object(
-                c"java/util/concurrent/atomic/AtomicInteger",
+                jni_str!("java/util/concurrent/atomic/AtomicInteger"),
                 jni_sig!("(I)V"),
                 &[JValue::from(0)],
             ),
@@ -53,7 +53,7 @@ pub fn global_ref_works_in_other_threads() {
                             unwrap(
                                 env.call_method(
                                     atomic_integer,
-                                    c"incrementAndGet",
+                                    jni_str!("incrementAndGet"),
                                     jni_sig!("()I"),
                                     &[],
                                 ),
@@ -83,7 +83,7 @@ pub fn global_ref_works_in_other_threads() {
                     unwrap(
                         env.call_method(
                             atomic_integer,
-                            c"getAndSet",
+                            jni_str!("getAndSet"),
                             jni_sig!("(I)I"),
                             &[JValue::from(0)]
                         ),

--- a/tests/jni_weak_refs.rs
+++ b/tests/jni_weak_refs.rs
@@ -6,7 +6,7 @@ use std::{
 };
 
 use jni::{
-    jni_sig,
+    jni_sig, jni_str,
     objects::{IntoAuto as _, JObject, JValue, Weak},
     sys::jint,
     Env,
@@ -22,7 +22,7 @@ pub fn weak_ref_works_in_other_threads() {
     attach_current_thread(|env| {
         let atomic_integer_local = unwrap(
             env.new_object(
-                c"java/util/concurrent/atomic/AtomicInteger",
+                jni_str!("java/util/concurrent/atomic/AtomicInteger"),
                 jni_sig!("(I)V"),
                 &[JValue::from(0)],
             ),
@@ -55,7 +55,7 @@ pub fn weak_ref_works_in_other_threads() {
                                 unwrap(
                                     env.call_method(
                                         &atomic_integer,
-                                        c"incrementAndGet",
+                                        jni_str!("incrementAndGet"),
                                         jni_sig!("()I"),
                                         &[],
                                     ),
@@ -83,7 +83,7 @@ pub fn weak_ref_works_in_other_threads() {
                     unwrap(
                         env.call_method(
                             &atomic_integer_local,
-                            c"getAndSet",
+                            jni_str!("getAndSet"),
                             jni_sig!("(I)I"),
                             &[JValue::from(0)]
                         ),
@@ -108,7 +108,12 @@ fn weak_ref_is_actually_weak() {
         fn run_gc(env: &mut Env) {
             unwrap(
                 env.with_local_frame(1, |env| {
-                    env.call_static_method(c"java/lang/System", c"gc", jni_sig!("()V"), &[])?;
+                    env.call_static_method(
+                        jni_str!("java/lang/System"),
+                        jni_str!("gc"),
+                        jni_sig!("()V"),
+                        &[],
+                    )?;
                     Ok(())
                 }),
                 env,
@@ -118,7 +123,7 @@ fn weak_ref_is_actually_weak() {
         for _ in 0..100 {
             let obj_local = unwrap(
                 env.with_local_frame_returning_local::<_, JObject, _>(2, |env| {
-                    env.new_object(c"java/lang/Object", jni_sig!("()V"), &[])
+                    env.new_object(jni_str!("java/lang/Object"), jni_sig!("()V"), &[])
                 }),
                 env,
             )

--- a/tests/test_generated_aliases.rs
+++ b/tests/test_generated_aliases.rs
@@ -1,7 +1,7 @@
 #![cfg(feature = "invocation")]
 
 use jni::{
-    jni_sig,
+    jni_sig, jni_str,
     objects::{JCollection, JList, JSet},
 };
 
@@ -14,7 +14,7 @@ pub fn test_generated_alias_methods() {
     let _: Result<()> = attach_current_thread(|env| {
         // Test JList as_collection method
         let list_object = unwrap(
-            env.new_object(c"java/util/ArrayList", jni_sig!("()V"), &[]),
+            env.new_object(jni_str!("java/util/ArrayList"), jni_sig!("()V"), &[]),
             env,
         );
         let list = unwrap(JList::cast_local(env, list_object), env);
@@ -23,7 +23,7 @@ pub fn test_generated_alias_methods() {
 
         // Test JList From implementation (using a fresh instance)
         let list_object2 = unwrap(
-            env.new_object(c"java/util/ArrayList", jni_sig!("()V"), &[]),
+            env.new_object(jni_str!("java/util/ArrayList"), jni_sig!("()V"), &[]),
             env,
         );
         let list2 = unwrap(JList::cast_local(env, list_object2), env);
@@ -32,7 +32,7 @@ pub fn test_generated_alias_methods() {
 
         // Test JSet as_collection method
         let set_object = unwrap(
-            env.new_object(c"java/util/HashSet", jni_sig!("()V"), &[]),
+            env.new_object(jni_str!("java/util/HashSet"), jni_sig!("()V"), &[]),
             env,
         );
         let set = unwrap(JSet::cast_local(env, set_object), env);
@@ -41,7 +41,7 @@ pub fn test_generated_alias_methods() {
 
         // Test JSet From implementation (using a fresh instance)
         let set_object2 = unwrap(
-            env.new_object(c"java/util/HashSet", jni_sig!("()V"), &[]),
+            env.new_object(jni_str!("java/util/HashSet"), jni_sig!("()V"), &[]),
             env,
         );
         let set2 = unwrap(JSet::cast_local(env, set_object2), env);

--- a/tests/threads_atomic_int_proxy.rs
+++ b/tests/threads_atomic_int_proxy.rs
@@ -10,7 +10,7 @@ use std::{
 };
 
 use jni::{
-    errors, objects::IntoAuto as _, strings::JNIStr, sys::jint, AttachGuard, JavaVM,
+    errors, jni_str, objects::IntoAuto as _, strings::JNIStr, sys::jint, AttachGuard, JavaVM,
     DEFAULT_LOCAL_FRAME_CAPACITY,
 };
 
@@ -87,7 +87,7 @@ rusty_fork_test! {
 fn test_destroy() {
     const THREAD_NUM: usize = 2;
     const DAEMON_THREAD_NUM: usize = 2;
-    static MATH_CLASS: &JNIStr = JNIStr::from_cstr(c"java/lang/Math");
+    static MATH_CLASS: &JNIStr = jni_str!("java/lang/Math");
 
     // We don't test this using an `Executor` because we don't want to
     // attach all the threads as daemon threads.

--- a/tests/threads_attach_config.rs
+++ b/tests/threads_attach_config.rs
@@ -2,7 +2,7 @@
 
 use std::thread::spawn;
 
-use jni::{jni_sig, objects::JString, AttachConfig};
+use jni::{jni_sig, jni_str, objects::JString, AttachConfig};
 
 mod util;
 use util::jvm;
@@ -21,8 +21,8 @@ fn attach_config() {
                     // Get the current Thread and query the name
                     let thread = env
                         .call_static_method(
-                            c"java/lang/Thread",
-                            c"currentThread",
+                            jni_str!("java/lang/Thread"),
+                            jni_str!("currentThread"),
                             jni_sig!("()Ljava/lang/Thread;"),
                             &[],
                         )
@@ -30,7 +30,12 @@ fn attach_config() {
                         .l()
                         .unwrap();
                     let name = env
-                        .call_method(thread, c"getName", jni_sig!("()Ljava/lang/String;"), &[])?
+                        .call_method(
+                            thread,
+                            jni_str!("getName"),
+                            jni_sig!("()Ljava/lang/String;"),
+                            &[],
+                        )?
                         .l()?;
                     let name = env.cast_local::<JString>(name).unwrap();
                     let name = name.mutf8_chars(env)?;

--- a/tests/ui/fail/const-jnistr-from-cstr.rs
+++ b/tests/ui/fail/const-jnistr-from-cstr.rs
@@ -1,5 +1,5 @@
 use jni::strings::JNIStr;
 
 fn main() {
-    const INVALID_MUTF8_CSTR: &JNIStr = JNIStr::from_cstr(c"invalid mutf8: 🦀");
+    const INVALID_MUTF8_CSTR: &JNIStr = JNIStr::from_cstr(c"invalid mutf8: 🦀").unwrap();
 }

--- a/tests/ui/fail/const-jnistr-from-cstr.stderr
+++ b/tests/ui/fail/const-jnistr-from-cstr.stderr
@@ -1,11 +1,5 @@
-error[E0080]: evaluation panicked: JNIStr::from_cstr: input is not valid modified UTF-8
+error[E0080]: evaluation panicked: called `Option::unwrap()` on a `None` value
  --> tests/ui/fail/const-jnistr-from-cstr.rs:4:41
   |
-4 |     const INVALID_MUTF8_CSTR: &JNIStr = JNIStr::from_cstr(c"invalid mutf8: 🦀");
-  |                                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `main::INVALID_MUTF8_CSTR` failed inside this call
-  |
-note: inside `JNIStr::from_cstr`
- --> src/strings/ffi_str.rs
-  |
-  |             panic!("JNIStr::from_cstr: input is not valid modified UTF-8");
-  |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the failure occurred here
+4 |     const INVALID_MUTF8_CSTR: &JNIStr = JNIStr::from_cstr(c"invalid mutf8: 🦀").unwrap();
+  |                                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `main::INVALID_MUTF8_CSTR` failed here

--- a/tests/util/example_proxy.rs
+++ b/tests/util/example_proxy.rs
@@ -4,7 +4,7 @@ use std::{ops::Deref, sync::Arc};
 
 use jni::{
     errors::*,
-    jni_sig,
+    jni_sig, jni_str,
     objects::{Global, JObject, JValue},
     sys::jint,
     JavaVM, DEFAULT_LOCAL_FRAME_CAPACITY,
@@ -33,7 +33,7 @@ impl AtomicIntegerProxy {
         vm.attach_current_thread(|env| -> Result<Self> {
             let obj = env.with_local_frame(DEFAULT_LOCAL_FRAME_CAPACITY, |env| {
                 let i = env.new_object(
-                    c"java/util/concurrent/atomic/AtomicInteger",
+                    jni_str!("java/util/concurrent/atomic/AtomicInteger"),
                     jni_sig!("(I)V"),
                     &[JValue::from(init_value)],
                 )?;
@@ -49,7 +49,7 @@ impl AtomicIntegerProxy {
     pub fn get(&mut self) -> Result<jint> {
         let vm = JavaVM::singleton()?;
         vm.attach_current_thread(|env| {
-            env.call_method(&*self.obj, c"get", jni_sig!("()I"), &[])?
+            env.call_method(&*self.obj, jni_str!("get"), jni_sig!("()I"), &[])?
                 .i()
         })
     }
@@ -58,8 +58,13 @@ impl AtomicIntegerProxy {
     pub fn increment_and_get(&mut self) -> Result<jint> {
         let vm = JavaVM::singleton()?;
         vm.attach_current_thread(|env| {
-            env.call_method(&*self.obj, c"incrementAndGet", jni_sig!("()I"), &[])?
-                .i()
+            env.call_method(
+                &*self.obj,
+                jni_str!("incrementAndGet"),
+                jni_sig!("()I"),
+                &[],
+            )?
+            .i()
         })
     }
 
@@ -68,8 +73,13 @@ impl AtomicIntegerProxy {
         let vm = JavaVM::singleton()?;
         vm.attach_current_thread(|env| {
             let delta = JValue::from(delta);
-            env.call_method(&*self.obj, c"addAndGet", jni_sig!("(I)I"), &[delta])?
-                .i()
+            env.call_method(
+                &*self.obj,
+                jni_str!("addAndGet"),
+                jni_sig!("(I)I"),
+                &[delta],
+            )?
+            .i()
         })
     }
 }

--- a/tests/util/mod.rs
+++ b/tests/util/mod.rs
@@ -1,7 +1,8 @@
 use std::sync::{Arc, Once};
 
 use jni::{
-    errors::Result, jni_sig, objects::JValue, sys::jint, Env, InitArgsBuilder, JNIVersion, JavaVM,
+    errors::Result, jni_sig, jni_str, objects::JValue, sys::jint, Env, InitArgsBuilder, JNIVersion,
+    JavaVM,
 };
 
 mod example_proxy;
@@ -36,8 +37,8 @@ pub fn jvm() -> &'static Arc<JavaVM> {
 #[allow(dead_code)]
 pub fn call_java_abs(env: &mut Env, value: i32) -> i32 {
     env.call_static_method(
-        c"java/lang/Math",
-        c"abs",
+        jni_str!("java/lang/Math"),
+        jni_str!("abs"),
         jni_sig!("(I)I"),
         &[JValue::from(value as jint)],
     )


### PR DESCRIPTION
JNIStr::from_cstr now returns an Option instead of panicking.

(It returns an `Option` instead of a `Result` so that it can still be a const function that can run at compile time)

Since we now have the `jni_str!` macro this also removes the `From<CStr> for JNIStr` implementation and migrates away from passing `CStr` literals to JNI in favor of using `jni_str!`.

`jni_str!` is a better solution than casting `CStr` literals because it has full unicode support and guarantees that the input string is validated and encoded to MUTF-8 at compile time.

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Change is covered by [automated tests](https://github.com/jni-rs/jni-rs/blob/master/CONTRIBUTING.md#tests)
- [x] The [coding guidelines](https://github.com/jni-rs/jni-rs/blob/master/CONTRIBUTING.md#the-code-style) are followed
- [x] Public API has documentation
- [x] User-visible changes are mentioned in the Changelog
- [x] The continuous integration build passes
