### PR TITLE
Remove dependency on paste macro crate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+#### Changed
+
+- Removed dependency on `paste` crate ([#752](https://github.com/jni-rs/jni-rs/pull/752))
+
 ## [0.22.1] — 2026-02-20
 
 *Note:* This release fixes several issues found in 0.22.0 which unfortunately required a few breaking changes.

--- a/crates/jni/Cargo.toml
+++ b/crates/jni/Cargo.toml
@@ -59,7 +59,6 @@ thiserror.workspace = true
 cfg-if = "1.0.0"
 cesu8 = "1.1.0"
 combine = "4.1.0"
-paste = "1"
 
 [target.'cfg(windows)'.dependencies]
 windows-link = "0.2"


### PR DESCRIPTION
Considering that the paste macro is marked as unmaintained now this removes the dependency as a simplification for downstream crates that may have automated auditing of their dependencies.

We now simply pass all the pasted symbol names we need to the internal `type_array` and `impl_ref_for_jprimitive_array` macros. This does slightly increase the risk of a copy and paste mistake (especially with the `type_array` macro usage) but overall it's a pretty self-contained list of types that aren't ever expected to change so I think that's acceptable.

Fixes: #746

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Change is covered by [automated tests](https://github.com/jni-rs/jni-rs/blob/master/CONTRIBUTING.md#tests)
- [x] The [coding guidelines](https://github.com/jni-rs/jni-rs/blob/master/CONTRIBUTING.md#the-code-style) are followed
- [x] Public API has documentation
- [x] User-visible changes are mentioned in the Changelog
- [x] The continuous integration build passes
