### PR TITLE
Windows: Use Fiber Local Storage to avoid loader lock deadlock

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -193,6 +193,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - `Env::get_string` no longer leaks local references. ([#528](https://github.com/jni-rs/jni-rs/pull/528), [#557](https://github.com/jni-rs/jni-rs/pull/557))
+- Deadlocks on Windows when automatically detaching JNI when threads exit. Attachments are now tracked with fiber local storage so detachment happens without holding OS loader lock. ([#701](https://github.com/jni-rs/jni-rs/issues/701))
 
 ### Removed
 - `JavaVM::attach_current_thread_as_daemon` (and general support for 'daemon' threads) has been removed, since their semantics are inherently poorly defined and unsafe (the distinction relates to the poorly defined limbo state after calling `JavaDestroyVM`, where it becomes undefined to touch the JVM) ([#593](https://github.com/jni-rs/jni-rs/pull/593))

--- a/crates/jni-gen-windows-bindings/bindings.config
+++ b/crates/jni-gen-windows-bindings/bindings.config
@@ -7,3 +7,6 @@
     Windows.Win32.Globalization.WideCharToMultiByte
     Windows.Win32.Globalization.MultiByteToWideChar
     Windows.Win32.Globalization.GetACP
+    Windows.Win32.System.Threading.FlsAlloc
+    Windows.Win32.System.Threading.FlsSetValue
+    Windows.Win32.System.Threading.FlsGetValue

--- a/crates/jni/Cargo.toml
+++ b/crates/jni/Cargo.toml
@@ -51,6 +51,7 @@ static_assertions = "1"
 
 [target.'cfg(windows)'.dev-dependencies]
 bytemuck = "1.13.0"
+windows-sys = { version = "0.61", features = ["Win32_System_Threading", "Win32_Foundation"] }
 
 [features]
 invocation = ["dep:java-locator", "dep:libloading"]

--- a/crates/jni/build.rs
+++ b/crates/jni/build.rs
@@ -1,0 +1,19 @@
+fn main() {
+    let target_os = std::env::var("CARGO_CFG_TARGET_OS").unwrap();
+
+    println!("cargo::rustc-check-cfg=cfg(use_fls_attach_guard)");
+    println!("cargo::rustc-check-cfg=cfg(use_tls_attach_guard)");
+    if target_os == "windows" {
+        let force_tls = std::env::var("_JNI_WINDOWS_FORCE_USE_TLS").is_ok();
+        if force_tls {
+            println!("cargo:rustc-cfg=use_tls_attach_guard");
+        } else {
+            println!("cargo:rustc-cfg=use_fls_attach_guard");
+        }
+    } else {
+        println!("cargo:rustc-cfg=use_tls_attach_guard");
+    }
+
+    // Re-run if the environment variable changes
+    println!("cargo:rerun-if-env-changed=_JNI_WINDOWS_FORCE_USE_TLS");
+}

--- a/crates/jni/src/lib.rs
+++ b/crates/jni/src/lib.rs
@@ -251,6 +251,9 @@ pub use jni_sys as sys;
 mod version;
 pub use self::version::*;
 
+#[cfg(windows)]
+mod windows_sys;
+
 #[macro_use]
 mod macros;
 

--- a/crates/jni/src/vm/fls_attach_guard.rs
+++ b/crates/jni/src/vm/fls_attach_guard.rs
@@ -1,0 +1,287 @@
+//! Windows-specific Fiber Local Storage (FLS) implementation for thread attachment tracking.
+//!
+//! This module provides a Windows-specific alternative to thread-local storage that uses Fiber
+//! Local Storage (FLS) callbacks. The key advantage is that FLS callbacks run without holding the
+//! Windows loader lock, avoiding potential deadlocks.
+//!
+//! For example see: <https://github.com/jni-rs/jni-rs/issues/701>
+//!
+//! On Windows, this sequence of events can trigger a deadlock:
+//!
+//! 1. A native thread, previously attached to a JVM, is stopped
+//! 2. Windows kernel calls the TLS destructor - This happens while [holding Windows Loader
+//!    Lock](https://doc.rust-lang.org/stable/std/thread/struct.LocalKey.html#synchronization-in-thread-local-destructors)
+//! 3. jni-rs `InternalAttachGuard` calls `DetachCurrentThread`. This involves a thread state
+//!    transition from Native to VM
+//! 4. Concurrently, there is a new Java thread being started by some other thread
+//! 5. During the Native -> VM transition, the native thread is trapped in a JVM safepoint. While
+//!    holding the loader lock!
+//! 6. The Java thread created at step no. 4 is already runnable from JVM's point of view, and the
+//!    JVM expects this thread to arrive at the safepoint. But Windows won't execute user code on
+//!    this thread until it manages to acquire the loader lock. Which is held by the Rust thread
+//!    that is trapped at safepoint. This means the Java thread cannot make any progress and
+//!    certainly cannot reach the safepoint. JVM won't release the native thread until all threads
+//!    are at safepoint -> Deadlock
+//!
+//! Design Notes:
+//! - The goal is not to try and support fibers in a general-purpose way and in fact we don't expect
+//!   any application using Rust + JNI to be scheduling multiple fibers on the same thread.
+//! - At the very-least, if an application does schedule fibers then we're assuming they are never
+//!   preempting Rust code that is using JNI.
+//! - No attempt is made to support fiber switching while there are active `AttachGuard`s.
+//!    - Trying to support this would raise all kinds of state tracking / safety issues, like, what
+//!      happens to any pushed local frames, or pending exceptions, etc.
+//! - No attempt is made support the freeing of fibers while there are active `AttachGuard`s for the
+//!   current thread.
+//!     - This could effectively rug pull the thread's attachment state while JNI is in use by a
+//!       different fiber context.
+//!
+//! Consistent with other platforms, we assume that no external code (e.g., other JNI language
+//! bindings may spontaneously detach the current thread while there are active `AttachGuard`s. This
+//! isn't something we can technically enforce, but we document it as a safety invariant. It would
+//! be totally impractical to try and use JNI without being able to make this assumption and
+//! probably impossible if code could be arbitrarily preempted by fiber switches (since you wouldn't
+//! ever know if your per-thread env pointer is still valid)
+//!
+//! As with TLS based attachment tracking we do want to be resilient to external code manually
+//! detaching threads when there are no active `AttachGuard`s, so attach_current_thread() will
+//! always check the real JNI attachment state if there are no active guards.
+
+use std::{
+    ptr,
+    sync::OnceLock,
+    thread::{Thread, current},
+};
+
+use log::{debug, error};
+
+use crate::{
+    AttachGuard, JavaVM,
+    errors::*,
+    vm::{java_vm::sys_detach_current_thread, sys_attach_current_thread},
+};
+
+use crate::windows_sys::{FlsAlloc, FlsGetValue, FlsSetValue};
+
+/// The FLS index used to store the attachment guard data.
+/// This is allocated once when the first thread attaches.
+static FLS_INDEX: OnceLock<u32> = OnceLock::new();
+
+/// Data stored in FLS for each attached fiber.
+///
+/// Note: We don't store the env pointer because:
+/// 1. Multiple fibers on the same thread share the same env pointer
+/// 2. After the first fiber detaches, the env pointer becomes invalid
+/// 3. Even with a single fiber, it's possible for external code to manually detach the thread,
+///    making the stored env pointer invalid.
+#[derive(Debug)]
+struct FlsAttachData {
+    thread: Thread,
+}
+
+/// FLS callback that runs when a fiber terminates.
+///
+/// SAFETY: This callback is invoked by Windows when:
+/// 1. A fiber terminates or is deleted
+/// 2. The FLS slot is freed (via FlsFree)
+///
+/// When this callback runs, it detaches the current thread from the JVM.
+///
+/// In the unlikely event that multiple fibers have attached the same thread (e.g., if
+/// DetachCurrentThread was called manually by external code), each fiber's termination
+/// will attempt to detach the thread, but subsequent detach calls are harmless no-ops.
+///
+/// # Panics
+///
+/// This function will panic if called while there are active `AttachGuard` instances
+/// (`thread_attach_guard_level() > 0`). Fiber switching or termination must not occur
+/// while an `AttachGuard` is in scope - this is a critical safety invariant.
+unsafe extern "system" fn fls_callback(data: *const core::ffi::c_void) {
+    // The pointer could have been cleared via fls_detach_current_thread()
+    if data.is_null() {
+        // Technically this should never be reached because the FlsFree docs state that
+        // callbacks are only invoked for non-null values, but just in case...
+        return;
+    }
+
+    // Safety: We only ever store Box<FlsAttachData> in FLS
+    let attach_data = unsafe { Box::from_raw(data as *mut FlsAttachData) };
+
+    // SAFETY INVARIANT: Fiber switching or freeing must not occur while an AttachGuard is in scope.
+    let guard_level = crate::JavaVM::thread_attach_guard_level();
+    assert!(
+        guard_level == 0,
+        "FATAL: FLS callback invoked with active AttachGuard (nest_level={}). \
+         Fiber switching must not occur while an AttachGuard is in scope. \
+         Thread: {} ({:?})",
+        guard_level,
+        attach_data.thread.name().unwrap_or_default(),
+        attach_data.thread.id()
+    );
+
+    // Always safe to detach when guard_level == 0
+    // Note: We pass None for cross_check_env because with multiple fibers, subsequent
+    // detach attempts will have stale env pointers. DetachCurrentThread is idempotent.
+    if let Err(e) = unsafe { sys_detach_current_thread(None, &attach_data.thread) } {
+        error!(
+            "Error detaching thread in FLS callback: {:#?}\nThread {} id={:?}",
+            e,
+            attach_data.thread.name().unwrap_or_default(),
+            attach_data.thread.id(),
+        );
+    }
+}
+
+/// Initialize FLS if not already initialized.
+///
+/// Returns the FLS index, allocating it if necessary.
+fn get_or_init_fls_index() -> Result<u32> {
+    // Try to get existing index first
+    if let Some(&index) = FLS_INDEX.get() {
+        return Ok(index);
+    }
+
+    // Need to initialize - allocate a new FLS index with our callback
+    // Safety: fls_callback is a valid callback function
+    let new_index = unsafe { FlsAlloc(Some(fls_callback)) };
+
+    if new_index == u32::MAX {
+        // FLS_OUT_OF_INDEXES
+        return Err(Error::JniCall(JniError::Unknown));
+    }
+
+    // Try to store it, or use the value another thread stored
+    Ok(*FLS_INDEX.get_or_init(|| new_index))
+}
+
+/// Attach the current fiber using FLS for cleanup tracking.
+///
+/// This attaches the current thread and stores attachment data in FLS so that when the fiber
+/// terminates, the FLS callback will automatically detach the thread from the JVM (without holding
+/// the loader lock).
+///
+/// Note: This function assumes that the caller has already used GetEnv to check if the thread is
+/// already attached, and only calls this function if it is not attached.
+///
+/// Typically only one fiber per thread will call this function because subsequent fibers on the
+/// same thread will find the thread already attached.
+///
+/// Note: Although it is unlikely, it's possible that this can be called from multiple fibers on the
+/// the same thread, if DetachCurrentThread was called manually by external code (we allow this as
+/// long as there are no active AttachGuards). In this case we allow the ATTACHED_THREADS counter to
+/// be incremented for each fiber with its own FLS data so the number can technically diverge from
+/// the real _thread_ attachment count. This is acceptable since the number is only used for
+/// debugging and unit tests. In fact, on Windows the unit tests will test for this scenario.
+///
+/// If we do end up with multiple fibers having FLS data then each fiber's termination will attempt to
+/// detach the thread, but subsequent detach calls are harmless no-ops. They will also decrement the
+/// ATTACHED_THREADS counter accordingly so the logical count remains correct.
+///
+/// # Panics
+///
+/// This function will panic if called while there are active `AttachGuard`s.
+pub(super) unsafe fn fls_attach_current_thread<'local>(
+    java_vm: &crate::JavaVM,
+    config: &super::java_vm::AttachConfig,
+) -> Result<super::java_vm::AttachGuard<'local>> {
+    // CRITICAL INVARIANT: Fiber attachment must not occur while an AttachGuard is in scope.
+    // This would indicate that a new fiber is being attached (or an existing fiber is being
+    // switched to) while an AttachGuard is active, which violates our safety contract.
+    let guard_level = JavaVM::thread_attach_guard_level();
+    assert!(
+        guard_level == 0,
+        "FATAL: fls_attach_current_thread called with active AttachGuard (nest_level={}). \
+         Fiber attachment/switching must not occur while an AttachGuard is in scope. \
+         Thread: {} ({:?})",
+        guard_level,
+        current().name().unwrap_or_default(),
+        current().id()
+    );
+
+    let fls_index = get_or_init_fls_index()?;
+
+    // Check if already attached via FLS for THIS fiber
+    // Safety: fls_index is valid
+    let existing = unsafe { FlsGetValue(fls_index) };
+    // Although it's unlikely, it's possible that the thread was already permanently attached
+    // but some external code manually detached it (this is allowed as long as there are no
+    // active AttachGuards). In this case we don't want to double-increment the attached
+    // threads counter.
+    let inc_attached_count = existing.is_null();
+
+    let thread = current();
+    let env = unsafe { sys_attach_current_thread(java_vm, config, &thread, inc_attached_count)? };
+
+    // Create attachment data for this fiber
+    // Note: We don't store the env pointer to avoid holding stale pointers when
+    // multiple fibers share the same thread attachment
+    let attach_data = Box::new(FlsAttachData { thread: current() });
+
+    let data_ptr = Box::into_raw(attach_data) as *mut core::ffi::c_void;
+
+    // Store in FLS for this fiber
+    // Safety: fls_index is valid, data_ptr is a valid pointer
+    let result = unsafe { FlsSetValue(fls_index, data_ptr) };
+
+    if result == 0 {
+        // Failed to set FLS value, clean up
+        unsafe {
+            let _ = Box::from_raw(data_ptr as *mut FlsAttachData);
+        }
+        return Err(Error::JniCall(JniError::Unknown));
+    }
+
+    debug!(
+        "Attached fiber via FLS: {} ({:?}). {} threads attached",
+        current().name().unwrap_or_default(),
+        current().id(),
+        java_vm.threads_attached(),
+    );
+
+    Ok(unsafe { AttachGuard::from_unowned(env) })
+}
+
+/// Explicitly detach the current fiber if attached via FLS.
+///
+/// This clears the FLS slot without invoking the callback, since we're detaching manually.
+/// If the thread is attached via JNI, it will be detached.
+///
+/// # Panics
+///
+/// This function will panic if called while there are active `AttachGuard` instances.
+/// Fiber detachment/switching must not occur while an `AttachGuard` is in scope.
+pub(super) fn fls_detach_current_thread() -> Result<()> {
+    if JavaVM::thread_attach_guard_level() != 0 {
+        return Err(Error::ThreadAttachmentGuarded);
+    }
+
+    let Some(&fls_index) = FLS_INDEX.get() else {
+        return Ok(()); // FLS never initialized, so not attached
+    };
+
+    // Get the current FLS value
+    // Safety: fls_index is valid
+    let data_ptr = unsafe { FlsGetValue(fls_index) };
+    if data_ptr.is_null() {
+        // Not attached via FLS for this fiber
+        return Ok(());
+    }
+
+    // Clear the FLS slot first (before detaching) to prevent the callback from running
+    // Safety: fls_index is valid
+    let result = unsafe { FlsSetValue(fls_index, ptr::null_mut()) };
+    // Treat this as a fatal error because the only documented errors are:
+    // - ERROR_INVALID_PARAMETER: fls_index is invalid (implies a bug and should not happen)
+    // - ERROR_NO_MEMORY: Should not happen if we're clearing a slot that must have been allocated
+    // Returning an error here would lead to a double-decrement of the attached threads counter
+    assert_ne!(result, 0, "FATAL: Failed to clear FLS slot during detach");
+
+    // Clean up the FLS data and detach
+    // Safety: data_ptr came from FlsGetValue and we stored Box<FlsAttachData>
+    let attach_data = unsafe { Box::from_raw(data_ptr as *mut FlsAttachData) };
+
+    // Note: We pass None for cross_check_env because we don't store env pointers in FLS
+    // (they can become stale with multiple fibers). DetachCurrentThread is idempotent.
+    unsafe { sys_detach_current_thread(None, &attach_data.thread)? };
+    Ok(())
+}

--- a/crates/jni/src/vm/mod.rs
+++ b/crates/jni/src/vm/mod.rs
@@ -5,3 +5,8 @@ pub use self::init_args::*;
 
 mod java_vm;
 pub use self::java_vm::*;
+
+#[cfg(use_fls_attach_guard)]
+mod fls_attach_guard;
+#[cfg(not(use_fls_attach_guard))]
+mod tls_attach_guard;

--- a/crates/jni/src/vm/tls_attach_guard.rs
+++ b/crates/jni/src/vm/tls_attach_guard.rs
@@ -1,0 +1,127 @@
+//! Thread Local Storage (TLS) implementation for thread attachment tracking on non-Windows platforms.
+//!
+//! This module provides the default thread attachment mechanism using Rust's standard thread-local
+//! storage. On non-Windows platforms, TLS destructors are safe to use for automatic thread detachment
+//! without the loader lock issues that affect Windows.
+
+use std::{
+    cell::RefCell,
+    thread::{Thread, current},
+};
+
+use log::error;
+
+use crate::{
+    JavaVM,
+    errors::*,
+    vm::java_vm::{
+        AttachConfig, AttachGuard, sys_attach_current_thread, sys_detach_current_thread,
+    },
+};
+
+thread_local! {
+    // There's a false-positive Clippy bug: https://github.com/rust-lang/rust-clippy/issues/13422
+    #[cfg_attr(target_os = "android", allow(clippy::missing_const_for_thread_local))]
+    static TLS_ATTACH_GUARD: RefCell<Option<TLSAttachGuard>> = const { RefCell::new(None) }
+}
+
+/// Data stored in TLS for automatic thread detachment.
+///
+/// Note: We don't store the env pointer because we consider the possibility that external code
+/// may manually detach the thread so long as there are no active AttachGuards. In that case,
+/// the env pointer can become invalid before the TLS destructor runs.
+#[derive(Debug)]
+struct TLSAttachGuard {
+    /// A call std::thread::current() function can panic in case the local data has been destroyed
+    /// before the thread local variables. The possibility of this happening depends on the platform
+    /// implementation of the sys_common::thread_local_dtor::register_dtor_fallback.
+    ///
+    /// Since this struct will be saved as a thread-local variable, we capture the thread meta-data
+    /// during creation
+    thread: Thread,
+}
+
+impl TLSAttachGuard {
+    /// Detach the current thread after checking there are no active [`AttachGuard`]s
+    ///
+    /// # Safety
+    /// Since this is used in the implementation of `Drop` you must make sure
+    /// to not let `Drop` run if this is called explicitly.
+    unsafe fn detach_impl(&self) -> Result<()> {
+        unsafe { sys_detach_current_thread(None, &self.thread) }
+    }
+}
+
+impl Drop for TLSAttachGuard {
+    fn drop(&mut self) {
+        if let Err(e) = unsafe { self.detach_impl() } {
+            error!(
+                "Error detaching current thread: {:#?}\nThread {} id={:?}",
+                e,
+                self.thread.name().unwrap_or_default(),
+                self.thread.id(),
+            );
+        }
+    }
+}
+
+/// Attach the current thread to the Java VM using TLS for automatic cleanup.
+///
+/// This function stores attachment information in thread-local storage so that when the thread
+/// terminates, the TLS destructor will automatically detach the thread from the JVM.
+///
+/// Note: This function assumes that the caller has already used GetEnv to check if the thread
+/// is already attached, and only calls this function if it is not attached.
+///
+/// # Panics
+///
+/// This function will panic if called while there are active `AttachGuard`s.
+pub(super) unsafe fn tls_attach_current_thread<'local>(
+    java_vm: &JavaVM,
+    config: &AttachConfig,
+) -> Result<AttachGuard<'local>> {
+    let thread = current();
+
+    // Store in TLS for automatic detachment when thread terminates
+    let env = TLS_ATTACH_GUARD.with(move |f| -> jni::errors::Result<*mut jni::sys::JNIEnv> {
+        // Although it's unlikely, it's possible that the thread was already permanently attached
+        // but some external code manually detached it (this is allowed as long as there are no
+        // active AttachGuards). In this case we don't want to double-increment the attached
+        // threads counter.
+        let inc_attached_count = if let Some(guard) = f.borrow_mut().take() {
+            // We use `std::mem::forget` to ensure we don't drop the existing guard and
+            // call detach again.
+            std::mem::forget(guard);
+            false
+        } else {
+            true
+        };
+        let env =
+            unsafe { sys_attach_current_thread(java_vm, config, &thread, inc_attached_count)? };
+        *f.borrow_mut() = Some(TLSAttachGuard { thread: current() });
+        Ok(env)
+    })?;
+
+    Ok(unsafe { AttachGuard::from_unowned(env) })
+}
+
+/// Detach a thread before the thread terminates **IFF** it was previously attached via
+/// [`JavaVM::attach_current_thread`] **AND** there is no active [`AttachGuard`] in use
+/// for this thread.
+pub(super) fn tls_detach_current_thread() -> Result<()> {
+    if JavaVM::thread_attach_guard_level() != 0 {
+        return Err(Error::ThreadAttachmentGuarded);
+    }
+
+    TLS_ATTACH_GUARD.with(move |f| {
+        if let Some(guard) = f.borrow_mut().take() {
+            // Safety: we use `std::mem::forget` to ensure we don't also
+            // run the `Drop` implementation
+            let res = unsafe { guard.detach_impl() };
+            std::mem::forget(guard);
+            res
+        } else {
+            Ok(())
+        }
+    })
+}

--- a/crates/jni/src/windows_sys.rs
+++ b/crates/jni/src/windows_sys.rs
@@ -8,6 +8,9 @@
     clippy::all
 )]
 
