### PR TITLE
`JStackTraceElement`: lookup `isNativeMethod` not `isNative`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `Env::get_[static_]method/field_id` APIs now correctly clear + map internal exceptions to `Error::Method/FieldNotFound` errors ([#748](https://github.com/jni-rs/jni-rs/pull/748))
 - `Global/Weak::Drop` no longer have the side effect of catching/clearing pending exceptions ([#749](https://github.com/jni-rs/jni-rs/pull/749))
 - Ensure that the `Env::throw*` APIs _actually_ return `Err(JavaException)` as the docs state ([#755](https://github.com/jni-rs/jni-rs/pull/755))
+- `JStackTraceElement` binding fixed to lookup `isNativeMethod` instead of `isNative` ([#760](https://github.com/jni-rs/jni-rs/pull/760))
 
 ## [0.22.1] — 2026-02-20
 

--- a/crates/jni/src/objects/jiterator.rs
+++ b/crates/jni/src/objects/jiterator.rs
@@ -1,12 +1,10 @@
-use jni_macros::bind_java_type;
-
 use crate::{
     env::Env,
     errors::{Error, Result},
     objects::JObject,
 };
 
-bind_java_type! {
+crate::bind_java_type! {
     pub JIterator => "java.util.Iterator",
     methods {
         /// Returns true if the iteration has more elements.

--- a/crates/jni/src/objects/jobject.rs
+++ b/crates/jni/src/objects/jobject.rs
@@ -85,12 +85,12 @@ impl ::std::ops::Deref for JObject<'_> {
     }
 }
 
-struct JObjectAPI {
+pub(crate) struct JObjectAPI {
     class: Global<JClass<'static>>,
     // no methods cached for now
 }
 impl JObjectAPI {
-    fn get(env: &Env<'_>) -> Result<&'static Self> {
+    pub(crate) fn get(env: &Env<'_>) -> Result<&'static Self> {
         static API: std::sync::OnceLock<JObjectAPI> = std::sync::OnceLock::new();
 
         // Fast path: already initialized

--- a/crates/jni/src/objects/jobject_array.rs
+++ b/crates/jni/src/objects/jobject_array.rs
@@ -88,7 +88,7 @@ impl<'local, E: Reference> From<JObjectArray<'local, E>> for JObject<'local> {
 
 unsafe impl<'local, E: Reference> AsJArrayRaw<'local> for JObjectArray<'local, E> {}
 
-struct JObjectArrayAPI<E: Reference> {
+pub(crate) struct JObjectArrayAPI<E: Reference> {
     class: Global<JClass<'static>>,
     _marker: std::marker::PhantomData<E>,
 }
@@ -99,7 +99,7 @@ static API_REGISTRY: OnceLock<RwLock<HashMap<TypeId, &'static (dyn Any + Send + 
     OnceLock::new();
 
 impl<E: Reference + Send + Sync> JObjectArrayAPI<E> {
-    fn get<'any_local>(
+    pub(crate) fn get<'any_local>(
         env: &Env<'_>,
         loader_context: &LoaderContext<'any_local, '_>,
     ) -> Result<&'static Self> {

--- a/crates/jni/src/objects/jprimitive_array.rs
+++ b/crates/jni/src/objects/jprimitive_array.rs
@@ -374,12 +374,12 @@ unsafe impl<'local, T: TypeArray> AsJArrayRaw<'local> for JPrimitiveArray<'local
 macro_rules! impl_ref_for_jprimitive_array {
     ($type:ident, $class_name:expr, $api_type:ident) => {
         #[allow(non_camel_case_types)]
-        struct $api_type {
+        pub(crate) struct $api_type {
             class: Global<JClass<'static>>,
         }
 
         impl $api_type {
-            fn get<'any_local>(
+            pub(crate) fn get<'any_local>(
                 env: &Env<'_>,
                 loader_context: &LoaderContext<'any_local, '_>,
             ) -> Result<&'static Self> {

--- a/crates/jni/src/objects/jstack_trace_element.rs
+++ b/crates/jni/src/objects/jstack_trace_element.rs
@@ -10,11 +10,26 @@ crate::bind_java_type! {
         /// Get the method name of the stack trace element.
         fn get_method_name() -> JString,
         /// Check if the stack trace element corresponds with a native method.
-        fn is_native() -> bool,
+        fn is_native_method() -> bool,
         /// Returns a string representation of this stack trace element.
         fn try_to_string {
             name = "toString",
             sig = () -> JString,
         }
+    }
+}
+
+impl<'local> JStackTraceElement<'local> {
+    // In jni 0.22.0 and 0.22.1 we were incorrectly trying to lookup an isNative
+    // method and although it was impossible to call (because this API binding
+    // would fail to initialize) we also exported a public `is_native()` method
+    // that code could potentially have linked against.
+    #[doc(hidden)]
+    #[deprecated(since = "0.22.1", note = "Use `is_native_method` instead")]
+    pub fn is_native<'env_local>(
+        &self,
+        env: &::jni::Env<'env_local>,
+    ) -> ::jni::errors::Result<bool> {
+        self.is_native_method(env)
     }
 }

--- a/crates/jni/src/objects/mod.rs
+++ b/crates/jni/src/objects/mod.rs
@@ -75,3 +75,31 @@ pub use crate::refs::*;
     note = "Please use array elements types under `jni::elements::*` instead of `jni::objects::*`."
 )]
 pub use crate::elements::*;
+
+// Provides a way to validate all our object bindings in a unit test, considering
+// that the `J<Foo>API::get` functions are only exported with `pub(crate)` visibility.
+//
+// If any typos in method names or incorrect method or field signatures will result
+// in a panic here when the binding initialization fails.
+#[doc(hidden)]
+pub fn _test_jni_init(env: &crate::Env, loader: &crate::refs::LoaderContext) {
+    JByteBufferAPI::get(env, loader).expect("Failed to initialize JByteBufferAPI bindings");
+    JClassLoaderAPI::get(env, loader).expect("Failed to initialize JClassLoaderAPI bindings");
+    JClassAPI::get(env, loader).expect("Failed to initialize JClassAPI bindings");
+    JCollectionAPI::get(env, loader).expect("Failed to initialize JCollectionAPI bindings");
+    JIteratorAPI::get(env, loader).expect("Failed to initialize JIteratorAPI bindings");
+    JListAPI::get(env, loader).expect("Failed to initialize JListAPI bindings");
+    JMapAPI::get(env, loader).expect("Failed to initialize JMapAPI bindings");
+    JMapEntryAPI::get(env, loader).expect("Failed to initialize JMapEntryAPI bindings");
+    JObjectArrayAPI::<JString>::get(env, loader)
+        .expect("Failed to initialize JObjectArrayAPI<JString> bindings");
+    JObjectAPI::get(env).expect("Failed to initialize JObjectAPI bindings");
+    JPrimitiveArrayAPI_jboolean::get(env, loader)
+        .expect("Failed to initialize JPrimitiveArrayAPI_jboolean bindings");
+    JSetAPI::get(env, loader).expect("Failed to initialize JSetAPI bindings");
+    JStackTraceElementAPI::get(env, loader)
+        .expect("Failed to initialize JStackTraceElementAPI bindings");
+    JStringAPI::get(env, loader).expect("Failed to initialize JStringAPI bindings");
+    JThreadAPI::get(env, loader).expect("Failed to initialize JThreadAPI bindings");
+    JThrowableAPI::get(env, loader).expect("Failed to initialize JThrowableAPI bindings");
+}

--- a/crates/jni/tests/builtin_bindings.rs
+++ b/crates/jni/tests/builtin_bindings.rs
@@ -1,0 +1,14 @@
+#![cfg(feature = "invocation")]
+
+mod util;
+
+#[test]
+fn test_builtin_bindings() {
+    let jvm = util::jvm();
+
+    jvm.attach_current_thread(|env| -> jni::errors::Result<()> {
+        jni::objects::_test_jni_init(env, &Default::default());
+        Ok(())
+    })
+    .unwrap();
+}


### PR DESCRIPTION
This fixes the binding for `java.lang.StackTraceElement` so that it looks for `isNativeMethod` instead of the non-existent `isNative` method.

This issue wasn't caught by the unit tests because there was no verifiably error-free use of the `StackTraceElement` API. Although there was a test that uses `JThrowable::get_stack_trace()` there was no attempt to check for `StackTraceElement` errors since we would have required a more complex test fixture based on a native method that would have Java stack frames.

This patch adds a very general `test_builtin_bindings` test that calls a `#[doc(hidden)] jni::objects::_test_jni_init()` function that simply calls _all_ of the internal/builtin `J<Foo>API::get()` functions to initialize and validate all `jni-rs` bindings.

(for `JObjectArray` and `JPrimitiveArray` we just pick two arbitrary element types to validate)

This doesn't rely on needing to call any binding methods and is enough to validate that there are no typos in the names of bound methods and that all their signatures are correct.

This catches the mistake with `JStackTraceElement::is_native`, and didn't find any other incorrect bindings.

Addresses: #743
Fixes: #759

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Change is covered by [automated tests](https://github.com/jni-rs/jni-rs/blob/master/CONTRIBUTING.md#tests)
- [x] The [coding guidelines](https://github.com/jni-rs/jni-rs/blob/master/CONTRIBUTING.md#the-code-style) are followed
- [x] Public API has documentation
- [x] User-visible changes are mentioned in the Changelog
- [x] The continuous integration build passes
