### PR TITLE
Have `Env::throw*` APIs return Error::JavaException

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ highly unlikely anyone is strictly locking in a 0.22.0 dependency yet)_
 Fixed in [#733](https://github.com/jni-rs/jni-rs/issues/733)
 
 - `JavaVM::attach_current_thread*` APIs all finish by calling `AttachGuard::detach_with_catch` to clear pending Java exceptions - mapping to `Error::CaughtJavaException` ([#736](https://github.com/jni-rs/jni-rs/pull/736))
+- `Env::throw*` APIs now return `Error::JavaException` after throwing and creating a pending exception that must be handled before using JNI further ([#738](https://github.com/jni-rs/jni-rs/pull/738))
 
 ## [0.22.0] — 2026-02-17
 

--- a/crates/jni/docs/0.22-MIGRATION.md
+++ b/crates/jni/docs/0.22-MIGRATION.md
@@ -25,6 +25,9 @@ Essential changes that affect most code:
 - [ ] **Add type parameters**: `Global<T>`, `Weak<T>`, `JObjectArray<T>` now generic over Java types
 - [ ] **JNI strings**: Replace runtime string encoding with `jni_str!("...")` macro
 - [ ] **Signatures**: Parse signatures at compile-time with `jni_sig!((args) -> ReturnType)` macro
+- [ ] **Throw Errors**: Take into account that `env.throw*` APIs will return
+      `Err(Error::JavaException)` after throwing (which should typically be
+      propagated to callers via '?')
 
 Optional but recommended:
 

--- a/crates/jni/src/env.rs
+++ b/crates/jni/src/env.rs
@@ -845,8 +845,17 @@ See the jni-rs Env documentation for more details.
     // FIXME: this API shouldn't need a `&mut self` reference since it doesn't return a local reference
     // (currently it just needs the `&mut self` for the sake of `Desc<JThrowable>::lookup`)
     //
-    /// Raise an exception from an existing object. This will continue being
-    /// thrown in java unless `exception_clear` is called.
+    /// Raise an exception from an existing object. This will continue being thrown in java unless
+    /// `exception_clear` is called.
+    ///
+    /// Returns [`Error::JavaException`] after throwing the exception.
+    ///
+    /// The '?' operator should typically used to ensure that the new pending exception is reported
+    /// as an error to calling Rust code, allowing the stack to unwind until something decides to
+    /// catch the exception (or it propagates back to the JVM).
+    ///
+    /// *Note:* that once there is a pending exception then most JNI calls (that are not exception
+    /// safe) will return [`Error::JavaException`] until the exception is cleared.
     ///
     /// # Examples
     /// ```rust,no_run
@@ -928,8 +937,14 @@ See the jni-rs Env documentation for more details.
     // FIXME: this API shouldn't need a `&mut self` reference since it doesn't return a local reference
     // (currently it just needs the `&mut self` for the sake of `Desc<JClass>::lookup`)
     //
-    /// Create and throw a new exception from a class descriptor and an error
-    /// message.
+    /// Create and throw a new exception from a class descriptor and an error message.
+    ///
+    /// The '?' operator should typically used to ensure that the new pending exception is reported
+    /// as an error to calling Rust code, allowing the stack to unwind until something decides to
+    /// catch the exception (or it propagates back to the JVM).
+    ///
+    /// *Note:* that once there is a pending exception then most JNI calls (that are not exception
+    /// safe) will return [`Error::JavaException`] until the exception is cleared.
     ///
     /// # Example
     /// ```rust,no_run
@@ -941,8 +956,8 @@ See the jni-rs Env documentation for more details.
     /// # }
     /// ```
     ///
-    /// Alternatively, see [Env::throw_new_void] if you want to construct an exception
-    /// with no message argument.
+    /// Alternatively, see [Env::throw_new_void] if you want to construct an exception with no
+    /// message argument.
     pub fn throw_new<'other_local, S, T>(&mut self, class: T, msg: S) -> Result<()>
     where
         S: AsRef<JNIStr>,
@@ -953,8 +968,14 @@ See the jni-rs Env documentation for more details.
         self.throw_new_optional(class.as_ref(), Some(msg))
     }
 
-    /// Create and throw a new exception from a class descriptor and no error
-    /// message.
+    /// Create and throw a new exception from a class descriptor and no error message.
+    ///
+    /// The '?' operator should typically used to ensure that the new pending exception is reported
+    /// as an error to calling Rust code, allowing the stack to unwind until something decides to
+    /// catch the exception (or it propagates back to the JVM).
+    ///
+    /// *Note:* that once there is a pending exception then most JNI calls (that are not exception
+    /// safe) will return [`Error::JavaException`] until the exception is cleared.
     ///
     /// # Example
     /// ```rust,no_run
@@ -968,8 +989,7 @@ See the jni-rs Env documentation for more details.
     ///
     /// This will expect to find a constructor for the given `class` that takes no arguments.
     ///
-    /// Alternatively, see [Env::throw_new] if you want to construct an exception
-    /// with a message.
+    /// Alternatively, see [Env::throw_new] if you want to construct an exception with a message.
     pub fn throw_new_void<'other_local, T>(&mut self, class: T) -> Result<()>
     where
         T: Desc<'local, JClass<'other_local>>,

--- a/crates/jni/src/errors/policy.rs
+++ b/crates/jni/src/errors/policy.rs
@@ -197,6 +197,9 @@ impl<T: Default, E: std::error::Error> ErrorPolicy<T, E> for ThrowRuntimeExAndDe
             return Ok(T::default()); // already thrown
         }
         let err_string = format!("Rust error: {}", err);
+        // Note: `env.throw()` will return `Err(Error::JavaException)` after throwing but in this case
+        // (where we are going to be letting the exception propagate to Java), we want to ensure we
+        // don't return that as an error
         let _ = env.throw(err_string);
         Ok(T::default())
     }
@@ -218,7 +221,11 @@ impl<T: Default, E: std::error::Error> ErrorPolicy<T, E> for ThrowRuntimeExAndDe
                 "non-string panic payload".to_string()
             }
         };
-        env.throw(format!("Rust panic: {}", panic_string))?;
+
+        // Note: `env.throw()` will return `Err(Error::JavaException)` after throwing but in this case
+        // (where we are going to be letting the exception propagate to Java), we want to ensure we
+        // don't return that as an error
+        let _ = env.throw(format!("Rust panic: {}", panic_string));
         Ok(T::default())
     }
 }


### PR DESCRIPTION
After a Java exception has been thrown by these APIs it's important for callers to know that there is a pending exception and that JNI can't continue to be used until it has been cleared.

The normal way this is handled is via the `JavaException` error.

The idea is that '?' should be used in conjunction with `Env::throw*` so that a `JavaException` error is returned to callers and the stack should unwind until something explicitly decides to catch the exception or else it propagates to the JVM.

Fixes: #737

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Change is covered by [automated tests](https://github.com/jni-rs/jni-rs/blob/master/CONTRIBUTING.md#tests)
- [x] The [coding guidelines](https://github.com/jni-rs/jni-rs/blob/master/CONTRIBUTING.md#the-code-style) are followed
- [x] Public API has documentation
- [x] User-visible changes are mentioned in the Changelog
- [x] The continuous integration build passes
