### PR TITLE
`get_[static_]method/field_id`: squash exceptions into `Method/FieldNotFound` errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,9 +17,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-#### Changed
+### Changed
 
 - Removed dependency on `paste` crate ([#752](https://github.com/jni-rs/jni-rs/pull/752))
+
+### Fixed
+
+- `Env::get_[static_]method/field_id` APIs now correctly clear + map internal exceptions to `Error::Method/FieldNotFound` errors ([#748](https://github.com/jni-rs/jni-rs/pull/748))
 
 ## [0.22.1] — 2026-02-20
 
@@ -33,7 +37,7 @@ Instead of bumping to 0.23 though, the assumption is that no one will yet be dep
 - `AttachGuard::detach_with_catch` lets you explicitly detach/drop a guard (like `::detach()`) and catch any pending Java exception as a `Error::CaughtJavaException` ([#736](https://github.com/jni-rs/jni-rs/pull/736)).
 - `JClass::get_name` lets you query the binary name for a class, such as `java.lang.String` ([#736](https://github.com/jni-rs/jni-rs/pull/736))
 
-#### Changed
+### Changed
 
 The following APIs have had to be made fallible again, in order to safely check for pending exceptions before calling
 JNI functions that are not documented as being safe to call with a pending exception:


### PR DESCRIPTION
The way that the `Get[Static]Method/FieldID` JNI calls work is that they will throw an exception on failure, in addition to returning a null ID.

Since these JNI calls were wrapped with the
`jni_call_post_check_ex_and_null_ret` macro that meant that we would immediately return a `JavaException` error to the caller without having the chance to try and map these exceptions to a `Method/FieldNotFound` error instead.

Additionally the previous attempt to map `NullPtr` errors into `Method/FieldNotFound` errors did not consider the need to clear pending exceptions in case we are not returning a `JavaException` error.

The `get_[static]_method/field_id` implementations now make sure to:
- check for pending exceptions before making any JNI call so that they will avoid any side effects from potentially clearing exceptions that they didn't cause.
- check for null method/field IDs and explicitly clear exceptions before returning a `Method/FieldNotFound` error.
- as an extra pedantic check we also assert that there must be no pending exception in case we get back a non-null/valid method/field ID.

This adds unit tests to ensure we get `Method/FieldNotFound` errors with no pending exception side effects.

Fixes: #741

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Change is covered by [automated tests](https://github.com/jni-rs/jni-rs/blob/master/CONTRIBUTING.md#tests)
- [x] The [coding guidelines](https://github.com/jni-rs/jni-rs/blob/master/CONTRIBUTING.md#the-code-style) are followed
- [x] Public API has documentation
- [x] User-visible changes are mentioned in the Changelog
- [x] The continuous integration build passes
