### PR TITLE
Don't clear pre-pending exceptions in `attach_current_thread*` APIs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Removed dependency on `paste` crate ([#752](https://github.com/jni-rs/jni-rs/pull/752))
+- `attach_current_thread*` APIs immediately return `Err(JavaException)` if a Java exception is pending, so they don't have the side effect of clearing exceptions not thrown in the given closure ([#756](https://github.com/jni-rs/jni-rs/pull/756))
 
 ### Fixed
 


### PR DESCRIPTION
This ensures that the `JavaVM::attach_current_thread*` APIs (the ones that take a closure) don't have the side effect of clearing any exception that was already pending (if the thread was already attached).

This is related to #743 (where `Global::Drop` had the side effect of clearing exceptions).

In that specific case `Global::Drop` needs to make an exception-safe JNI call and so it doesn't need to bail early, but in the more typical case `attach_current_thread` is not use for exception safe calls and it would be surprising to allow `attach_current_thread` to catch + clear an exception that was not thrown from within its given closure.

This adds a unit test to check that when `env.attach_current_thread()` is called with a pending exception then it must return `Error::JavaException` without running the closure and the exception must still be pending afterwards.

Fixes: #754

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Change is covered by [automated tests](https://github.com/jni-rs/jni-rs/blob/master/CONTRIBUTING.md#tests)
- [x] The [coding guidelines](https://github.com/jni-rs/jni-rs/blob/master/CONTRIBUTING.md#the-code-style) are followed
- [x] Public API has documentation
- [x] User-visible changes are mentioned in the Changelog
- [x] The continuous integration build passes
