### PR TITLE
Call `ExceptionCheck` before any non-exception-safe JNI calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+#### Changed
+
+The following APIs have had to be made fallible again, in order to safely check for pending
+exceptions before calling JNI functions that are not documented as being safe to call with a pending
+exception:
+
+- `Env::get_java_vm` (`GetJavaVM` is not exception safe)
+- `Env::version` (`GetVersion` is not exception safe)
+- `Env::is_same_object` (`IsSameObject` is not exception safe)
+- `Weak::is_garbage_collected` (based on `Env::is_same_object`)
+- `Weak::is_same_object` (deprecated) and (based on
+  `Env::is_same_object`)
+- `Weak::is_weak_ref_to_same_object (deprecated)` (based on
+  `Env::is_same_object`)
+
+_*Note:* These are a breaking change but we're probably going to sneak them into a jni 0.22.1
+release and yank 0.22.0 before anyone notices (since 0.22.0 was released very recently and it's
+highly unlikely anyone is strictly locking in a 0.22.0 dependency yet)_
+
+Fixed in [#733](https://github.com/jni-rs/jni-rs/issues/733)
 
 ## [0.22.0] — 2026-02-17
 

--- a/crates/jni/src/elements/auto_elements_critical.rs
+++ b/crates/jni/src/elements/auto_elements_critical.rs
@@ -84,13 +84,14 @@ where
     ///
     /// If `mode` is not [`sys::JNI_COMMIT`], then `self.ptr` must not have already been released.
     unsafe fn release_primitive_array_critical(&mut self, mode: i32) -> Result<()> {
-        // Errors:
+        // Safety/Errors:
         // - Since we can't construct `AutoElementsCritical` without a valid `Env` reference we know
         //   we can call `JavaVM::singleton()` without an error.
         // - Since `self` is associated with a local reference frame lifetime we know that the
         //   thread is attached and so `with_top_local_frame()` can't return an error.
+        // - ReleasePrimitiveArrayCritical can be called while there is a pending exception
         JavaVM::singleton()?.with_top_local_frame(|env| unsafe {
-            jni_call_unchecked!(
+            ex_safe_jni_call_no_post_check_ex!(
                 env,
                 v1_2,
                 ReleasePrimitiveArrayCritical,

--- a/crates/jni/src/lib.rs
+++ b/crates/jni/src/lib.rs
@@ -418,3 +418,10 @@ pub use jni_macros::bind_java_type;
 
 #[doc = include_str!("../docs/macros/native_method.md")]
 pub use jni_macros::native_method;
+
+// For internal jni call macros to ensure their results are checked
+#[doc(hidden)]
+#[must_use]
+pub fn __must_use<T>(v: T) -> T {
+    v
+}

--- a/crates/jni/src/objects/jobject_array.rs
+++ b/crates/jni/src/objects/jobject_array.rs
@@ -176,7 +176,7 @@ impl<'local, E: Reference + 'local> JObjectArray<'local, E> {
         env.assert_top();
         let element_class = E::lookup_class(env, &LoaderContext::default())?;
         let array = unsafe {
-            jni_call_check_ex!(
+            jni_call_post_check_ex!(
                 env,
                 v1_1,
                 NewObjectArray,
@@ -258,7 +258,7 @@ impl<'local, E: Reference + 'local> JObjectArray<'local, E> {
             self.as_raw() as jobjectArray,
             "JObjectArray::len self argument"
         )?;
-        let len = unsafe { jni_call_unchecked!(env, v1_1, GetArrayLength, array) } as usize;
+        let len = unsafe { jni_call_no_post_check_ex!(env, v1_1, GetArrayLength, array)? } as usize;
         Ok(len)
     }
 
@@ -281,7 +281,7 @@ impl<'local, E: Reference + 'local> JObjectArray<'local, E> {
             ));
         }
         unsafe {
-            jni_call_check_ex!(env, v1_1, GetObjectArrayElement, array, index as i32)
+            jni_call_post_check_ex!(env, v1_1, GetObjectArrayElement, array, index as i32)
                 .map(|obj| E::kind_from_raw(obj))
         }
     }
@@ -303,7 +303,7 @@ impl<'local, E: Reference + 'local> JObjectArray<'local, E> {
             ));
         }
         unsafe {
-            jni_call_check_ex!(
+            jni_call_post_check_ex!(
                 env,
                 v1_1,
                 SetObjectArrayElement,

--- a/crates/jni/src/objects/jprimitive_array.rs
+++ b/crates/jni/src/objects/jprimitive_array.rs
@@ -142,7 +142,7 @@ impl<'local, T: TypeArray> JPrimitiveArray<'local, T> {
     /// Returns the length of the array.
     pub fn len(&self, env: &Env) -> Result<usize> {
         let array = null_check!(self.as_raw(), "JPrimitiveArray::len self argument")?;
-        let len = unsafe { jni_call_unchecked!(env, v1_1, GetArrayLength, array) } as usize;
+        let len = unsafe { jni_call_no_post_check_ex!(env, v1_1, GetArrayLength, array)? } as usize;
         Ok(len)
     }
 

--- a/crates/jni/src/objects/jstring.rs
+++ b/crates/jni/src/objects/jstring.rs
@@ -146,7 +146,7 @@ impl JString<'_> {
         env.assert_top();
         let ffi_str: &JNIStr = from.as_ref();
         unsafe {
-            jni_call_check_ex_and_null_ret!(env, v1_1, NewStringUTF, ffi_str.as_ptr())
+            jni_call_post_check_ex_and_null_ret!(env, v1_1, NewStringUTF, ffi_str.as_ptr())
                 .map(|s| JString::from_raw(env, s))
         }
     }

--- a/crates/jni/src/objects/type_array.rs
+++ b/crates/jni/src/objects/type_array.rs
@@ -92,7 +92,7 @@ pub(crate) mod type_array_sealed {
                 unsafe impl TypeArraySealed for $jni_type {
                     /// Create new Java $jni_type array
                     unsafe fn new_array(env: &mut Env, length: jsize) -> Result<jarray> {
-                        let raw_array = unsafe { jni_call_check_ex_and_null_ret!(env, v1_1, [< New $jni_type_name Array>], length)? };
+                        let raw_array = unsafe { jni_call_post_check_ex_and_null_ret!(env, v1_1, [< New $jni_type_name Array>], length)? };
                         Ok(raw_array)
                     }
 
@@ -115,8 +115,10 @@ pub(crate) mod type_array_sealed {
                         ptr: NonNull<Self>,
                         mode: i32,
                     ) -> Result<()> {
-                        // There are no documented exceptions for Release<Primitive>ArrayElements()
-                        unsafe { jni_call_unchecked!(env, v1_1, [< Release $jni_type_name ArrayElements>], array, ptr.as_ptr(), mode as i32) };
+                        // Release<Primitive>ArrayElements() is safe to call while there is a
+                        // pending exception and there are no documented exceptions for
+                        // Release<Primitive>ArrayElements()
+                        unsafe { ex_safe_jni_call_no_post_check_ex!(env, v1_1, [< Release $jni_type_name ArrayElements>], array, ptr.as_ptr(), mode as i32) };
                         Ok(())
                     }
 
@@ -129,7 +131,7 @@ pub(crate) mod type_array_sealed {
                         let array =
                             null_check!(array, "get_*_array_region array argument")?;
                         unsafe {
-                            jni_call_check_ex!(
+                            Ok(jni_call_post_check_ex!(
                                 env,
                                 v1_1,
                                 [< Get $jni_type_name ArrayRegion>],
@@ -137,7 +139,7 @@ pub(crate) mod type_array_sealed {
                                 start,
                                 buf.len() as jsize,
                                 buf.as_mut_ptr()
-                            )
+                            )?)
                         }
                     }
 
@@ -149,7 +151,7 @@ pub(crate) mod type_array_sealed {
                     ) -> Result<()> {
                         let array = null_check!(array, "set_*_array_region array argument")?;
                         unsafe {
-                            jni_call_check_ex!(
+                            Ok(jni_call_post_check_ex!(
                                 env,
                                 v1_1,
                                 [< Set $jni_type_name ArrayRegion>],
@@ -157,7 +159,7 @@ pub(crate) mod type_array_sealed {
                                 start,
                                 buf.len() as jsize,
                                 buf.as_ptr()
-                            )
+                            )?)
                         }
                     }
                 }

--- a/crates/jni/src/refs/global.rs
+++ b/crates/jni/src/refs/global.rs
@@ -286,7 +286,7 @@ where
                     }
                     // Safety: This method is safe to call in case of pending exceptions (see chapter 2 of the spec)
                     unsafe {
-                        jni_call_unchecked!(env, v1_1, DeleteGlobalRef, obj.as_raw());
+                        ex_safe_jni_call_no_post_check_ex!(env, v1_1, DeleteGlobalRef, obj.as_raw());
                     }
                     Ok(())
                 },

--- a/crates/jni/src/refs/weak.rs
+++ b/crates/jni/src/refs/weak.rs
@@ -203,7 +203,9 @@ where
     ///
     /// This is equivalent to
     /// <code>self.[is_same_object][Weak::is_same_object](env, [JObject::null]\())</code>.
-    pub fn is_garbage_collected(&self, env: &Env) -> bool {
+    ///
+    /// This may return [`Error::JavaException`] if called while there is a pending exception.
+    pub fn is_garbage_collected(&self, env: &Env) -> Result<bool> {
         env.is_same_object(self, JObject::null())
     }
 
@@ -214,7 +216,7 @@ where
     /// `Weak` has been garbage collected, or false if the object has not yet been garbage
     /// collected.
     #[deprecated = "Use Env::is_same_object"]
-    pub fn is_same_object<'local, O>(&self, env: &Env<'local>, object: O) -> bool
+    pub fn is_same_object<'local, O>(&self, env: &Env<'local>, object: O) -> Result<bool>
     where
         O: AsRef<JObject<'local>>,
     {
@@ -227,7 +229,7 @@ where
     /// This method will also return true if both weak references refer to an object that has been
     /// garbage collected.
     #[deprecated = "Use Env::is_same_object"]
-    pub fn is_weak_ref_to_same_object(&self, env: &Env, other: &Self) -> bool {
+    pub fn is_weak_ref_to_same_object(&self, env: &Env, other: &Self) -> Result<bool> {
         env.is_same_object(self, other)
     }
 
@@ -267,7 +269,7 @@ where
                 // Safety: This method is safe to call in case of pending exceptions (see chapter 2 of the spec)
                 // jni-rs requires JNI_VERSION > 1.2
                 unsafe {
-                    jni_call_unchecked!(env, v1_2, DeleteWeakGlobalRef, obj.as_raw());
+                    ex_safe_jni_call_no_post_check_ex!(env, v1_2, DeleteWeakGlobalRef, obj.as_raw());
                 }
                 Ok(())
             });

--- a/crates/jni/src/strings/mutf8_chars.rs
+++ b/crates/jni/src/strings/mutf8_chars.rs
@@ -279,7 +279,9 @@ where
             // `JavaVM::singleton()` must be initialized and won't panic.
             JavaVM::singleton()?.with_top_local_frame(|env| {
                 // This method is safe to call in case of pending exceptions (see the chapter 2 of the spec)
-                unsafe { jni_call_unchecked!(env, v1_1, ReleaseStringUTFChars, obj, chars) };
+                unsafe {
+                    ex_safe_jni_call_no_post_check_ex!(env, v1_1, ReleaseStringUTFChars, obj, chars)
+                };
 
                 Ok(())
             })

--- a/crates/jni/tests/exception_safe_calls.rs
+++ b/crates/jni/tests/exception_safe_calls.rs
@@ -1,0 +1,30 @@
+#![cfg(feature = "invocation")]
+
+mod util;
+
+use rusty_fork::rusty_fork_test;
+
+rusty_fork_test! {
+#[test]
+fn test_exception_unsafe_calls() {
+    let jvm = util::jvm();
+    jvm.attach_current_thread(|env| -> jni::errors::Result<()> {
+        let _ = env.throw("Test Exception".to_string());
+
+        let res = env.new_string("Test");
+
+        println!("new_string res = {:?}", res);
+        // No new string should be allocated because there is a pending exception
+        // and until the exception is cleared, the JNI calls would lead to
+        // undefined behavior
+        assert!(matches!(res, Err(jni::errors::Error::JavaException)));
+
+        let pending = env.with_local_frame(8, |env| -> jni::errors::Result<bool> {
+            Ok(env.exception_check())
+        }).expect("Push/PopLocalFrame + ExceptionCheck should be exception safe");
+
+        assert!(pending);
+        Ok(())
+    }).unwrap();
+}
+}

--- a/crates/jni/tests/jni_api.rs
+++ b/crates/jni/tests/jni_api.rs
@@ -138,7 +138,7 @@ pub fn is_same_object_diff_references() {
     attach_current_thread(|env| {
         let string = JString::from_jni_str(env, TESTING_OBJECT_STR).unwrap();
         let ref_from_string = unwrap(env.new_local_ref(&string), env);
-        assert!(env.is_same_object(&string, &ref_from_string));
+        assert!(env.is_same_object(&string, &ref_from_string).unwrap());
         env.delete_local_ref(ref_from_string);
 
         Ok(())
@@ -150,7 +150,7 @@ pub fn is_same_object_diff_references() {
 pub fn is_same_object_same_reference() {
     attach_current_thread(|env| {
         let string = JString::from_jni_str(env, TESTING_OBJECT_STR).unwrap();
-        assert!(env.is_same_object(&string, &string));
+        assert!(env.is_same_object(&string, &string).unwrap());
 
         Ok(())
     })
@@ -162,7 +162,7 @@ pub fn is_not_same_object() {
     attach_current_thread(|env| {
         let string = JString::from_jni_str(env, TESTING_OBJECT_STR).unwrap();
         let same_src_str = JString::from_jni_str(env, TESTING_OBJECT_STR).unwrap();
-        assert!(!env.is_same_object(string, same_src_str));
+        assert!(!env.is_same_object(&string, &same_src_str).unwrap());
 
         Ok(())
     })
@@ -172,7 +172,10 @@ pub fn is_not_same_object() {
 #[test]
 pub fn is_not_same_object_null() {
     attach_current_thread(|env| {
-        assert!(env.is_same_object(JObject::null(), JObject::null()));
+        assert!(
+            env.is_same_object(JObject::null(), JObject::null())
+                .unwrap()
+        );
 
         Ok(())
     })
@@ -510,7 +513,7 @@ fn set_static_public_field_by_id() {
             .unwrap();
 
         // The restored value should be the same as original
-        assert!(env.is_same_object(&original_in, &restored_in));
+        assert!(env.is_same_object(&original_in, &restored_in).unwrap());
 
         Ok(())
     })
@@ -1549,7 +1552,7 @@ fn new_weak_ref_null() {
         assert!(matches!(result, Err(Error::ObjectFreed)));
 
         let null_weak: Weak<JObject<'static>> = Weak::null();
-        assert!(null_weak.is_garbage_collected(env));
+        assert!(null_weak.is_garbage_collected(env).unwrap());
 
         Ok(())
     })
@@ -1762,18 +1765,18 @@ pub fn test_conversion() {
 
         let string = env.cast_local::<JString>(obj).unwrap();
         let actual = JObject::from(string);
-        assert!(env.is_same_object(&orig_obj, actual));
+        assert!(env.is_same_object(&orig_obj, actual).unwrap());
 
         let global_ref = env.new_global_ref(&orig_obj).unwrap();
-        assert!(env.is_same_object(&orig_obj, global_ref));
+        assert!(env.is_same_object(&orig_obj, global_ref).unwrap());
 
         let weak_ref = unwrap(env.new_weak_ref(&orig_obj), env);
         let actual =
             unwrap(weak_ref.upgrade_local(env), env).expect("weak ref should not have been GC'd");
-        assert!(env.is_same_object(&orig_obj, actual));
+        assert!(env.is_same_object(&orig_obj, actual).unwrap());
 
         let auto_local = unwrap(env.new_local_ref(&orig_obj), env).auto();
-        assert!(env.is_same_object(&orig_obj, auto_local));
+        assert!(env.is_same_object(&orig_obj, auto_local).unwrap());
 
         Ok(())
     })

--- a/crates/jni/tests/jni_weak_refs.rs
+++ b/crates/jni/tests/jni_weak_refs.rs
@@ -142,7 +142,10 @@ fn weak_ref_is_actually_weak() {
                         .auto();
 
                     assert!(!obj_local_from_weak.is_null());
-                    assert!(env.is_same_object(&obj_local_from_weak, &obj_local));
+                    assert!(
+                        env.is_same_object(&obj_local_from_weak, &obj_local)
+                            .unwrap()
+                    );
                 }
 
                 {
@@ -150,18 +153,21 @@ fn weak_ref_is_actually_weak() {
                         .expect("object shouldn't have been GC'd yet");
 
                     assert!(!obj_global_from_weak.is_null());
-                    assert!(env.is_same_object(&obj_global_from_weak, &obj_local));
+                    assert!(
+                        env.is_same_object(&obj_global_from_weak, &obj_local)
+                            .unwrap()
+                    );
                 }
 
-                assert!(env.is_same_object(obj_weak, &obj_local));
+                assert!(env.is_same_object(obj_weak, &obj_local).unwrap());
 
                 assert!(
-                    !obj_weak.is_garbage_collected(env),
+                    !obj_weak.is_garbage_collected(env).unwrap(),
                     "`is_garbage_collected` returned incorrect value"
                 );
             }
 
-            assert!(env.is_same_object(&obj_weak, &obj_weak2));
+            assert!(env.is_same_object(&obj_weak, &obj_weak2).unwrap());
 
             drop(obj_local);
             run_gc(env);
@@ -186,12 +192,12 @@ fn weak_ref_is_actually_weak() {
                 }
 
                 assert!(
-                    obj_weak.is_garbage_collected(env),
+                    obj_weak.is_garbage_collected(env).unwrap(),
                     "`is_garbage_collected` returned incorrect value"
                 );
             }
 
-            assert!(env.is_same_object(obj_weak, &obj_weak2));
+            assert!(env.is_same_object(obj_weak, &obj_weak2).unwrap());
         }
 
         Ok(())


### PR DESCRIPTION
The JNI spec lists a small number of functions that are considered to be safe to call if there is a pending exception and they are:

- ExceptionOccurred()
- ExceptionDescribe()
- ExceptionClear()
- ExceptionCheck()
- ReleaseStringChars()
- ReleaseStringUTFChars()
- ReleaseStringCritical()
- Release<Type>ArrayElements()
- ReleasePrimitiveArrayCritical()
- DeleteLocalRef()
- DeleteGlobalRef()
- DeleteWeakGlobalRef()
- MonitorExit()
- PushLocalFrame()
- PopLocalFrame()
- DetachCurrentThread()

For all other functions we would trigger undefined behaviour if we call them while there is a pending Java exception.

This updates the `jni/src/macros.rs` so:
- We have a separate macro for calling the above exception-safe macros, with no extra checks
- All other JNI calls are preceded with an `ExceptionCheck` call to ensure we can't trigger undefined behaviour. If any pending exception is found then we simply return `JavaException` as we do when a call first triggers an exception.

In the case of `DetachCurrentThread`, which is technically an invocation API, this updates `sys_detach_current_thread` so it always calls `env.exception_clear()` before calling `DetachCurrentThread` and the plan is to follow up with some changes to the `JavaVM::attach_current_thread*` APIs to allow them to capture pending exceptions well before `sys_detach_current_thread` is reached. (See #736)

Unfortunately this has forced us to break a few APIs that had been made infallible for jni 0.22.0, namely:

- `Env::get_java_vm` (`GetJavaVM` is not exception safe)
- `Env::version` (`GetVersion` is not exception safe)
- `Env::is_same_object` (`IsSameObject` is not exception safe)
- `Weak::is_garbage_collected` (based on `Env::is_same_object`)
- `Weak::is_same_object` (deprecated) and (based on `Env::is_same_object`)
- `Weak::is_weak_ref_to_same_object (deprecated)` (based on `Env::is_same_object`)

The current hope is that we land this change fairly quickly and release as jni 0.22.1 and then yank jni 0.22.0 before anyone is depending on it.

Fixes: #731

