### PR TITLE
jni-macros: Add exception_checks before raw JNI calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `Global/Weak::Drop` no longer have the side effect of catching/clearing pending exceptions ([#749](https://github.com/jni-rs/jni-rs/pull/749))
 - Ensure that the `Env::throw*` APIs _actually_ return `Err(JavaException)` as the docs state ([#755](https://github.com/jni-rs/jni-rs/pull/755))
 - `JStackTraceElement` binding fixed to lookup `isNativeMethod` instead of `isNative` ([#760](https://github.com/jni-rs/jni-rs/pull/760))
+- `bind_java_type` emits `exception_checks` before JNI calls to avoid undefined behaviour from calling non-exception-safe JNI functions with pending exceptions. ([#757](https://github.com/jni-rs/jni-rs/pull/757))
 
 ## [0.22.1] — 2026-02-20
 


### PR DESCRIPTION
This is a counterpart to #731, applied to the `jni-macros` crate.

Some of the JNI calls emitted by `bind_java_type` are made directly through the `JNINativeInterface_` and so there's no automatic check done for pending exceptions, like we have in the `jni` crate.

This adds calls to `env.exception_check()` before any of the raw JNI calls so we can bail and return `Err(Error::JavaException)` if there is a pending exception (and the call would trigger undefined behaviour).

Fixes: #751

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Change is covered by [automated tests](https://github.com/jni-rs/jni-rs/blob/master/CONTRIBUTING.md#tests)
- [x] The [coding guidelines](https://github.com/jni-rs/jni-rs/blob/master/CONTRIBUTING.md#the-code-style) are followed
- [x] Public API has documentation
- [x] User-visible changes are mentioned in the Changelog
- [x] The continuous integration build passes
