### PR TITLE
Release jni macros 0.22.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ repository = "https://github.com/jni-rs/jni-rs"
 
 
 [workspace.dependencies]
-jni-macros = { path = "./crates/jni-macros", version = "0.1.0" }
+jni-macros = { path = "./crates/jni-macros", version = "0.22.0" }
 javac = { path = "./crates/javac", version = "0.1.0" }
 jni = { path = "./crates/jni", version = "0.21.1" }
 

--- a/crates/jni-macros/Cargo.toml
+++ b/crates/jni-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jni-macros"
-version = "0.1.0"
+version = "0.22.0"
 description = "Procedural macros for the jni crate"
 keywords = ["jni", "java", "jvm", "android", "ndk"]
 categories = ["api-bindings", "development-tools::procedural-macro-helpers"]

--- a/crates/jni-macros/README.md
+++ b/crates/jni-macros/README.md
@@ -1,5 +1,8 @@
 Proc macros for the [jni](https://crates.io/crates/jni) crate.
 
+These macros are only expected to be used via the `jni` crate and only expected
+to be compatible with the `jni` crate version that re-exports them.
+
 See the [jni docs](https://docs.rs/jni/latest/jni/) for more details, since
 these macros are re-exported by the `jni` crate.
 


### PR DESCRIPTION
In preparation for making a [jni 0.22 release](https://github.com/jni-rs/jni-rs/pull/650), this releases the corresponding `jni-macros` proc macros crate
