### PR TITLE
Ensure `Global/Weak::Drop` has no exception_clear side effects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - `Env::get_[static_]method/field_id` APIs now correctly clear + map internal exceptions to `Error::Method/FieldNotFound` errors ([#748](https://github.com/jni-rs/jni-rs/pull/748))
+- `Global/Weak::Drop` no longer have the side effect of catching/clearing pending exceptions ([#749](https://github.com/jni-rs/jni-rs/pull/749))
 
 ## [0.22.1] — 2026-02-20
 


### PR DESCRIPTION
This updates the implementations of `Global/Weak::Drop` so that they don't clear pending exceptions as a side effect.

The issue was that #736 overlooked the internal use of `attach_current_thread` in these Drop implementations and didn't consider that these Drop methods need to remain exception safe and should leave any existing pending exception in place.

We now use `JavaVM::attach_current_thread_guard` so we can intentionally avoid `AttachGuard::detach_with_catch`, which would catch/clear any pending exceptions.

This adds unit tests to check that there are no exception_clear side effects from dropping a `Global` or `Weak` reference.

Addresses: #743

(It's not marked as a fix for #743 because #743 represents more than one underlying issue.)


### Definition of Done

- [x] There are no TODOs left in the code
- [x] Change is covered by [automated tests](https://github.com/jni-rs/jni-rs/blob/master/CONTRIBUTING.md#tests)
- [x] The [coding guidelines](https://github.com/jni-rs/jni-rs/blob/master/CONTRIBUTING.md#the-code-style) are followed
- [x] Public API has documentation
- [x] User-visible changes are mentioned in the Changelog
- [x] The continuous integration build passes
