### PR TITLE
Fix to return `JavaException` from `Env::throw*` APIs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `Env::get_[static_]method/field_id` APIs now correctly clear + map internal exceptions to `Error::Method/FieldNotFound` errors ([#748](https://github.com/jni-rs/jni-rs/pull/748))
 - `Global/Weak::Drop` no longer have the side effect of catching/clearing pending exceptions ([#749](https://github.com/jni-rs/jni-rs/pull/749))
+- Ensure that the `Env::throw*` APIs _actually_ return `Err(JavaException)` as the docs state ([#755](https://github.com/jni-rs/jni-rs/pull/755))
 
 ## [0.22.1] — 2026-02-20
 

--- a/crates/jni/src/env.rs
+++ b/crates/jni/src/env.rs
@@ -895,7 +895,7 @@ See the jni-rs Env documentation for more details.
         drop(throwable);
 
         if res == 0 {
-            Ok(())
+            Err(Error::JavaException)
         } else {
             Err(Error::ThrowFailed(res))
         }
@@ -928,7 +928,7 @@ See the jni-rs Env documentation for more details.
         };
 
         if res == 0 {
-            Ok(())
+            Err(Error::JavaException)
         } else {
             Err(Error::ThrowFailed(res))
         }

--- a/crates/jni/tests/jni_api.rs
+++ b/crates/jni/tests/jni_api.rs
@@ -641,8 +641,10 @@ pub fn with_local_frame_misuse_panic() {
 #[test]
 pub fn with_local_frame_pending_exception() {
     attach_current_thread(|env| {
-        env.throw_new(RUNTIME_EXCEPTION_CLASS, jni_str!("Test Exception"))
-            .unwrap();
+        // Intentionally avoid unwrapping the `.throw_new()` result since it will report Err(JavaException) but for the
+        // test we want to continue regardless
+        let res = env.throw_new(RUNTIME_EXCEPTION_CLASS, jni_str!("Test Exception"));
+        assert!(matches!(res, Err(Error::JavaException)));
 
         // Try to allocate a frame of locals
         env.with_local_frame(16, |_| -> Result<_, Error> { Ok(()) })
@@ -1682,8 +1684,10 @@ fn get_object_array_element() {
 #[test]
 pub fn throw_new() {
     attach_current_thread(|env| {
-        env.throw_new(RUNTIME_EXCEPTION_CLASS, jni_str!("Test Exception"))
-            .unwrap();
+        // Intentionally avoid unwrapping the `.throw_new()` result since it will report Err(JavaException) but for the
+        // test we want to continue regardless
+        let res = env.throw_new(RUNTIME_EXCEPTION_CLASS, jni_str!("Test Exception"));
+        assert!(matches!(res, Err(Error::JavaException)));
         assert_pending_java_exception_detailed(
             env,
             Some(RUNTIME_EXCEPTION_CLASS),
@@ -1698,7 +1702,10 @@ pub fn throw_new() {
 #[test]
 pub fn throw_new_void() {
     attach_current_thread(|env| {
-        env.throw_new_void(RUNTIME_EXCEPTION_CLASS).unwrap();
+        // Intentionally avoid unwrapping the `.throw_new_void()` result since it will report Err(JavaException) but for the
+        // test we want to continue regardless
+        let res = env.throw_new_void(RUNTIME_EXCEPTION_CLASS);
+        assert!(matches!(res, Err(Error::JavaException)));
 
         assert!(env.exception_check());
         let exception = env.exception_occurred().expect("Unable to get exception");
@@ -1993,7 +2000,10 @@ fn test_java_char_conversion() {
 #[test]
 fn test_throwable_get_stack_trace() {
     attach_current_thread(|env| {
-        env.throw("Test exception").unwrap();
+        // Intentionally avoid unwrapping the `.throw()` result since it will report Err(JavaException) but for the test
+        // we want to continue regardless
+        let res = env.throw("Test exception");
+        assert!(matches!(res, Err(Error::JavaException)));
         let exception = env.exception_occurred().unwrap();
         env.exception_clear();
 


### PR DESCRIPTION
The PR for #738 was unfortunately rushed and since it didn't add a unit test then I missed the fact that I had actually only updated all the docs + changelog but omitted the functional change 🤦

This makes the functional change that was documented in #738.

This updates existing `env.throw*` tests and adds some additional tests to ensure the APIs return `Err(JavaException)` as expected - and double checks the exceptions match what we threw.

Fixes: #750

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Change is covered by [automated tests](https://github.com/jni-rs/jni-rs/blob/master/CONTRIBUTING.md#tests)
- [x] The [coding guidelines](https://github.com/jni-rs/jni-rs/blob/master/CONTRIBUTING.md#the-code-style) are followed
- [x] Public API has documentation
- [x] User-visible changes are mentioned in the Changelog
- [x] The continuous integration build passes
