### PR TITLE
docs: fix duplicate word typos in docs/comments

### DIFF
--- a/crates/jni/docs/0.22-MIGRATION.md
+++ b/crates/jni/docs/0.22-MIGRATION.md
@@ -751,7 +751,7 @@ of RAII guard types in `jni-rs` that may automatically call JNI methods in their
 ### My application freezes after migrating away from daemon thread attachments
 
 If you find that your application freezes or blocks when exiting, after migrating
-away from daemon thread attachments this is a warning sign that you you have an
+away from daemon thread attachments this is a warning sign that you have an
 unsound exit path where there may be threads running that have an invalid JNI
 environment pointer and the potential to try calling JNI methods after
 the JVM is destroyed.

--- a/crates/jni/docs/macros/bind_java_type_3_advanced.md
+++ b/crates/jni/docs/macros/bind_java_type_3_advanced.md
@@ -267,7 +267,7 @@ fn wrapper<'local>(mut unowned_env: EnvUnowned<'local>, this: MyType<'local>) ->
 
 ### Disabling `catch_unwind`
 
-If you you want to allow your native method to abort on panic or you plan to handle panics
+If you want to allow your native method to abort on panic or you plan to handle panics
 yourself, you can disable the `catch_unwind` wrapper:
 
 ```rust,ignore

--- a/crates/jni/src/env.rs
+++ b/crates/jni/src/env.rs
@@ -1924,7 +1924,7 @@ See the jni-rs Env documentation for more details.
     /// `pop_local_frame`
     ///
     /// The caller must ensure that a new `AttachGuard` is created before
-    /// creating a new local frame and the the local frame may only access
+    /// creating a new local frame and the local frame may only access
     /// a `Env` that is borrowed from this new guard (so that local
     /// references will be tied to lifetime of the new guard)
     unsafe fn push_local_frame(&self, capacity: i32) -> Result<()> {
@@ -3989,7 +3989,7 @@ See the jni-rs Env documentation for more details.
     ///
     /// # Safety
     ///
-    /// This will lead to undefined behaviour if the the specified field
+    /// This will lead to undefined behaviour if the specified field
     /// doesn't have a type of `long`.
     ///
     /// It's important to note that using this API will leak memory if
@@ -4055,7 +4055,7 @@ See the jni-rs Env documentation for more details.
     ///
     /// # Safety
     ///
-    /// This will lead to undefined behaviour if the the specified field
+    /// This will lead to undefined behaviour if the specified field
     /// doesn't have a type of `long`.
     ///
     /// If the field contains a non-zero value then it is assumed to be a valid
@@ -4101,7 +4101,7 @@ See the jni-rs Env documentation for more details.
     ///
     /// # Safety
     ///
-    /// This will lead to undefined behaviour if the the specified field
+    /// This will lead to undefined behaviour if the specified field
     /// doesn't have a type of `long`.
     ///
     /// If the field contains a non-zero value then it is assumed to be a valid
@@ -4586,7 +4586,7 @@ impl<'local> EnvUnowned<'local> {
     ///
     /// If you have a raw [`crate::sys::JNIEnv`] pointer, this API should be
     /// marginally safer than using [`crate::AttachGuard`] manually
-    /// since since the attach guard management will be hidden within the
+    /// since the attach guard management will be hidden within the
     /// [`Self::with_env`] and [`Self::with_env_no_catch`] methods.
     ///
     /// Beware that [`Self::with_env`] and [`Self::with_env_no_catch`] will not

--- a/crates/jni/src/refs/reference.rs
+++ b/crates/jni/src/refs/reference.rs
@@ -288,7 +288,7 @@ pub unsafe trait Reference: Sized {
     /// `Global<JClass>` that is cheap to lookup and doesn't require a JNI call
     /// or creating any new references.
     ///
-    /// Note that that in order to avoid creating a new JNI reference, this API
+    /// Note that in order to avoid creating a new JNI reference, this API
     /// will return a guard that derefs to a `Global<JClass>`, rather than a
     /// `JClass` directly.
     ///

--- a/crates/jni/src/vm/java_vm.rs
+++ b/crates/jni/src/vm/java_vm.rs
@@ -1617,7 +1617,7 @@ impl Drop for AttachGuard<'_> {
 /// local scope when attaching the current thread to a Java VM.
 ///
 /// This gives us something for an [`AttachGuard`] to borrow that's not likely
-/// to to be accidentally made `'static`.
+/// to be accidentally made `'static`.
 ///
 /// This is only relevant for `unsafe` code that is manually creating
 /// [`AttachGuard`]s.


### PR DESCRIPTION
  ## Overview                                                                                             
                                                                                                          
  Fix duplicate word typos in docs and comments.                                                                    

  ### Definition of Done                                                                                  
                                                                                                          
  - [x] There are no TODOs left in the code                                                               
  - [x] Change is covered by [automated tests](https://github.com/jni-rs/jni-rs/blob/master/              
  CONTRIBUTING.md#tests)                                                                                  
  - [x] The [coding guidelines](https://github.com/jni-rs/jni-rs/blob/master/CONTRIBUTING.md#the-code-    
  style) are followed                                                                                     
  - [x] Public API has documentation                                                                      
  - [ ] User-visible changes are mentioned in the Changelog                                               
  - [ ] The continuous integration build passes  