+windows_link::link!("kernel32.dll" "system" fn FlsAlloc(lpcallback : PFLS_CALLBACK_FUNCTION) -> u32);
+windows_link::link!("kernel32.dll" "system" fn FlsGetValue(dwflsindex : u32) -> *mut core::ffi::c_void);
+windows_link::link!("kernel32.dll" "system" fn FlsSetValue(dwflsindex : u32, lpflsdata : *const core::ffi::c_void) -> BOOL);
 windows_link::link!("kernel32.dll" "system" fn GetACP() -> u32);
 windows_link::link!("kernel32.dll" "system" fn MultiByteToWideChar(codepage : u32, dwflags : MULTI_BYTE_TO_WIDE_CHAR_FLAGS, lpmultibytestr : PCSTR, cbmultibyte : i32, lpwidecharstr : PWSTR, cchwidechar : i32) -> i32);
 windows_link::link!("kernel32.dll" "system" fn WideCharToMultiByte(codepage : u32, dwflags : u32, lpwidecharstr : PCWSTR, cchwidechar : i32, lpmultibytestr : PSTR, cbmultibyte : i32, lpdefaultchar : PCSTR, lpuseddefaultchar : *mut BOOL) -> i32);
@@ -17,6 +20,8 @@ pub const CP_UTF8: u32 = 65001u32;
 pub type MULTI_BYTE_TO_WIDE_CHAR_FLAGS = u32;
 pub type PCSTR = *const u8;
 pub type PCWSTR = *const u16;
