### PR TITLE
jni: smallvec optimisation for args + inline assert_top() checks

### DIFF
--- a/crates/jni/Cargo.toml
+++ b/crates/jni/Cargo.toml
@@ -60,6 +60,7 @@ cfg-if = "1.0.0"
 cesu8 = "1.1.0"
 combine = "4.1.0"
 paste = "1"
+smallvec = { version = "1", features = ["const_new"] }
 
 [target.'cfg(windows)'.dependencies]
 windows-link = "0.2"

--- a/crates/jni/src/jvalue.rs
+++ b/crates/jni/src/jvalue.rs
@@ -182,6 +182,7 @@ impl<'local> JValueOwned<'local> {
 
 impl<'obj_ref> JValue<'obj_ref> {
     /// Convert the enum to its jni-compatible equivalent.
+    #[inline(always)]
     pub fn as_jni(&self) -> jvalue {
         let val: jvalue = match self {
             Self::Object(obj) => jvalue { l: obj.as_raw() },

--- a/crates/jni/src/vm/java_vm.rs
+++ b/crates/jni/src/vm/java_vm.rs
@@ -747,6 +747,7 @@ impl JavaVM {
     ///
     /// This is only really public since it's useful for unit tests
     #[doc(hidden)]
+    #[inline(always)]
     pub fn thread_attach_guard_level() -> usize {
         THREAD_GUARD_NEST_LEVEL.get()
     }


### PR DESCRIPTION
This adds a `smallvec` crate dependency so that we can avoid any heap allocation in `Env::new_object`, `Env::call_method`, `Env::call_static_method` and `Env::call_nonvirtual_method` when there are <= 8 arguments.

Since jni 0.22 generally expects method calls to pass pre-encoded method names (via `jni_str!`) as well as pre-parsed signatures (via `jni_sig!`) we've now got to the point where (safe) method calls can be made without needing any per-call heap allocations.

This also ensures that all `assert_top()` checks (for ensuring we can only create new local references in the top JNI stack frame) are inlined (since these checks showed up in some of the micro benchmarks when comparing with jni 0.21).