### PR TITLE
bind_java_type: add pub(crate) to API structs

### DIFF
--- a/crates/jni-macros/src/bind_java_type.rs
+++ b/crates/jni-macros/src/bind_java_type.rs
@@ -1484,7 +1484,7 @@ fn generate_api_struct(
 
     quote! {
         #[allow(non_snake_case)]
-        struct #api_name {
+        pub(crate) struct #api_name {
             class: #jni::refs::Global<#jni::objects::JClass<'static>>,
             #priv_field
             #(#method_id_fields)*


### PR DESCRIPTION
The generated `<RustType>API` structs exist to store `JClass` and Method/Field IDs that are cached for Java type API binding.

These cached singleton API structs are got via
`<RustType>API::get()`, within the implementation of `RustType` method bindings.

Most of the time the API structs can be treated as a private implementation detail of `bind_java_type` but sometimes it's expected that you might want to hand-write some method bindings that should also be able to refer to this cached API state.

Previously the generate API struct was generated with no visibility qualifier, which made it private to the current module. This was assumed to be OK, since manually written bindings would be expected to go in the same module.

Another use case for `<RustType>API::get()` though is for explicitly initializing a binding, so you can control exactly when the class and method/field IDs are resolved instead of waiting for them to be resolved lazily.

In order to support the generation of `jni_init` methods that may recursively initialize a set of inter-dependent JNI type bindings it can also be useful to access these `::get()` methods from outside the module in which they are defined - though still within the crate they are defined - and so they are now generated with `pub(crate)` visibility.
