### PR TITLE
jni_macros: add `#[doc(hidden)]` to native method export symbols

### DIFF
--- a/crates/jni-macros/src/bind_java_type.rs
+++ b/crates/jni-macros/src/bind_java_type.rs
@@ -3559,6 +3559,7 @@ fn generate_single_native_export(
     };
 
     Ok(quote! {
+        #[doc(hidden)]
         #no_mangle_attr
         #[allow(non_snake_case)]
         pub unsafe extern "system" fn #mangled_ident<#lifetime>(

--- a/crates/jni-macros/src/native_method.rs
+++ b/crates/jni-macros/src/native_method.rs
@@ -687,6 +687,7 @@ pub fn native_method_impl(input: TokenStream) -> Result<TokenStream> {
         // The export wrapper calls the wrapper function (for wrapped) or user function (for raw)
         Ok(quote! {
             const {
+                #[doc(hidden)]
                 #export_name_attr
                 pub extern "system" fn __native_method_export<#lifetime>(
                     #(#raw_params),*


### PR DESCRIPTION
The mangled functions used to export a native method from a shared library need to be public but they are not really considered to be part of the public Rust API itself and so they are now hidden from rustdoc.

