### PR TITLE
jni-macros: Remove `proc-macro-crate` dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Removed dependency on `paste` crate ([#752](https://github.com/jni-rs/jni-rs/pull/752))
 - `attach_current_thread*` APIs immediately return `Err(JavaException)` if a Java exception is pending, so they don't have the side effect of clearing exceptions not thrown in the given closure ([#756](https://github.com/jni-rs/jni-rs/pull/756))
+- Removed `proc-macro-crate` dependency from the `jni-macros` crate ([#758](https://github.com/jni-rs/jni-rs/pull/758))
 
 ### Fixed
 

--- a/crates/jni-macros/Cargo.toml
+++ b/crates/jni-macros/Cargo.toml
@@ -20,7 +20,6 @@ rustc_version = "0.4"
 syn = { version = "2.0", features = ["full"] }
 quote = "1.0"
 proc-macro2 = "1.0"
-proc-macro-crate = "3"
 cesu8 = "1.1.0"
 
 [dev-dependencies]


### PR DESCRIPTION
It should be very rare that the `jni` crate will be used with a non-standard name and so it's hard to justify the dependencies and added complexity for automatically trying to resolve the name by parsing Cargo.toml metadata.

It's especially hard to justify when:

1. All of the macros support a simpler, explicit `jni=<name>` override. This is well tested and documented and doesn't require external deps.
2. The most likely reason (imo) for needing a rename would probably be due to needing to use multiple major versions in the same project - and `proc-macro-crate` won't be able to automatically pick the right name in this case anyway (it will just use the last seen name).

Closes: #747

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Change is covered by [automated tests](https://github.com/jni-rs/jni-rs/blob/master/CONTRIBUTING.md#tests)
- [x] The [coding guidelines](https://github.com/jni-rs/jni-rs/blob/master/CONTRIBUTING.md#the-code-style) are followed
- [x] Public API has documentation
- [x] User-visible changes are mentioned in the Changelog
- [x] The continuous integration build passes
