### PR TITLE
bind_java_type: support visibility spec for rust types

### DIFF
--- a/crates/jni-macros/docs/bind_java_type_advanced.md
+++ b/crates/jni-macros/docs/bind_java_type_advanced.md
@@ -28,7 +28,7 @@ use jni::{Env, bind_java_type};
 use jni::refs::LoaderContext;
 
 # bind_java_type! {
-#     ExampleType => com.example.ExampleType,
+#     pub ExampleType => com.example.ExampleType,
 #     native_methods { extern fn native_method() -> jint }
 # }
 # impl ExampleTypeNativeInterface for ExampleTypeAPI {
@@ -62,7 +62,7 @@ symbols that the JVM can resolve when loading a shared library:
 use jni::bind_java_type;
 
 bind_java_type! {
-    MyType => com.example.MyType,
+    pub MyType => com.example.MyType,
     native_methods {
         // Generates: Java_com_example_MyType_earlyMethod__
         extern fn early_method() -> jint,
@@ -88,7 +88,7 @@ Registration without export symbols is useful in specific scenarios:
 use jni::bind_java_type;
 
 bind_java_type! {
-    MyType => com.example.MyType,
+    pub MyType => com.example.MyType,
     native_methods_export = false,  // Disable exports
     native_methods {
         fn registration_only() -> jint,
@@ -110,7 +110,7 @@ compatibility:
 use jni::bind_java_type;
 
 bind_java_type! {
-    MyType => com.example.MyType,
+    pub MyType => com.example.MyType,
     // Default: native_methods_export = true
     native_methods {
         extern fn both_exported_and_registered() -> jint,
@@ -147,7 +147,7 @@ Set a default policy for all native methods in a binding:
 use jni::{Env, bind_java_type};
 
 bind_java_type! {
-    MyType => com.example.MyType,
+    pub MyType => com.example.MyType,
     native_methods_error_policy = jni::errors::LogErrorAndDefault,
     native_methods {
         extern fn method1() -> jint,  // Uses global policy
@@ -171,7 +171,7 @@ Override the global policy for specific methods:
 use jni::{Env, bind_java_type};
 
 bind_java_type! {
-    MyType => com.example.MyType,
+    pub MyType => com.example.MyType,
     native_methods_error_policy = jni::errors::LogErrorAndDefault,  // Global default
     native_methods {
         extern fn quiet_method() -> jint,  // Uses LogErrorAndDefault
@@ -208,7 +208,7 @@ Raw native methods (`raw`) bypass error handling entirely:
 use jni::{EnvUnowned, bind_java_type};
 
 bind_java_type! {
-    MyType => com.example.MyType,
+    pub MyType => com.example.MyType,
     native_methods {
         // No catch_unwind, no error policy for raw methods
         raw extern fn raw_method() -> jint,
@@ -240,7 +240,7 @@ from unwinding across the JNI boundary (which will cause the program to abort).
 use jni::bind_java_type;
 
 bind_java_type! {
-    MyType => com.example.MyType,
+    pub MyType => com.example.MyType,
     native_methods {
         // Automatically wrapped with catch_unwind
         extern fn safe_method() -> jint,
@@ -275,7 +275,7 @@ yourself, you can disable the `catch_unwind` wrapper:
 use jni::bind_java_type;
 
 bind_java_type! {
-    MyType => com.example.MyType,
+    pub MyType => com.example.MyType,
     native_methods {
         fn no_unwind {
             sig = () -> jint,
@@ -301,7 +301,7 @@ Raw methods (`raw`) never use `catch_unwind`:
 use jni::{EnvUnowned, bind_java_type};
 
 bind_java_type! {
-    MyType => com.example.MyType,
+    pub MyType => com.example.MyType,
     native_methods {
         // No catch_unwind wrapper
         raw extern fn raw_fast() -> jint,
@@ -337,7 +337,7 @@ impl From<Handle> for jlong {
 }
 
 bind_java_type! {
-    MyType => com.example.MyType,
+    pub MyType => com.example.MyType,
     type_map = {
         // Generates compile-time size/alignment assertions
         unsafe Handle => long,
@@ -368,7 +368,7 @@ use jni::bind_java_type;
 # use jni::objects::JObject;
 
 bind_java_type! {
-    MyType => com.example.MyType,
+    pub MyType => com.example.MyType,
     type_map = {
         // Validates at runtime that CustomType is actually com.example.CustomClass
         CustomType => com.example.CustomClass,
@@ -383,10 +383,10 @@ be disabled:
 
 ```rust,ignore
 use jni::bind_java_type;
-# bind_java_type! { BaseClass => com.example.Base }
+# bind_java_type! { pub BaseClass => com.example.Base }
 
 bind_java_type! {
-    MyType => com.example.MyType,
+    pub MyType => com.example.MyType,
     is_instance_of = {
         // Validates at runtime that MyType is an instance of BaseClass
         base: BaseClass,
@@ -405,7 +405,7 @@ validates that the second parameter matches the method type:
 use jni::bind_java_type;
 
 bind_java_type! {
-    MyType => com.example.MyType,
+    pub MyType => com.example.MyType,
     native_methods {
         // Validates receiver is an instance
         extern fn instance_method(value: jint) -> jint,
@@ -430,7 +430,7 @@ you may need to disable the checks:
 use jni::bind_java_type;
 
 bind_java_type! {
-    MyType => com.example.MyType,
+    pub MyType => com.example.MyType,
     abi_check = UnsafeNever,  // Disable all checks globally
     type_map = {
         unsafe Handle => long,
@@ -438,7 +438,7 @@ bind_java_type! {
     },
 }
 # impl From<Handle> for jni::sys::jlong { fn from(h: Handle) -> Self { h.0 as jni::sys::jlong } }
-# bind_java_type! { CustomType => com.example.CustomClass }
+# bind_java_type! { pub CustomType => com.example.CustomClass }
 ```
 
 Or per-native-method:
@@ -448,7 +448,7 @@ Or per-native-method:
 use jni::bind_java_type;
 
 bind_java_type! {
-    MyType => com.example.MyType,
+    pub MyType => com.example.MyType,
     type_map = {
         unsafe Handle => long,
     },
@@ -485,7 +485,7 @@ struct MyContext {
 }
 
 bind_java_type! {
-    MyType => com.example.MyType,
+    pub MyType => com.example.MyType,
     priv_type = MyContext,
     hooks = {
         init_priv = |_env, _class, _load_context| {
@@ -519,7 +519,7 @@ Override the default class loading behavior with a `load_class` hook:
 use jni::bind_java_type;
 
 bind_java_type! {
-    MyType => com.example.MyType,
+    pub MyType => com.example.MyType,
     hooks = {
         load_class = |env, load_context, initialize| {
             // Custom class loading logic
@@ -556,8 +556,8 @@ Create custom wrapper macros to encapsulate common configuration across multiple
 use jni::bind_java_type;
 
 // Define common types
-bind_java_type! { UserId => com.example.types.UserId }
-bind_java_type! { Timestamp => com.example.types.Timestamp }
+bind_java_type! { pub UserId => com.example.types.UserId }
+bind_java_type! { pub Timestamp => com.example.types.Timestamp }
 
 // Create a wrapper macro
 macro_rules! my_bind {
@@ -578,7 +578,7 @@ macro_rules! my_bind {
 
 // Use the wrapper - no need to repeat type_map or error_policy
 my_bind! {
-    User => com.example.User,
+    pub User => com.example.User,
     fields {
         id: UserId,
         created: Timestamp,
@@ -586,7 +586,7 @@ my_bind! {
 }
 
 my_bind! {
-    Post => com.example.Post,
+    pub Post => com.example.Post,
     fields {
         author_id: UserId,
         posted: Timestamp,

--- a/crates/jni-macros/docs/bind_java_type_examples.md
+++ b/crates/jni-macros/docs/bind_java_type_examples.md
@@ -9,7 +9,7 @@ The simplest binding just creates a wrapper type for a Java class:
 ```rust
 use jni::bind_java_type;
 
-bind_java_type! { MyType => com.example.MyClass }
+bind_java_type! { pub MyType => com.example.MyClass }
 ```
 
 This generates a `MyType<'local>` wrapper and `MyTypeAPI` struct, but no constructors or methods.
@@ -24,7 +24,7 @@ use jni::Env;
 use jni::objects::JString;
 
 bind_java_type! {
-    Counter => com.example.Counter,
+    pub Counter => com.example.Counter,
     constructors {
         fn new(),
         fn with_initial(value: jint),
@@ -58,7 +58,7 @@ use jni::Env;
 use jni::objects::JString;
 
 bind_java_type! {
-    Counter => com.example.Counter,
+    pub Counter => com.example.Counter,
     constructors {
         fn new(),
     },
@@ -99,9 +99,9 @@ use jni::Env;
 use jni::objects::JString;
 use jni::sys::jint;
 
-# bind_java_type! { Counter => com.example.Counter }
+# bind_java_type! { pub Counter => com.example.Counter }
 bind_java_type! {
-    Utils => com.example.Utils,
+    pub Utils => com.example.Utils,
     type_map = {
         Counter => com.example.Counter,
     },
@@ -136,7 +136,7 @@ use jni::Env;
 use jni::objects::JString;
 
 bind_java_type! {
-    Person => com.example.Person,
+    pub Person => com.example.Person,
     constructors {
         fn new(),
     },
@@ -187,7 +187,7 @@ use jni::Env;
 use jni::objects::{JIntArray, JObjectArray, JString};
 
 bind_java_type! {
-    ArrayUtils => com.example.ArrayUtils,
+    pub ArrayUtils => com.example.ArrayUtils,
     methods {
         // 1D primitive array
         static fn sum_array(values: jint[]) -> jint,
@@ -237,12 +237,12 @@ use jni::bind_java_type;
 use jni::Env;
 
 // First, define bindings for custom types
-bind_java_type! { CustomType => com.example.CustomType, constructors { fn new() } }
-bind_java_type! { OtherType => com.example.OtherType }
+bind_java_type! { pub CustomType => com.example.CustomType, constructors { fn new() } }
+bind_java_type! { pub OtherType => com.example.OtherType }
 
 // Then use them in type_map
 bind_java_type! {
-    Container => com.example.Container,
+    pub Container => com.example.Container,
     type_map = {
         CustomType => com.example.CustomType,
         OtherType => com.example.OtherType,
@@ -282,7 +282,7 @@ use jni::objects::{JClass, JString};
 use jni::sys::jint;
 
 bind_java_type! {
-    Calculator => com.example.Calculator,
+    pub Calculator => com.example.Calculator,
     constructors {
         fn new(),
     },
@@ -357,7 +357,7 @@ use jni::{Env, EnvUnowned, bind_java_type};
 use jni::sys::jint;
 
 bind_java_type! {
-    FastCalc => com.example.FastCalc,
+    pub FastCalc => com.example.FastCalc,
     native_methods {
         // Raw method - no catch_unwind, no error handling
         raw extern fn fast_add(a: jint, b: jint) -> jint,
@@ -388,7 +388,7 @@ use jni::{Env, bind_java_type};
 use jni::sys::jint;
 
 bind_java_type! {
-    DirectCalc => com.example.DirectCalc,
+    pub DirectCalc => com.example.DirectCalc,
     native_methods {
         fn native_square {
             sig = (value: jint) -> jint,
@@ -417,12 +417,12 @@ use jni::Env;
 use jni::objects::JObject;
 
 bind_java_type! {
-    BaseClass => com.example.Base,
+    pub BaseClass => com.example.Base,
     constructors { fn new() },
 }
 
 bind_java_type! {
-    DerivedClass => com.example.Derived,
+    pub DerivedClass => com.example.Derived,
     type_map = {
         BaseClass => com.example.Base,
     },
@@ -457,7 +457,7 @@ use jni::Env;
 use jni::objects::JString;
 
 bind_java_type! {
-    MyType => com.example.MyType,
+    pub MyType => com.example.MyType,
     constructors {
         fn new(),
     },
@@ -486,7 +486,7 @@ use jni::bind_java_type;
 use jni::objects::JString;
 
 bind_java_type! {
-    Config => com.example.Config,
+    pub Config => com.example.Config,
     fields {
         // Custom Java field name
         internal_value {
@@ -519,7 +519,7 @@ use jni::bind_java_type;
 use jni::objects::JString;
 
 bind_java_type! {
-    Counter => com.example.Counter,
+    pub Counter => com.example.Counter,
     constructors {
         /// Creates a new counter with initial value 0
         fn new(),
@@ -560,11 +560,10 @@ use jni::sys::jint;
 use jni::refs::LoaderContext;
 
 // Define related types
-bind_java_type! { CustomData => com.example.Data }
+bind_java_type! { pub CustomData => com.example.Data }
 
 bind_java_type! {
-    rust_type = CompleteExample,
-    java_type = com.example.CompleteExample,
+    pub CompleteExample => com.example.CompleteExample,
 
     type_map = {
         CustomData => com.example.Data,

--- a/crates/jni-macros/docs/bind_java_type_overview.md
+++ b/crates/jni-macros/docs/bind_java_type_overview.md
@@ -22,7 +22,7 @@ The simplest form uses shorthand syntax for trivial bindings:
 use jni::bind_java_type;
 
 // Minimal binding - just creates the wrapper type
-bind_java_type! { MyType => com.example.MyClass }
+bind_java_type! { pub MyType => com.example.MyClass }
 ```
 
 For more complete bindings with methods and fields:
@@ -94,7 +94,7 @@ The macro supports two forms:
 **Shorthand syntax** for simple bindings:
 ```rust
 # use jni::bind_java_type;
-bind_java_type! { MyType => com.example.MyClass }
+bind_java_type! { pub MyType => com.example.MyClass }
 ```
 
 **Block syntax** for full control:
@@ -102,6 +102,7 @@ bind_java_type! { MyType => com.example.MyClass }
 # use jni::bind_java_type;
 bind_java_type! {
     rust_type = MyType,
+    rust_type_vis = pub,
     java_type = com.example.MyClass,
     // ... additional properties
 }
@@ -111,7 +112,7 @@ Both forms can be mixed - you can use shorthand for the type names and add block
 ```rust
 # use jni::bind_java_type;
 bind_java_type! {
-    MyType => com.example.MyClass,
+    pub MyType => com.example.MyClass,
     constructors { fn new() },
 }
 ```
@@ -123,7 +124,7 @@ Methods and fields also support shorthand and block syntax.
 **Shorthand syntax** (recommended when possible):
 ```rust
 # use jni::bind_java_type;
-# bind_java_type! { MyType => com.example.MyClass,
+# bind_java_type! { pub MyType => com.example.MyClass,
 methods {
     fn add(a: jint, b: jint) -> jint,
     static fn get_version() -> jint,
@@ -135,7 +136,7 @@ methods {
 ```rust
 # use jni::bind_java_type;
 # use jni::objects::JString;
-# bind_java_type! { MyType => com.example.MyClass,
+# bind_java_type! { pub MyType => com.example.MyClass,
 methods {
     fn my_method {
         sig = (value: jint),
@@ -180,7 +181,7 @@ Names with existing uppercase letters are preserved as-is (e.g., `MY_CONSTANT` s
 You can always override the Java name explicitly:
 ```rust
 # use jni::bind_java_type;
-# bind_java_type! { MyType => com.example.MyClass,
+# bind_java_type! { pub MyType => com.example.MyClass,
 methods {
     fn my_method {
         sig = (),

--- a/crates/jni-macros/docs/bind_java_type_properties.md
+++ b/crates/jni-macros/docs/bind_java_type_properties.md
@@ -10,13 +10,33 @@ The name of the Rust wrapper type to generate.
 # use jni::bind_java_type;
 bind_java_type! {
     rust_type = MyType,
+    rust_type_vis = pub,
     java_type = com.example.MyClass,
 }
 ```
 
+Normally it's recommended to use the shorthand syntax for the `rust_type`, `rust_type_vis`, and `java_type`:
+
+```rust
+# use jni::bind_java_type;
+bind_java_type! {
+    pub MyType => com.example.MyClass,
+}
+```
+
+## `rust_type_vis` (optional)
+
+The visibility of the generated Rust wrapper type. Defaults to private.
+
+Normally it's recommended to use the shorthand syntax for the `rust_type`, `rust_type_vis`, and `java_type`,
+as shown in the `rust_type` section above.
+
 ## `java_type` (required)
 
 The fully-qualified Java class name. Can be specified as dot-separated identifiers or as a string literal.
+
+Normally it's recommended to use the shorthand syntax for the `rust_type`, `rust_type_vis`, and `java_type`,
+as shown in the `rust_type` section above.
 
 **Syntax options:**
 
@@ -28,17 +48,17 @@ The fully-qualified Java class name. Can be specified as dot-separated identifie
 # use jni::bind_java_type;
 // Using identifiers
 bind_java_type! {
-    MyType => com.example.MyClass,
+    pub MyType => com.example.MyClass,
 }
 
 // Using string literal (useful for inner classes)
 bind_java_type! {
-    MyInner => "com.example.Outer$Inner",
+    pub MyInner => "com.example.Outer$Inner",
 }
 
 // Default package class
 bind_java_type! {
-    MyDefaultPkg => .DefaultPackageClass,
+    pub MyDefaultPkg => .DefaultPackageClass,
 }
 ```
 
@@ -52,7 +72,7 @@ Multiple `type_map` blocks can be specified and will be merged.
 ```rust,ignore
 # use jni::bind_java_type;
 bind_java_type! {
-    MyType => com.example.MyClass,
+    pub MyType => com.example.MyClass,
     type_map = {
         // Map Rust type to Java class
         CustomType => com.example.CustomClass,
@@ -92,7 +112,7 @@ Declares that this type can be safely cast to other [Reference] types. The macro
 # use jni::bind_java_type;
 # bind_java_type! { BaseClass => com.example.Base }
 bind_java_type! {
-    MyType => com.example.MyClass,
+    pub MyType => com.example.MyClass,
     is_instance_of = {
         // With stem: generates as_base() method + From traits
         base: BaseClass,
@@ -143,7 +163,7 @@ The `fields` block defines bindings for instance and static fields, generating g
 # use jni::bind_java_type;
 # use jni::objects::JString;
 bind_java_type! {
-    MyType => com.example.MyClass,
+    pub MyType => com.example.MyClass,
     fields {
         // Shorthand: instance fields
         value: jint,
@@ -186,7 +206,7 @@ after the colon. In block syntax, it's explicitly specified with the `sig` prope
 # use jni::bind_java_type;
 # use jni::objects::JString;
 bind_java_type! {
-    MyType => com.example.MyClass,
+    pub MyType => com.example.MyClass,
     fields {
         // Shorthand
         value: jint,
@@ -210,7 +230,7 @@ specify a different Java field name.
 ```rust
 # use jni::sys::jint;
 # use jni::bind_java_type;
-# bind_java_type! { MyType => com.example.MyClass,
+# bind_java_type! { pub MyType => com.example.MyClass,
 # fields {
 rust_name {
     sig = jint,
@@ -237,7 +257,7 @@ Omit `set` to create a read-only field binding.
 ```rust,ignore
 # use jni::sys::jint;
 # use jni::bind_java_type;
-# bind_java_type! { MyType => com.example.MyClass,
+# bind_java_type! { pub MyType => com.example.MyClass,
 # fields {
 // Read-only field (no setter)
 static CONSTANT {
@@ -275,7 +295,7 @@ and setter methods:
 # use jni::bind_java_type;
 # use jni::objects::JString;
 bind_java_type! {
-    MyType => com.example.MyClass,
+    pub MyType => com.example.MyClass,
     fields {
         /// This documentation appears on the getter
         value: jint,
@@ -333,7 +353,7 @@ All three method blocks support two syntax forms with common qualifiers:
 # use jni::bind_java_type;
 # use jni::objects::JString;
 bind_java_type! {
-    MyType => com.example.MyClass,
+    pub MyType => com.example.MyClass,
     constructors {
         fn new(),
         fn with_value(value: jint),
@@ -382,7 +402,7 @@ For constructors the return type must always be void.
 # use jni::bind_java_type;
 # use jni::objects::JString;
 bind_java_type! {
-    MyType => com.example.MyClass,
+    pub MyType => com.example.MyClass,
     constructors {
         fn new(),
         fn with_value(value: jint),
@@ -403,7 +423,7 @@ specify a different Java method name.
 
 ```rust
 # use jni::bind_java_type;
-# bind_java_type! { MyType => com.example.MyClass,
+# bind_java_type! { pub MyType => com.example.MyClass,
 # methods {
 fn rust_name {
     sig = (),
@@ -424,7 +444,7 @@ Defines constructor bindings that call the Java class's `<init>` methods.
 # use jni::bind_java_type;
 # use jni::objects::JString;
 bind_java_type! {
-    MyType => com.example.MyClass,
+    pub MyType => com.example.MyClass,
     constructors {
         fn new(),
         fn with_value(value: jint),
@@ -451,7 +471,7 @@ Defines bindings for instance and static methods.
 # use jni::bind_java_type;
 # use jni::objects::JString;
 bind_java_type! {
-    MyType => com.example.MyClass,
+    pub MyType => com.example.MyClass,
     methods {
         // Instance methods
         fn get_value() -> jint,
@@ -487,7 +507,7 @@ Defines native methods that are implemented in Rust and called from Java.
 # use jni::bind_java_type;
 # use jni::objects::JString;
 bind_java_type! {
-    MyType => com.example.MyClass,
+    pub MyType => com.example.MyClass,
     native_methods {
         // Exported instance method (implemented via trait)
         extern fn native_add(a: jint, b: jint) -> jint,
@@ -519,7 +539,7 @@ Instead of implementing the native methods trait, you can provide a direct funct
 # use jni::sys::jint;
 # use jni::bind_java_type;
 # use jni::Env;
-# bind_java_type! { MyType => com.example.MyClass,
+# bind_java_type! { pub MyType => com.example.MyClass,
 # native_methods {
 fn native_method {
     sig = (value: jint) -> jint,
@@ -548,7 +568,7 @@ The `extern` qualifier in shorthand syntax is equivalent to `export = true`.
 # use jni::sys::jint;
 # use jni::bind_java_type;
 bind_java_type! {
-    MyType => com.example.MyClass,
+    pub MyType => com.example.MyClass,
     native_methods_export = false,  // Don't export by default (otherwise export = true / extern are redundant)
     native_methods {
         // Exported with standard name (extern is shorthand for export = true)
@@ -594,7 +614,7 @@ for errors and returns a default value.
 # use jni::sys::jint;
 # use jni::bind_java_type;
 bind_java_type! {
-    MyType => com.example.MyClass,
+    pub MyType => com.example.MyClass,
     native_methods {
         fn native_method {
             sig = (value: jint) -> jint,
@@ -621,7 +641,7 @@ Controls whether the native method wrapper catches Rust panics. Defaults to `tru
 # use jni::sys::jint;
 # use jni::bind_java_type;
 bind_java_type! {
-    MyType => com.example.MyClass,
+    pub MyType => com.example.MyClass,
     native_methods {
         fn native_method {
             sig = (value: jint) -> jint,
@@ -647,7 +667,7 @@ By default, native methods are implemented via a generated trait. For example:
 # use jni::objects::JString;
 # use jni::sys::jint;
 # bind_java_type! {
-#     MyType => com.example.MyClass,
+#     pub MyType => com.example.MyClass,
 #     native_methods {
 #         extern fn native_add(a: jint, b: jint) -> jint,
 #     }
@@ -693,7 +713,7 @@ Custom name for the generated native methods trait. Default is `{Type}NativeInte
 ```rust,ignore
 # use jni::bind_java_type;
 bind_java_type! {
-    MyType => com.example.MyClass,
+    pub MyType => com.example.MyClass,
     native_trait = MyCustomNativeTrait,
     native_methods {
         extern fn native_method() -> jint,
@@ -710,7 +730,7 @@ Individual methods can override with `export = true/false` or the `extern` quali
 # use jni::sys::jint;
 # use jni::bind_java_type;
 bind_java_type! {
-    MyType => com.example.MyClass,
+    pub MyType => com.example.MyClass,
     native_methods_export = false,  // Don't export by default
     native_methods {
         // Not exported
@@ -749,7 +769,7 @@ exceptions and default values.
 # use jni::sys::jint;
 # use jni::bind_java_type;
 bind_java_type! {
-    MyType => com.example.MyClass,
+    pub MyType => com.example.MyClass,
     native_methods_error_policy = jni::errors::LogErrorAndDefault,
     native_methods {
         extern fn native_method() -> jint,  // Uses global policy
@@ -778,7 +798,7 @@ Individual methods can override with `catch_unwind = true/false`.
 # use jni::sys::jint;
 # use jni::bind_java_type;
 bind_java_type! {
-    MyType => com.example.MyClass,
+    pub MyType => com.example.MyClass,
     native_methods_catch_unwind = false,  // Don't catch panics by default
     native_methods {
         // No panic catching (unsafe!)
@@ -825,7 +845,7 @@ Controls validation of type mappings at compile-time and runtime. Defaults to `A
 # #[repr(transparent)] #[derive(Copy, Clone)] struct Handle(*const u8);
 # bind_java_type! { CustomType => com.example.CustomClass }
 bind_java_type! {
-    MyType => com.example.MyClass,
+    pub MyType => com.example.MyClass,
     abi_check = Always,  // Enable checks in all builds
     type_map = {
         // Compile-time: validates Handle has the size and alignment of a jlong
@@ -866,7 +886,7 @@ For advanced use cases, you can inject custom data into the API struct.
 # unsafe impl Send for MyCustomData {}
 # unsafe impl Sync for MyCustomData {}
 bind_java_type! {
-    MyType => com.example.MyClass,
+    pub MyType => com.example.MyClass,
     priv_type = MyCustomData,
     hooks = {
         init_priv = |_env, _class, _load_context| {
@@ -892,7 +912,7 @@ Override the default class loading behavior with a custom class loader.
 ```rust,ignore
 # use jni::bind_java_type;
 bind_java_type! {
-    MyType => com.example.MyClass,
+    pub MyType => com.example.MyClass,
     hooks = {
         load_class = |env, load_context, initialize| {
             // Custom loading logic here

--- a/crates/jni-macros/tests/bind_visibility.rs
+++ b/crates/jni-macros/tests/bind_visibility.rs
@@ -3,8 +3,7 @@ mod inner {
 
     // Test visibility specifiers on methods using shorthand syntax
     bind_java_type! {
-        rust_type = TestVisibility,
-        java_type = "com.example.TestVisibility",
+        pub TestVisibility => "com.example.TestVisibility",
         methods {
             // Public method (default)
             fn public_method() -> void,

--- a/crates/jni-macros/tests/ui/bind_java_type/fail/visibility_private_field.rs
+++ b/crates/jni-macros/tests/ui/bind_java_type/fail/visibility_private_field.rs
@@ -4,8 +4,7 @@ mod inner {
     use jni::bind_java_type;
 
     bind_java_type! {
-        rust_type = TestClass,
-        java_type = "com.example.TestClass",
+        pub TestClass => "com.example.TestClass",
         fields {
             // Private field using priv keyword (both getter and setter are private)
             priv private_field: int,

--- a/crates/jni-macros/tests/ui/bind_java_type/fail/visibility_private_field.stderr
+++ b/crates/jni-macros/tests/ui/bind_java_type/fail/visibility_private_field.stderr
@@ -1,13 +1,12 @@
 error[E0624]: method `private_field` is private
-  --> tests/ui/bind_java_type/fail/visibility_private_field.rs:18:31
+  --> tests/ui/bind_java_type/fail/visibility_private_field.rs:17:31
    |
  6 | /     bind_java_type! {
- 7 | |         rust_type = TestClass,
- 8 | |         java_type = "com.example.TestClass",
- 9 | |         fields {
+ 7 | |         pub TestClass => "com.example.TestClass",
+ 8 | |         fields {
 ...  |
-13 | |     }
+12 | |     }
    | |_____- private method defined here
 ...
-18 |       let _ = inner::TestClass::private_field;
+17 |       let _ = inner::TestClass::private_field;
    |                                 ^^^^^^^^^^^^^ private method

--- a/crates/jni-macros/tests/ui/bind_java_type/fail/visibility_private_method.rs
+++ b/crates/jni-macros/tests/ui/bind_java_type/fail/visibility_private_method.rs
@@ -5,6 +5,7 @@ mod inner {
 
     bind_java_type! {
         rust_type = TestClass,
+        rust_type_vis = pub,
         java_type = "com.example.TestClass",
         methods {
             // Private method using pub(self)

--- a/crates/jni-macros/tests/ui/bind_java_type/fail/visibility_private_method.stderr
+++ b/crates/jni-macros/tests/ui/bind_java_type/fail/visibility_private_method.stderr
@@ -1,13 +1,13 @@
 error[E0624]: method `private_method` is private
-  --> tests/ui/bind_java_type/fail/visibility_private_method.rs:18:31
+  --> tests/ui/bind_java_type/fail/visibility_private_method.rs:19:31
    |
  6 | /     bind_java_type! {
  7 | |         rust_type = TestClass,
- 8 | |         java_type = "com.example.TestClass",
- 9 | |         methods {
+ 8 | |         rust_type_vis = pub,
+ 9 | |         java_type = "com.example.TestClass",
 ...  |
-13 | |     }
+14 | |     }
    | |_____- private method defined here
 ...
-18 |       let _ = inner::TestClass::private_method;
+19 |       let _ = inner::TestClass::private_method;
    |                                 ^^^^^^^^^^^^^^ private method

--- a/crates/jni-macros/tests/ui/bind_java_type/fail/visibility_private_setter.rs
+++ b/crates/jni-macros/tests/ui/bind_java_type/fail/visibility_private_setter.rs
@@ -4,8 +4,7 @@ mod inner {
     use jni::bind_java_type;
 
     bind_java_type! {
-        rust_type = TestClass,
-        java_type = "com.example.TestClass",
+        pub TestClass => "com.example.TestClass",
         fields {
             // Public getter, private setter
             mixed_field {

--- a/crates/jni-macros/tests/ui/bind_java_type/fail/visibility_private_setter.stderr
+++ b/crates/jni-macros/tests/ui/bind_java_type/fail/visibility_private_setter.stderr
@@ -1,13 +1,12 @@
 error[E0624]: method `set_mixed` is private
-  --> tests/ui/bind_java_type/fail/visibility_private_setter.rs:22:31
+  --> tests/ui/bind_java_type/fail/visibility_private_setter.rs:21:31
    |
  6 | /     bind_java_type! {
- 7 | |         rust_type = TestClass,
- 8 | |         java_type = "com.example.TestClass",
- 9 | |         fields {
+ 7 | |         pub TestClass => "com.example.TestClass",
+ 8 | |         fields {
 ...  |
-17 | |     }
+16 | |     }
    | |_____- private method defined here
 ...
-22 |       let _ = inner::TestClass::set_mixed;
+21 |       let _ = inner::TestClass::set_mixed;
    |                                 ^^^^^^^^^ private method

--- a/crates/jni/src/objects/jbytebuffer.rs
+++ b/crates/jni/src/objects/jbytebuffer.rs
@@ -1,1 +1,1 @@
-crate::bind_java_type! { JByteBuffer => "java.nio.ByteBuffer" }
+crate::bind_java_type! { pub JByteBuffer => "java.nio.ByteBuffer" }

--- a/crates/jni/src/objects/jclass.rs
+++ b/crates/jni/src/objects/jclass.rs
@@ -1,8 +1,7 @@
 use crate::jni_str;
 
 crate::bind_java_type! {
-    rust_type = JClass,
-    java_type = "java.lang.Class",
+    pub JClass => "java.lang.Class",
     __jni_core = true,
     __sys_type = jclass,
     hooks {

--- a/crates/jni/src/objects/jclass_loader.rs
+++ b/crates/jni/src/objects/jclass_loader.rs
@@ -1,8 +1,7 @@
 use crate::jni_str;
 
 crate::bind_java_type! {
-    rust_type = JClassLoader,
-    java_type = "java.lang.ClassLoader",
+    pub JClassLoader => "java.lang.ClassLoader",
     hooks {
         load_class = |env, _loader_context, _initialize| {
             // As a special-case; we ignore loader_context and use `env.find_class` just to be clear that there's no risk of

--- a/crates/jni/src/objects/jcollection.rs
+++ b/crates/jni/src/objects/jcollection.rs
@@ -1,6 +1,5 @@
 crate::bind_java_type! {
-    rust_type = JCollection,
-    java_type = "java.util.Collection",
+    pub JCollection => "java.util.Collection",
     methods {
         /// Adds the given element to this set if it is not already present
         ///

--- a/crates/jni/src/objects/jiterator.rs
+++ b/crates/jni/src/objects/jiterator.rs
@@ -7,8 +7,7 @@ use crate::{
 };
 
 bind_java_type! {
-    rust_type = JIterator,
-    java_type = "java.util.Iterator",
+    pub JIterator => "java.util.Iterator",
     methods {
         /// Returns true if the iteration has more elements.
         fn has_next() -> bool,

--- a/crates/jni/src/objects/jlist.rs
+++ b/crates/jni/src/objects/jlist.rs
@@ -6,8 +6,7 @@ use crate::{
 };
 
 crate::bind_java_type! {
-    rust_type = JList,
-    java_type = "java.util.List",
+    pub JList => "java.util.List",
     is_instance_of {
         collection = JCollection,
     },

--- a/crates/jni/src/objects/jmap.rs
+++ b/crates/jni/src/objects/jmap.rs
@@ -10,8 +10,7 @@ use std::ops::Deref;
 use crate::objects::JSet;
 
 crate::bind_java_type! {
-    rust_type = JMap,
-    java_type = "java.util.Map",
+    pub JMap => "java.util.Map",
     methods = {
         /// Returns the number of key-value mappings in this map
         ///
@@ -246,8 +245,7 @@ impl<'local> JMap<'local> {
 }
 
 crate::bind_java_type! {
-    rust_type = JMapEntry,
-    java_type = "java.util.Map$Entry",
+    pub JMapEntry => "java.util.Map$Entry",
     methods = {
         /// Get the key of the map entry by calling the `getKey` method.
         ///

--- a/crates/jni/src/objects/jset.rs
+++ b/crates/jni/src/objects/jset.rs
@@ -5,8 +5,7 @@ use crate::{
 };
 
 crate::bind_java_type! {
-    rust_type = JSet,
-    java_type = "java.util.Set",
+    pub JSet => "java.util.Set",
     is_instance_of {
         collection = JCollection,
     }

--- a/crates/jni/src/objects/jstack_trace_element.rs
+++ b/crates/jni/src/objects/jstack_trace_element.rs
@@ -1,6 +1,5 @@
 crate::bind_java_type! {
-    rust_type = JStackTraceElement,
-    java_type = "java.lang.StackTraceElement",
+    pub JStackTraceElement => "java.lang.StackTraceElement",
     methods {
         /// Get the class name of the stack trace element.
         fn get_class_name() -> JString,

--- a/crates/jni/src/objects/jstring.rs
+++ b/crates/jni/src/objects/jstring.rs
@@ -12,8 +12,7 @@ use super::Reference as _;
 use crate::errors::Error;
 
 crate::bind_java_type! {
-    rust_type = JString,
-    java_type = "java.lang.String",
+    pub JString => "java.lang.String",
     __jni_core = true,
     __sys_type = jstring,
     methods {

--- a/crates/jni/src/objects/jthread.rs
+++ b/crates/jni/src/objects/jthread.rs
@@ -1,8 +1,7 @@
 use crate::jni_str;
 
 crate::bind_java_type! {
-    rust_type = JThread,
-    java_type = "java.lang.Thread",
+    pub JThread => "java.lang.Thread",
     hooks {
         load_class = |env, _loader_context, _initialize| {
             // As a special-case; we ignore loader_context and use `env.find_class` just to be clear that there's no risk of

--- a/crates/jni/src/objects/jthrowable.rs
+++ b/crates/jni/src/objects/jthrowable.rs
@@ -1,6 +1,5 @@
 crate::bind_java_type! {
-    rust_type = JThrowable,
-    java_type = "java.lang.Throwable",
+    pub JThrowable => "java.lang.Throwable",
     __jni_core = true,
     __sys_type = jthrowable,
     methods {


### PR DESCRIPTION
A visibility specifier can now either be given with the short-form syntax like:

```
bind_java_type! { pub MyType => com.example.MyType }
```

or as `rust_type_vis` property like:

```
bind_java_type! {
    rust_type = MyType,
    rust_type_vis = pub,
    java_type = com.example.MyType
}
```

If no visibility is specified then the type will be private to the module.

Without this change then I found it awkward to use `bind_java_type` within the `android-activity` crate which wants to implement private bindings for `android.view.KeyCharacterMap` and `android.view.InputDevice`.