+pub type PFLS_CALLBACK_FUNCTION =
+    Option<unsafe extern "system" fn(lpflsdata: *const core::ffi::c_void)>;
 pub type PSTR = *mut u8;
 pub type PWSTR = *mut u16;
 pub const WC_COMPOSITECHECK: u32 = 512u32;

--- a/crates/jni/tests/util/mod.rs
+++ b/crates/jni/tests/util/mod.rs
@@ -75,6 +75,23 @@ pub fn detach_current_thread() -> Result<()> {
     jvm().detach_current_thread()
 }
 
+/// Manually detach the current thread from the JVM, bypassing the jni crate's
+/// tracking.
+///
+/// This simulates external code detaching the thread. (The jni crate handles
+/// this so long as there are no active AttachGuards.)
+///
+/// # Safety
+///
+/// There must be no active AttachGuards for the thread when this is called,
+/// otherwise we're breaking jni crate safety invariants.
+#[allow(dead_code)]
+pub unsafe fn sys_detach_current_thread() {
+    let vm = jvm();
+    let jvm: *mut jni_sys::JavaVM = vm.get_raw();
+    unsafe { ((*(*jvm)).v1_4.DetachCurrentThread)(jvm) };
+}
+
 pub fn print_exception(env: &Env) {
     let exception_occurred = env.exception_check();
     if exception_occurred {

--- a/crates/jni/tests/windows_fiber_attach.rs
+++ b/crates/jni/tests/windows_fiber_attach.rs
@@ -1,0 +1,255 @@
+//! Windows-specific test for fiber-aware JNI attachment.
+//!
+//! This test verifies that the FLS-based attachment mechanism works correctly
+//! on Windows, including proper tracking when:
+//! - There are multiple redundant attach_current_thread() calls across multiple
+//!   fibers on the same OS thread.
+//! - detach_current_thread() is used in fibers with no FLS attachment.
+//! - detach_current_thread() is used in fibers with an FLS attachment.
+//!
+//! No attempt is made to test misuse of fibers that would violate safety
+//! invariants (e.g., switching or deleting fibers while AttachGuards are
+//! active).
+
+#![cfg(all(use_fls_attach_guard, feature = "invocation"))]
+
+mod util;
+
+use jni::{JavaVM, errors::Result};
+use std::ptr;
+use util::jvm;
+use windows_sys::Win32::System::Threading::ConvertThreadToFiber;
+use windows_sys::Win32::System::Threading::{CreateFiber, DeleteFiber, SwitchToFiber};
+
+use rusty_fork::rusty_fork_test;
+
+use crate::util::sys_detach_current_thread;
+
+rusty_fork_test! {
+#[test]
+fn test_attached_threads_counter_with_actual_fibers() {
+    let jvm = jvm();
+
+    // Detach the initial thread attachment
+    assert_eq!(jvm.threads_attached(), 1);
+    jvm.detach_current_thread().unwrap();
+    let initial_count = jvm.threads_attached();
+    assert_eq!(initial_count, 0);
+
+    eprintln!("Converting main thread to fiber and creating fibers");
+    unsafe {
+        // Convert the current thread to a fiber (main fiber)
+        let main_fiber = ConvertThreadToFiber(ptr::null_mut());
+        assert!(!main_fiber.is_null(), "Failed to convert thread to fiber");
+
+        // Track fiber execution
+        static mut FIBER1_EXECUTED: bool = false;
+        static mut FIBER1_PART2_EXECUTED: bool = false;
+        static mut FIBER2_EXECUTED: bool = false;
+        static mut FIBER3_EXECUTED: bool = false;
+        static mut FIBER4_EXECUTED: bool = false;
+        static mut MAIN_FIBER: *mut std::ffi::c_void = ptr::null_mut();
+
+        MAIN_FIBER = main_fiber;
+
+        // Fiber callbacks - each attaches to JVM using TLS attachment (which persists)
+        unsafe extern "system" fn fiber1_proc(param: *mut std::ffi::c_void) {
+            let jvm = unsafe { &*(param as *const std::sync::Arc<JavaVM>) };
+            eprintln!("Running fiber 1, part 1");
+
+            // FLS attachment - stays attached after callback returns
+            jvm.attach_current_thread(|env| -> Result<()> {
+                let _string = env.new_string("Fiber 1")?;
+                unsafe { FIBER1_EXECUTED = true; }
+                Ok(())
+            })
+            .expect("Fiber 1 failed to attach");
+
+            // The thread should be permanently attached now with an FLS allocation
+            assert!(jvm.is_thread_attached().unwrap());
+            assert_eq!(jvm.threads_attached(), 1);
+
+            // Manually detach the thread to test re-attachment in fiber 2
+            unsafe { sys_detach_current_thread(); }
+
+            unsafe { SwitchToFiber(MAIN_FIBER); }
+
+            //panic!("DEBUG: Back in fiber 1 part 1 after switching to main fiber");
+            eprintln!("Running fiber 1, part 2");
+            // At this point, all the other fibers have been deleted and we should be left with
+            // a count of 1 from the FLS attachment we got earlier
+            assert_eq!(jvm.threads_attached(), 1);
+            assert!(!jvm.is_thread_attached().unwrap());
+
+            // Re-attach the thread/fiber again (without incrementing the attached count) - stays attached after callback returns
+            jvm.attach_current_thread(|env| -> Result<()> {
+                let _string = env.new_string("Fiber 1, part 2")?;
+                unsafe { FIBER1_PART2_EXECUTED = true; }
+                Ok(())
+            })
+            .expect("Fiber 1 failed to attach");
+
+            assert!(jvm.is_thread_attached().unwrap());
+            assert_eq!(jvm.threads_attached(), 1);
+
+            unsafe { SwitchToFiber(MAIN_FIBER); }
+        }
+
+        unsafe extern "system" fn fiber2_proc(param: *mut std::ffi::c_void) {
+            let jvm = unsafe { &*(param as *const std::sync::Arc<JavaVM>) };
+            eprintln!("Running fiber 2");
+
+            // Ensure the thread is detached before running this fiber
+            assert!(!jvm.is_thread_attached().unwrap());
+
+            // New FLS attachment (due to manual detach) - stays attached after callback returns
+            jvm.attach_current_thread(|env| -> Result<()> {
+                let _string = env.new_string("Fiber 2")?;
+                unsafe { FIBER2_EXECUTED = true; }
+                Ok(())
+            })
+            .expect("Fiber 2 failed to attach");
+
+            // Since we manually detach the thread before running this fiber,
+            // this fiber will re-attach the thread now fiber1 and fiber2 will
+            // have FLS allocations that will also try to detach the thread when
+            // they are deleted.
+            assert!(jvm.is_thread_attached().unwrap());
+            assert_eq!(jvm.threads_attached(), 2);
+
+            // This should succeed because this fiber does have its own FLS allocation
+            // This should set the FLS slot to null and detach the thread such that
+            // when the fiber is deleted later, the FLS callback is a no-op.
+            jvm.detach_current_thread().expect("Fiber 2 failed to call detach_current_thread");
+
+            // Note: threads_attached() at this point is 1 because fiber1 still
+            // has its FLS allocation although the thread itself is technically
+            // detached now. This is a corner case for the Windows FLS
+            // attachment model where this number is more like "number of FLS
+            // attachments". The number should still remain balanced and return
+            // to zero when all fibers are deleted.
+            assert!(!jvm.is_thread_attached().unwrap());
+            assert_eq!(jvm.threads_attached(), 1);
+
+            unsafe { SwitchToFiber(MAIN_FIBER); }
+        }
+
+        unsafe extern "system" fn fiber3_proc(param: *mut std::ffi::c_void) {
+            let jvm = unsafe { &*(param as *const std::sync::Arc<JavaVM>) };
+            eprintln!("Running fiber 3");
+
+            // Ensure the thread is detached before running this fiber
+            assert!(!jvm.is_thread_attached().unwrap());
+
+            // New FLS attachment (due to detach_current_thread()) - stays attached after callback returns
+            jvm.attach_current_thread(|env| -> Result<()> {
+                let _string = env.new_string("Fiber 3")?;
+                unsafe { FIBER3_EXECUTED = true; }
+                Ok(())
+            })
+            .expect("Fiber 3 failed to attach");
+
+            // Since we detach the thread before running this fiber, this fiber
+            // will re-attach the thread, so now fiber1, fiber2 and fiber3 will have
+            // FLS allocations but the fiber2 data is null after calling
+            //detach_current_thread()
+            assert!(jvm.is_thread_attached().unwrap());
+            assert_eq!(jvm.threads_attached(), 2);
+
+            unsafe { SwitchToFiber(MAIN_FIBER); }
+        }
+
+        unsafe extern "system" fn fiber4_proc(param: *mut std::ffi::c_void) {
+            let jvm = unsafe { &*(param as *const std::sync::Arc<JavaVM>) };
+            eprintln!("Running fiber 4");
+
+            // Use pre-existing attachment - stays attached after callback returns
+            jvm.attach_current_thread(|env| -> Result<()> {
+                let _string = env.new_string("Fiber 4")?;
+                unsafe { FIBER4_EXECUTED = true; }
+                Ok(())
+            })
+            .expect("Fiber 4 failed to attach");
+
+            assert!(jvm.is_thread_attached().unwrap());
+            // This fiber should see that something else has already attached the thread
+            // and so no new attachment is created
+            assert_eq!(jvm.threads_attached(), 2);
+
+            // This should be a no-op, since the fiber is using the pre-existing attachment
+            jvm.detach_current_thread().expect("Fiber 4 failed to call detach_current_thread");
+
+            assert!(jvm.is_thread_attached().unwrap());
+            assert_eq!(jvm.threads_attached(), 2);
+
+            unsafe { SwitchToFiber(MAIN_FIBER); }
+        }
+        // Create three fibers on the same OS thread
+        let jvm_ptr = jvm as *const _ as *mut std::ffi::c_void;
+
+        eprintln!("Creating fibers");
+
+        let fiber1 = CreateFiber(0, Some(fiber1_proc), jvm_ptr);
+        assert!(!fiber1.is_null(), "Failed to create fiber 1");
+
+        let fiber2 = CreateFiber(0, Some(fiber2_proc), jvm_ptr);
+        assert!(!fiber2.is_null(), "Failed to create fiber 2");
+
+        let fiber3 = CreateFiber(0, Some(fiber3_proc), jvm_ptr);
+        assert!(!fiber3.is_null(), "Failed to create fiber 3");
+
+        let fiber4 = CreateFiber(0, Some(fiber4_proc), jvm_ptr);
+        assert!(!fiber4.is_null(), "Failed to create fiber 4");
+
+        // Execute all three fibers on the same OS thread
+        SwitchToFiber(fiber1);
+        assert!(FIBER1_EXECUTED, "Fiber 1 did not execute");
+
+        SwitchToFiber(fiber2);
+        assert!(FIBER2_EXECUTED, "Fiber 2 did not execute");
+
+        SwitchToFiber(fiber3);
+        assert!(FIBER3_EXECUTED, "Fiber 3 did not execute");
+
+        SwitchToFiber(fiber4);
+        assert!(FIBER4_EXECUTED, "Fiber 4 did not execute");
+
+        assert!(jvm.is_thread_attached().unwrap());
+        assert_eq!(jvm.threads_attached(), 2);
+
+        eprintln!("Deleting fiber 2");
+        // Deleting fiber2 should be a no-op since it calls detach_current_thread() which
+        // cleared its FLS slot
+        DeleteFiber(fiber2);
+        assert!(jvm.is_thread_attached().unwrap());
+        assert_eq!(jvm.threads_attached(), 2);
+
+        eprintln!("Deleting fiber 3");
+        // Deleting fiber 3 should detach the thread and decrement the attached threads counter
+        DeleteFiber(fiber3);
+        assert!(!jvm.is_thread_attached().unwrap());
+        assert_eq!(jvm.threads_attached(), 1);
+
+        eprintln!("Deleting fiber 4");
+        // Deleting fiber4 should (redundantly) detach the thread and decrement the counter
+        DeleteFiber(fiber4);
+        assert!(!jvm.is_thread_attached().unwrap());
+        assert_eq!(jvm.threads_attached(), 1);
+
+        eprintln!("Running second part of fiber 1");
+        // Running the second part of fiber1 to verify it can re-attach without
+        // incrementing the counter (since it already has an FLS allocation)
+        SwitchToFiber(fiber1);
+        assert!(FIBER1_PART2_EXECUTED, "Fiber 1 part 2 did not execute");
+
+        assert!(jvm.is_thread_attached().unwrap());
+        assert_eq!(jvm.threads_attached(), 1);
+
+        //panic!("DEBUG: Before deleting fiber 1");
+        eprintln!("Deleting fiber 1");
+        DeleteFiber(fiber1);
+        assert!(!jvm.is_thread_attached().unwrap());
+        assert_eq!(jvm.threads_attached(), 0);
+    }
+}
+}


### PR DESCRIPTION
This re-works how we track permanent thread attachments on Windows to use fiber local storage, instead of thread local storage, so that the callback we get when the thread exits does not hold the system loader lock.

This avoids deadlocks that can happen when Java threads are being spawned at the same time that native threads are being detached via TLS destructors because DetachCurrentThread can't progress until all threads are at a safepoint but new Java threads can't run, and reach a safepoint, until the system loader lock is acquired.

It's worth noting that this does _not_ attempt to generally support the use of Windows Fibers with JNI. JNI is fundamentally designed around thread-local state and there would be too many issues with attempting to support fibers + JNI generally (e.g. how to manage the local frame stack or pending exceptions).

From a safety pov the implementation assumes:
- Fibers may never be switched while there are active AttachGuards
- Fibers my never be deleted while there are active AttachGuards.

So hypothetically a Windows application can could utilize fibers and not break those invariants, but in practice we expect that no application using Rust + JNI ever touches the win32 fibers API so they never have to consider the possibility that there is ever more than one fiber per OS thread.

Since the changed depends on additional windows_sys APIs, this updates `jni-gen-windows-bindings/bindings.config` so we continue to avoid having `windows_sys` as a crate dependency. This also tweaks how the generated code is imported as a `crate::windows_sys` module (affecting char_encoding_windows.rs).

For debugging, this PR adds a build.rs that makes it possible to forcibly revert to using thread local storage on Windows by setting the `_JNI_WINDOWS_FORCE_USE_TLS` environment variable.

If I test this against the reproduction repo here: https://github.com/rib/jni-rs-issue-701-repo/tree/rib/wip/windows-fls-alloc then I can reliably reproduce a deadlock when using TLS via `_JNI_WINDOWS_FORCE_USE_TLS=1` and I get no deadlock with the fiber local storage backend.

Fixes: #701

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Change is covered by [automated tests](https://github.com/jni-rs/jni-rs/blob/master/CONTRIBUTING.md#tests)
- [x] The [coding guidelines](https://github.com/jni-rs/jni-rs/blob/master/CONTRIBUTING.md#the-code-style) are followed
- [x] Public API has documentation
- [x] User-visible changes are mentioned in the Changelog
- [x] The continuous integration build passes
