### PR TITLE
Catch and Map Internal JNI Exceptions to Errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ Adds bindings for the following `java.lang` errors / exceptions ([#767](https://
 - Removed dependency on `paste` crate ([#752](https://github.com/jni-rs/jni-rs/pull/752))
 - `attach_current_thread*` APIs immediately return `Err(JavaException)` if a Java exception is pending, so they don't have the side effect of clearing exceptions not thrown in the given closure ([#756](https://github.com/jni-rs/jni-rs/pull/756))
 - Removed `proc-macro-crate` dependency from the `jni-macros` crate ([#758](https://github.com/jni-rs/jni-rs/pull/758))
+- All internal use of JNI functions (not general calls into Java code) now catch exceptions and map to `jni::errors::Error` ([#762](https://github.com/jni-rs/jni-rs/pull/762))
 
 ### Fixed
 

--- a/crates/jni/src/elements/auto_elements_critical.rs
+++ b/crates/jni/src/elements/auto_elements_critical.rs
@@ -42,11 +42,14 @@ where
         mode: ReleaseMode,
     ) -> Result<Self> {
         let mut is_copy: jboolean = true;
-        // There are no documented exceptions for GetPrimitiveArrayCritical() but
-        // it may return `NULL`.
 
         let ptr = unsafe {
-            jni_call_only_check_null_ret!(
+            jni_call_with_catch_and_null_check!(
+                catch |env| {
+                    crate::exceptions::JOutOfMemoryError =>
+                        Err(Error::JniCall(JniError::NoMemory)),
+                    else => Err(Error::NullPtr("Unexpected Exception")),
+                },
                 env,
                 v1_2,
                 GetPrimitiveArrayCritical,

--- a/crates/jni/src/macros.rs
+++ b/crates/jni/src/macros.rs
@@ -74,10 +74,18 @@ macro_rules! jni_call_no_post_check_ex {
 
 /// Calls a Env function, then checks for a pending exception
 ///
-/// This only checks for an exception, it doesn't clear the exception and so the
-/// exception will be thrown if the native code returns to the JVM.
+/// This will do a pre-check for pending exceptions to avoid undefined behaviour when calling JNI
+/// functions that are not exception safe.
 ///
-/// Returns `Err` if there is a pending exception after the call.
+/// Note: After the JNI call, this only _checks_ for an exception, it doesn't clear the exception
+/// and so the exception must still be handled (or left to be handled in Java by returning control
+/// to the JVM).
+///
+/// Returns `Err(Error::JavaException)` if there is a pending exception after the call.
+///
+/// Carefully consider whether to use `jni_call_with_catch` instead of this because if the function
+/// throws any exceptions they will not be caught/cleared by this macro (it will just return an
+/// `Err(Error::JavaException)` to notify you of the pending exception that must be handled).
 macro_rules! jni_call_post_check_ex {
     ( $jnienv:expr, $version:tt, $name:ident $(, $args:expr )* ) => ({
         jni_call_no_post_check_ex!($jnienv, $version, $name $(, $args)*).and_then(|ret| {
@@ -92,8 +100,19 @@ macro_rules! jni_call_post_check_ex {
 
 /// Calls a Env function, then checks for a pending exception, then checks for a `null` return value
 ///
-/// Returns `Err` if there is a pending exception after the call.
-/// Returns `Err(Error::NullPtr)` if the JNI function returns `null`
+/// This will do a pre-check for pending exceptions to avoid undefined behaviour when calling JNI
+/// functions that are not exception safe.
+///
+/// Note: After the JNI call, this only _checks_ for an exception, it doesn't clear the exception
+/// and so the exception must still be handled (or left to be handled in Java by returning control
+/// to the JVM).
+///
+/// Returns `Err(Error::JavaException)` if there is a pending exception after the call. Returns
+/// `Err(Error::NullPtr)` if the JNI function returns `null`
+///
+/// Carefully consider whether to use `jni_call_with_catch` instead of this because if the function
+/// throws any exceptions they will not be caught/cleared by this macro (it will just return an
+/// `Err(Error::JavaException)` to notify you of the pending exception that must be handled).
 macro_rules! jni_call_post_check_ex_and_null_ret {
     ( $jnienv:expr, $version:tt, $name:ident $(, $args:expr )* ) => ({
         jni_call_post_check_ex!($jnienv, $version, $name $(, $args)*).and_then(|ret| {
@@ -113,6 +132,10 @@ macro_rules! jni_call_post_check_ex_and_null_ret {
 /// when calling JNI functions that are not exception safe.
 ///
 /// Returns `Err(Error::NullPtr)` if the JNI function returns `null`
+///
+/// Carefully consider whether to use `jni_call_with_catch` instead of this because if the function
+/// throws any exceptions they will not be caught/cleared by this macro (it will just return an
+/// `Err(Error::JavaException)` to notify you of the pending exception that must be handled).
 macro_rules! jni_call_only_check_null_ret {
     ( $jnienv:expr, $version:tt, $name:ident $(, $args:expr )* ) => ({
         jni_call_no_post_check_ex!($jnienv, $version, $name $(, $args)*).and_then(|ret| {
@@ -123,6 +146,212 @@ macro_rules! jni_call_only_check_null_ret {
             }
         })
     })
+}
+
+/// Helper for building an exception-handler chain based on `catch {}` patterns
+///
+/// Each entry has the form `<path> => <expr>`, matched in order via
+/// `<ExType>::matches()`. A required terminal `else => <expr>` entry acts as
+/// a catch-all: its expression is evaluated unconditionally for any exception that
+/// was not claimed by an earlier handler.
+macro_rules! __jni_match_exceptions {
+    // Empty catch block
+    ($env:expr, $ex:expr $(,)?) => {
+        compile_error!("Missing 'else' expression in catch block")
+    };
+    // `else => expr` (with optional trailing comma) - unconditional
+    // fallback. Must be checked before the `$ex_type:path` arms so `else`
+    // isn't just matched as a `:path`
+    ($env:expr, $ex:expr, else => $ex_result:expr $(,)?) => {
+        $ex_result
+    };
+    // Single typed handler (with optional trailing comma) - implies a missing
+    // 'else' expression in the catch block
+    ($env:expr, $ex:expr, $ex_type:path => $ex_result:expr $(,)?) => {
+        compile_error!("Missing 'else' expression in catch block")
+    };
+    // Check the next exception type (with an unbound '_' name for the `Cast`
+    // exception) and then recursively check remaining patterns in the `catch
+    // {}` block (terminating at `else`)
+    ($env:expr, $ex:expr, $ex_type:path => $ex_result:expr, $($rest:tt)+) => {
+        if let Some(_) = <$ex_type>::matches($env, &$ex)? {
+            $ex_result
+        } else {
+            __jni_match_exceptions!($env, $ex, $($rest)+)
+        }
+    };
+    // Check the next exception type (with a given name for the `Cast`
+    // exception) and then recursively check remaining patterns in the `catch
+    // {}` block (terminating at `else`)
+    ($env:expr, $ex:expr, $ex_name:ident: $ex_type:path => $ex_result:expr, $($rest:tt)+) => {
+        if let Some($ex_name) = <$ex_type>::matches($env, &$ex)? {
+            $ex_result
+        } else {
+            __jni_match_exceptions!($env, $ex, $($rest)+)
+        }
+    };
+}
+
+/// Calls a Env function, then catches (checks + clears) any pending exception
+///
+/// This macro takes a `catch |env| {}` block that specifies how all possible
+/// exceptions should be mapped to `Result` values:
+///
+/// ```ignore
+/// jni_call_with_catch!(
+///     catch |env| {
+///         ExceptionType1 => Err(Error::Type1),
+///         exception: ExceptionType2 => {
+///             let cause = exception.get_cause(env)?;
+///             let cause = env.new_global_ref(cause)?;
+///             Err(Error::Type2(cause))
+///         },
+///         // required catch-all
+///         else => Err(Error::JniCall(JniError::Unknown)),
+///     },
+///     env, version, FunctionName, args...
+/// )
+/// ```
+/// The exception is always cleared before matching or evaluating any handler
+/// expression.
+///
+/// Any exception thrown by the JNI function is matched against the exception
+/// types in order (via its `::matches` method, which will also `Cast` the
+/// exception if it does match).
+///
+/// The expression of the first matching handler is returned as the `Result`
+/// value.
+///
+/// A required `else => expr` entry at the end acts as a catch-all for any
+/// exception not claimed by a typed handler.
+///
+/// When an exception is matched then it will also be `Cast` to the matched
+/// exception type and can be given a name that is accessible to right-hand
+/// expression (e.g. `exception_name: ExceptionType => { ... }`).
+///
+/// Note: The catch expressions always have access to an `env: &mut Env`
+/// reference (regardless of whether the initial `Env` reference passed to the
+/// macro was mutable) - since the mapping is always done within a
+/// `with_local_frame` closure. This `env` reference is named based on the
+/// `catch |env|` syntax in the macro invocation.
+macro_rules! jni_call_with_catch {
+    ( catch |$env_mut:ident| { $($ex_handlers:tt)* }, $jnienv:expr, $version:tt, $name:ident $(, $args:expr )* ) => ({
+        // Wrap everything in a closure so we can use '?' without causing a
+        // surprising return from the _callers_ function.
+        $crate::__must_use((|| -> $crate::errors::Result<_> {
+            // The only `Err` we expect here is `Error::JavaException` in case
+            // there is already a pending exception
+            let ret = jni_call_no_post_check_ex!($jnienv, $version, $name $(, $args)*) ?;
+            if $jnienv.exception_check() {
+                // Get a `&mut Env` we can use while mapping the exception to a `Result`
+                $jnienv.with_local_frame(
+                    $crate::DEFAULT_LOCAL_FRAME_CAPACITY,
+                    |$env_mut| -> $crate::errors::Result<_> {
+                        let e = $env_mut
+                            .exception_occurred()
+                            .expect("Expected an exception after ExceptionCheck");
+                        $env_mut.exception_clear();
+                        __jni_match_exceptions!($env_mut, e, $($ex_handlers)*)
+                    },
+                )
+            } else {
+                Ok(ret)
+            }
+        })())
+    });
+}
+
+/// Calls a Env function, then catches (checks + clears) any pending exception, then checks for null
+///
+/// This behaves the same as `jni_call_with_catch!`, but additionally checks if the result is null
+/// and returns `Err(Error::NullPtr)` in that case.
+///
+/// Use this when a `null` return value represents an error condition and `null` may be returned
+/// without any exception being thrown.
+macro_rules! jni_call_with_catch_and_null_check {
+    ( catch |$env_mut:ident| { $($ex_handlers:tt)* }, $jnienv:expr, $version:tt, $name:ident $(, $args:expr )* ) => ({
+        jni_call_with_catch! {
+            catch |$env_mut| { $($ex_handlers)* },
+            $jnienv,
+            $version,
+            $name $(, $args)*
+        }.and_then(|ret| {
+            if ret.is_null() {
+                Err($crate::errors::Error::NullPtr(concat!(stringify!($name), " result")))
+            } else {
+                Ok(ret)
+            }
+        })
+    });
+}
+
+/// Wrap a block of JNI code into a closure and then catch and handle exceptions
+/// after running
+///
+/// This macro takes a try block of code to run followed by a `catch |env| {}`
+/// block that specifies how all possible exceptions should be mapped to
+/// `Result` values:
+///
+/// ```ignore
+/// jni_try!(
+///     (env) -> ResultType {
+///         // JNI code here
+///     },
+///     catch |env| {
+///         ExceptionType1 => Err(Error::Type1),
+///         exception: ExceptionType2 => {
+///             let cause = exception.get_cause(env)?;
+///             let cause = env.new_global_ref(cause)?;
+///             Err(Error::Type2(cause))
+///         },
+///         // required catch-all
+///         else => Err(Error::JniCall(JniError::Unknown)),
+///     },
+/// )
+/// ```
+///
+/// The exception is always cleared before matching or evaluating any handler
+/// expression.
+///
+/// Any exception thrown is matched against the exception types in order (via
+/// its `::matches` method, which will also `Cast` the exception if it does
+/// match).
+///
+/// The expression of the first matching handler is returned as the `Result`
+/// value.
+///
+/// A required `else => expr` entry at the end acts as a catch-all for any
+/// exception not claimed by a typed handler.
+///
+/// When an exception is matched then it will also be `Cast` to the matched
+/// exception type and can be given a name that is accessible to right-hand
+/// expressions (e.g. `exception_name: ExceptionType => { ... }`).
+///
+/// Note: The catch expressions always have access to an `env: &mut Env`
+/// reference (regardless of whether the initial `Env` reference passed to the
+/// macro was mutable) - since the mapping is always done within a
+/// `with_local_frame` closure. This `env` reference is named based on the
+/// `catch |env|` syntax in the macro invocation.
+macro_rules! jni_try {
+    ( ($jnienv:expr) -> $ret_ty:ty { $($jni_code:tt)* } catch |$env_mut:ident| { $($ex_handlers:tt)* }) => ({
+        // Wrap everything in a closure so any use of '?' can't return from the encompassing function.
+        let ret = (|| -> $ret_ty {$($jni_code)*})();
+        if $jnienv.exception_check() {
+            // Get a `&mut Env` we can use while mapping the exception to a `Result`
+            $jnienv.with_local_frame(
+                $crate::DEFAULT_LOCAL_FRAME_CAPACITY,
+                |$env_mut| -> $ret_ty {
+                    let e = $env_mut
+                        .exception_occurred()
+                        .expect("Expected an exception after ExceptionCheck");
+                    $env_mut.exception_clear();
+                    __jni_match_exceptions!($env_mut, e, $($ex_handlers)*)
+                },
+            )
+        } else {
+            ret
+        }
+    });
 }
 
 /// Maps a pointer to either Ok(ptr) or Err(Error::NullPtr)
@@ -156,4 +385,140 @@ macro_rules! java_vm_call_unchecked {
         let jvm: *mut jni_sys::JavaVM = $jvm.get_raw();
         ((*(*jvm)).$version.$name)(jvm $(, $args)*)
     }};
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{
+        errors::{Error, JniError},
+        objects::JThrowable,
+    };
+
+    /// Smoke test that some example usage of `jni_call_with_catch_and_null_check!` compiles.
+    ///
+    /// `name` and `sig` represent the method/field name and descriptor that would be in scope when
+    /// calling a lookup JNI function.
+    ///
+    /// This tries to test plausible mappings for all the exception types we have bindings for.
+    fn _compile_test_jni_call_with_catch_and_null_check(
+        env: &mut crate::Env<'_>,
+        name: &crate::strings::JNIStr,
+        sig: &crate::strings::JNIStr,
+    ) -> crate::errors::Result<crate::sys::jclass> {
+        unsafe {
+            jni_call_with_catch_and_null_check!(
+                catch |env| {
+                    crate::exceptions::JOutOfMemoryError =>
+                        Err(Error::JniCall(JniError::NoMemory)),
+
+                    crate::exceptions::JClassFormatError =>
+                        Err(Error::ClassFormatError),
+
+                    crate::exceptions::JClassCircularityError =>
+                        Err(Error::ClassCircularityError),
+
+                    e: crate::exceptions::JClassNotFoundException => {
+                        let cause: &JThrowable = &e.as_throwable();
+                        let cause = env.new_global_ref(cause).ok();
+                        Err(Error::NoClassDefFound {
+                            requested: name.to_string(),
+                            cause
+                        })
+                    },
+                    e: crate::exceptions::JNoClassDefFoundError => {
+                        let cause: &JThrowable = &e.as_throwable();
+                        let cause = env.new_global_ref(cause).ok();
+                        Err(Error::NoClassDefFound {
+                            requested: name.to_string(),
+                            cause
+                        })
+                    },
+
+                    e: crate::exceptions::JExceptionInInitializerError => {
+                        let exception = e.get_exception(env);
+                        let exception = if let Ok(exception) = exception {
+                            env.new_global_ref(exception).ok()
+                        } else {
+                            None
+                        };
+                        Err(Error::ExceptionInInitializer { exception })
+                    },
+
+                    crate::exceptions::JNoSuchMethodError =>
+                        Err(Error::MethodNotFound {
+                            name: name.to_string(),
+                            sig: sig.to_string(),
+                        }),
+
+                    crate::exceptions::JNoSuchFieldError =>
+                        Err(Error::FieldNotFound {
+                            name: name.to_string(),
+                            sig: sig.to_string(),
+                        }),
+
+                    crate::exceptions::JArrayStoreException =>
+                        Err(Error::WrongObjectType),
+
+                    crate::exceptions::JIllegalArgumentException =>
+                        Err(Error::JniCall(JniError::InvalidArguments)),
+
+                    crate::exceptions::JIllegalMonitorStateException =>
+                        Err(Error::IllegalMonitorState),
+
+                    e: crate::exceptions::JLinkageError => {
+                        let cause: &JThrowable = &e.as_throwable();
+                        let cause = env.new_global_ref(cause).ok();
+                        Err(Error::LinkageError {
+                            requested: name.to_string(),
+                            cause
+                        })
+                    },
+
+                    crate::exceptions::JSecurityException =>
+                        Err(Error::SecurityViolation),
+
+                    crate::exceptions::JArrayIndexOutOfBoundsException =>
+                        Err(Error::IndexOutOfBounds),
+
+                    crate::exceptions::JStringIndexOutOfBoundsException =>
+                        Err(Error::IndexOutOfBounds),
+
+                    crate::exceptions::JInstantiationException =>
+                        Err(Error::Instantiation),
+
+                    crate::exceptions::JNumberFormatException =>
+                        Err(Error::ParseFailed(String::new())),
+
+                    else => Err(Error::NullPtr("Unexpected Exception"))
+                    //else => Err(Error::JniCall(JniError::Unknown))
+                },
+                env,
+                v1_1,
+                FindClass,
+                core::ptr::null()
+            )
+        }
+    }
+
+    fn _compile_test_jni_try(env: &mut crate::Env<'_>) -> crate::errors::Result<()> {
+        let _res = jni_try! {
+            (env) -> crate::errors::Result<crate::objects::JString> {
+                let s = env.new_string("String")?;
+
+                {
+                    let msg = env.new_string("Test")?;
+                    let e = crate::exceptions::JNumberFormatException::new(env, msg)?;
+                    let e: crate::objects::JThrowable = e.into();
+                    env.throw(e)?;
+                }
+
+                Ok(s)
+            } catch |env| {
+                crate::exceptions::JNumberFormatException => Err(Error::ParseFailed(String::new())),
+                else => Err(Error::NullPtr("Test"))
+            }
+        }?;
+
+        Ok(())
+    }
 }

--- a/crates/jni/src/objects/jprimitive_array.rs
+++ b/crates/jni/src/objects/jprimitive_array.rs
@@ -311,21 +311,31 @@ impl<'local, T: TypeArray> JPrimitiveArray<'local, T> {
         AutoElementsCritical::new(env, self, mode)
     }
 
-    /// Copy elements of the array from the `start` index to the
-    /// `buf` slice. The number of copied elements is equal to the `buf` length.
+    /// Copy elements of the array from the `start` index to the `buf` slice.
+    /// The number of copied elements is equal to the `buf` length.
     ///
     /// # Errors
-    /// If `start` is negative _or_ `start + buf.len()` is greater than [`array.length`]
-    /// then no elements are copied, an `ArrayIndexOutOfBoundsException` is thrown,
-    /// and `Err` is returned.
     ///
-    /// [`array.length`]: struct.Env.html#method.get_array_length
+    /// Returns [Error::IndexOutOfBounds] if `start` is negative _or_ `start +
+    /// buf.len()` is greater than [`Self::len`].
+    ///
+    /// This API catches exceptions internally and is not expected to return
+    /// [`Error::JavaException`] (unless called while there is a pending
+    /// exception).
     pub fn get_region(&self, env: &Env, start: crate::sys::jsize, buf: &mut [T]) -> Result<()> {
         unsafe { T::get_region(env, self.as_raw() as jarray, start, buf) }
     }
 
     /// Copy the contents of the `buf` slice to the java byte array at the
     /// `start` index.
+    ///
+    /// # Errors
+    ///
+    /// Returns [Error::IndexOutOfBounds] if `start` is negative _or_ `start +
+    /// buf.len()` is greater than [`Self::len`].
+    ///
+    /// This API catches exceptions internally and is not expected to return
+    /// [`Error::JavaException`] (unless called while there is a pending exception).
     pub fn set_region(&self, env: &Env, start: crate::sys::jsize, buf: &[T]) -> Result<()> {
         unsafe { T::set_region(env, self.as_raw() as jarray, start, buf) }
     }

--- a/crates/jni/tests/exception_safe_calls.rs
+++ b/crates/jni/tests/exception_safe_calls.rs
@@ -130,6 +130,74 @@ fn test_get_field_id_exception_side_effects() {
 }
 
 #[test]
+fn test_find_class_exception_side_effects() {
+    let jvm = util::jvm();
+
+    jvm.attach_current_thread(|env| -> jni::errors::Result<()> {
+        let res = env.find_class(jni::jni_str!("java/lang/string")); // typo of `String`
+        println!("result = {:?}", res);
+        match res {
+            Err(jni::errors::Error::NoClassDefFound { .. }) => {
+                assert!(
+                    !env.exception_check(),
+                    "Expected no pending exception with NoClassDefFound error"
+                );
+                println!("Got NoClassDefFound error as expected");
+            }
+            Err(jni::errors::Error::JavaException) => {
+                assert!(env.exception_check());
+                env.exception_describe();
+                panic!("Expected NoClassDefFound error for find_class failure");
+            }
+            _ => {
+                assert!(
+                    !env.exception_check(),
+                    "Spurious pending exception without JavaException error"
+                );
+                panic!("Expected NoClassDefFound error for find_class failure");
+            }
+        }
+
+        Ok(())
+    })
+    .unwrap();
+}
+
+#[test]
+fn test_load_class_exception_side_effects() {
+    let jvm = util::jvm();
+
+    jvm.attach_current_thread(|env| -> jni::errors::Result<()> {
+        let res = env.load_class(jni::jni_str!("java/lang/string")); // typo of `String`
+        println!("result = {:?}", res);
+        match res {
+            Err(jni::errors::Error::NoClassDefFound { .. }) => {
+                assert!(
+                    !env.exception_check(),
+                    "Expected no pending exception with NoClassDefFound error"
+                );
+                println!("Got NoClassDefFound error as expected");
+            }
+            Err(jni::errors::Error::JavaException) => {
+                assert!(env.exception_check());
+                env.exception_describe();
+                panic!("Expected NoClassDefFound error for load_class failure");
+            }
+            _ => {
+                assert!(
+                    !env.exception_check(),
+                    "Spurious pending exception without JavaException error"
+                );
+                panic!("Expected NoClassDefFound error for load_class failure");
+            }
+        }
+
+        Ok(())
+    })
+    .unwrap();
+}
+
+#[test]
 fn test_global_drop_no_exception_side_effects() {
     let jvm = util::jvm();
 

--- a/crates/jni/tests/jni_api.rs
+++ b/crates/jni/tests/jni_api.rs
@@ -1738,13 +1738,18 @@ pub fn throw_new_non_throwable_class() {
 #[test]
 pub fn throw_new_fail() {
     attach_current_thread(|env| {
+        // Note: this isn't a great test because it's really just testing
+        // what error we get from `Desc<JClass>::lookup` when looking up
+        // an invalid class - it doesn't really have anything to do with
+        // making a `ThrowNew` JNI call.
         let result = env.throw_new(
             jni_str!("java/lang/NonexistentException"),
             jni_str!("Test Exception"),
         );
         assert!(result.is_err());
-        // Just to clear the java.lang.NoClassDefFoundError
-        assert_pending_java_exception(env);
+        eprintln!("result = {:?}", result);
+
+        assert!(matches!(result, Err(Error::NoClassDefFound { .. })));
 
         Ok(())
     })


### PR DESCRIPTION
_Just as a brief clarification; up until now `jni-rs` would handle exceptions (broadly speaking) by checking for thrown exceptions and reporting them as Rust errors via `Error::JavaException`, and then it was your responsibility to take and clear the exception before continuing (or return to Java)._

_This is a very hands-off approach that takes a lot of effort to handle correctly and reliably because practically *any* `jni` method could throw an exception that you might need to handle before calling another `jni` method._

This PR is trying to reduce the burden on developers checking for exceptions, so that they only need to expect exceptions when code is calling into Java (such as when constructing objects or calling methods).

This makes it so that all of the lower-level JNI function bindings will catch their exceptions internally and report these as plain `jni::errors::Error` enum variants, with no extra need to check and clear an exception.

The API is still the same in the sense that `Error::JavaException` is how `jni-rs` indicates that you need to handle a pending exception, but for most lower-level APIs you can now assume that you'll never get back an `Error::JavaException` (and the documentation has been updated to clarify when this can be assumed).

# New `Error` variants

Firstly, this adds `Error`s to cover all internally-caught exceptions

The new variants ensure we can map any exceptions we catch internally into a `jni::errors::Error` result.

# Internal `catch |env| {}` macros

This adds a `jni_call_with_catch` macro to catch internal exceptions, making it practical to match exception types and map then to `Error` values, like this:

```rust
jni_call_with_catch_and_null_check!(
    catch |env| {
        crate::exceptions::JClassFormatError =>
            Err(Error::ClassFormatError),
        crate::exceptions::JClassCircularityError =>
            Err(Error::ClassCircularityError),
        crate::exceptions::JOutOfMemoryError =>
            Err(Error::JniCall(JniError::NoMemory)),
        crate::exceptions::JSecurityException =>
            Err(Error::SecurityViolation),
        else => Err(Error::NullPtr("Unexpected Exception")),
    },
    self,
    v1_1,
    DefineClass,
    name,
    loader.as_raw(),
    buf,
    buf_len as jsize
)
```

A similar `jni_call_with_catch_and_null_check` additionally maps `null` return values to `Error::NullPtr` (in case no exception was caught).

A more-general `jni_try!` macro can be used to wrap arbitrary blocks of JNI code in a closure and use the same `catch |env| {}` syntax for matching and mapping exceptions to `Error` results, like this:

```rust
jni_try!(
    (env) -> ResultType {
        // JNI code here
    },
    catch |env| {
        ExceptionType1 => Err(Error::Type1),
        exception: ExceptionType2 => {
            let cause = exception.get_cause(env)?;
            let cause = env.new_global_ref(cause)?;
            Err(Error::Type2(cause))
        },
        // required catch-all
        else => Err(Error::JniCall(JniError::Unknown)),
    },
)
```

In particular this is used in the implementation of `LoaderContext`.

# Audit of all JNI calls that may throw exceptions

This change audits all of the internal JNI calls and adds explicit capturing and clearing of exceptions so they can be mapped to more-precise errors than `Error::JavaException` and so there is less burden on developers to have to handle exceptions manually.

In this context "internal" JNI calls are defined as calls that don't intentionally invoke arbitrary Java code - such as `Call*` or `NewObject` functions.

With this change, developers should be able to assume that most lower-level JNI `Env` methods (not involving arbitrary Java binding method calls) will not return with a pending exception and `Error::JavaException` result.

Updated methods now explicitly document that they catch exceptions internally and clarify what kinds of `Error`s may be returned in different circumstances.

# Catching exceptions in LoaderContext

The `LoaderContext` changes deserve a special mention here because, unlike other APIs that may directly map to a single JNI function (such as `FindClass`, the `LoaderContext::load_class` implementation is itself based on various `jni::objects::` method bindings (which can still throw exceptions).

Although the implementation had already attempted to catch exceptions internally, there was an oversight and the `::find_class()` fallback didn't catch exceptions.

This PR has made a much-more-rigorous update to this code to use the internal `jni_try!` macro and it has also ensured there is consistency between `Env::find_class` and `Env::load_class` +
`LoaderContext::load_class` with how exceptions are mapped to errors.

Note: from a documentation POV this looks like a breaking change because the documentation now makes it clear that these APIs return `Error::NoClassDefFound` if no class could be loaded, where as before `find_class` suggested it would return `NullPtr` and `load_class` suggested it would return `ClassNotFound` but in practice the previous documentation was incorrect in both cases because they would most likely just return `Error::JavaException`.

The newly added `Error::NoClassDefFound` matches the `NoClassDefFoundError` that `FindClass` typically throws on failure, and for consistency `load_class` will map any lower-level `ClassNotFoundException` from the loader into a `NoClassDefFoundError` similar to what `FindClass` does. In either case, the original exception is also preserved in the Rust error as the `cause`, in case more details are needed.

Fixes: #761
Addresses: #744

## Audit Log

These are the JNI APIs that the spec says can throw exceptions (and which we use in `jni-rs`) which this PR has audited and updated to ensure they catch exceptions and map them to an `Error` instead of returning `Error::JavaException`:

- [x] `DefineClass`
  - **Returns:** Returns a Java class object or `NULL` if an error occurs.
  - **Throws:**
    - `ClassFormatError`: if the class data does not specify a valid class.
    - `ClassCircularityError`: if a class or interface would be its own superclass or superinterface.
    - `OutOfMemoryError`: if the system runs out of memory.
    - `SecurityException`: if the caller attempts to define a class in the `"java"` package tree.
  - **Status:** Handled (jni_call_with_catch_and_null_check)

- [x] `FindClass`
  - **Returns:** Returns a class object from a fully-qualified name, or `NULL` if the class cannot be found.
  - **Throws:**
    - `ClassFormatError`: if the class data does not specify a valid class.
    - `ClassCircularityError`: if a class or interface would be its own superclass or superinterface.
    - `NoClassDefFoundError`: if no definition for a requested class or interface can be found.
    - `OutOfMemoryError`: if the system runs out of memory.
  - **Status:** Handled (jni_call_with_catch_and_null_check)

- [x] `NewWeakGlobalRef`
  - **Returns:** Return a global weak reference to the given `obj`.
  - **Throws:**
    - `OutOfMemoryError`: if the system runs out of memory.
  - **Status:** Handled (jni_call_with_catch)

- [x] `AllocObject`
  - **Returns:** Returns a Java object, or `NULL` if the object cannot be constructed.
  - **Throws:**
    - `InstantiationException`: if the class is an interface or an abstract class.
    - `OutOfMemoryError`: if the system runs out of memory.
  - **Status:** Handled (jni_call_with_catch_and_null_check)

- [x] `GetFieldID`
  - **Returns:** Returns a field ID, or `NULL` if the operation fails.
  - **Throws:**
    - `NoSuchFieldError`: if the specified field cannot be found.
    - `ExceptionInInitializerError`: if the class initializer fails due to an exception.
    - `OutOfMemoryError`: if the system runs out of memory.
  - **Status:** Handled (jni_call_with_catch)

- [x] `GetMethodID`
  - **Returns:** Returns a method ID, or `NULL` if the specified method cannot be found.
  - **Throws:**
    - `NoSuchMethodError`: if the specified method cannot be found.
    - `ExceptionInInitializerError`: if the class initializer fails due to an exception.
    - `OutOfMemoryError`: if the system runs out of memory.
  - **Status:** Handled (jni_call_with_catch)

- [x] `GetStaticFieldID`
  - **Returns:** Returns a field ID, or `NULL` if the specified static field cannot be found.
  - **Throws:**
    - `NoSuchFieldError`: if the specified static field cannot be found.
    - `ExceptionInInitializerError`: if the class initializer fails due to an exception.
    - `OutOfMemoryError`: if the system runs out of memory.
  - **Status:** Handled (jni_call_with_catch)

- [x] `GetStaticMethodID`
  - **Returns:** Returns a method ID, or `NULL` if the operation fails.
  - **Throws:**
    - `NoSuchMethodError`: if the specified static method cannot be found.
    - `ExceptionInInitializerError`: if the class initializer fails due to an exception.
    - `OutOfMemoryError`: if the system runs out of memory.
  - **Status:** Handled (jni_call_with_catch)

- [x] `NewStringUTF`
  - **Returns:** Returns a Java string object, or `NULL` if the string cannot be constructed.
  - **Throws:**
    - `OutOfMemoryError`: if the system runs out of memory.
  - **Status:** Handled (jni_call_with_catch_and_null_check)

- [x] `NewObjectArray`
  - **Returns:** Returns a Java array object, or `NULL` if the array cannot be constructed.
  - **Throws:**
    - `OutOfMemoryError`: if the system runs out of memory.
  - **Status:** Handled (jni_call_with_catch_and_null_check) (correctly treats null as an error now)

- [x] `GetObjectArrayElement`
  - **Returns:** Returns a Java object.
  - **Throws:**
    - `ArrayIndexOutOfBoundsException`: if `index` does not specify a valid index in the array.
  - **Status:** Handled (jni_call_with_catch)

- [x] `SetObjectArrayElement`
  - **Returns:** None (void).
  - **Throws:**
    - `ArrayIndexOutOfBoundsException`: if `index` does not specify a valid index in the array.
    - `ArrayStoreException`: if the class of `value` is not a subclass of the element class of the array.
  - **Status:** Handled (jni_call_with_catch)

- [x] `New<Boolean|Byte|Char|Short|Int|Long|Float|Double>Array`
  - **Returns:** Returns a Java array, or `NULL` if the array cannot be constructed.
  - **Throws:**
    - `OutOfMemoryError`: if the system runs out of memory.
  - **Status:** Handled (jni_call_with_catch_and_null_check)

- [x] `Get<Boolean|Byte|Char|Short|Int|Long|Float|Double>ArrayElements`
  - **Returns:** Returns a pointer to the array elements, or `NULL` if the operation fails.
  - **Throws:**
    - `OutOfMemoryError`: if the system runs out of memory.
  - **Status:** Handled (jni_call_with_catch_and_null_check)

- [x] `Get<Boolean|Byte|Char|Short|Int|Long|Float|Double>ArrayRegion`
  - **Returns:** None (void).
  - **Throws:**
    - `ArrayIndexOutOfBoundsException`: if one of the indexes in the region is not valid.
  - **Status:** Handled (jni_call_with_catch)

- [x] `Set<Boolean|Byte|Char|Short|Int|Long|Float|Double>ArrayRegion`
  - **Returns:** None (void).
  - **Throws:**
    - `ArrayIndexOutOfBoundsException`: if one of the indexes in the region is not valid.
  - **Status:** Handled (jni_call_with_catch)

- [x] `GetPrimitiveArrayCritical`
  - **Returns:** Returns a pointer to the array elements, or `NULL` if the operation fails.
  - **Throws:**
    - `OutOfMemoryError`: if the system runs out of memory.
  - **Status:** Handled (jni_call_with_catch_and_null_check)

- [x] `RegisterNatives`
  - **Returns:** Returns `"0"` on success; returns a negative value on failure.
  - **Throws:**
    - `NoSuchMethodError`: if a specified method cannot be found or if the method is not native.
  - **Status:** Handled (jni_call_with_catch)

- [x] `MonitorExit`
  - **Returns:** Returns `"0"` on success; returns a negative value on failure.
  - **Throws:**
    - `IllegalMonitorStateException`: if the current thread does not own the monitor.
  - **Status:** Handled - `IllegalMonitorStateException` isn't possible because `MonitorGuard` is not `Send`

- [x] `NewDirectByteBuffer`
  - **Returns:** Returns a local reference to the newly-instantiated `java.nio.ByteBuffer` object; returns `NULL` if an exception occurs, or if JNI direct-buffer access is not supported by this VM.
  - **Throws:**
    - `IllegalArgumentException`: if `capacity` is negative or greater than `Integer.MAX_VALUE`.
    - `OutOfMemoryError`: if allocation of the `ByteBuffer` object fails.
  - **Status:** Handled (jni_call_with_catch_and_null_check)

Checking whether we need to update `jni-macros` to automatically catch exceptions I double checked which JNI functions `bind_java_type` calls directly and none of them are affected by this:
- `IsAssignableFrom` - doesn't throw exceptions
- `NewObjectA` - we don't want to automatically catch constructor exceptions
- `Call[Static]<Type>MethodA` - we don't want to automatically catch method exceptions
- `Get[Static]<Type>Field` - doesn't throw exceptions

A special-case that was also reviewed closely was the `LoaderContext::load_class` implementation.

`load_class` internally calls a number of other binding methods (such as `JThread::current_thread` and `JThread::get_context_class_loader`) and since these are regular Java methods they can throw exceptions, which in turn means that `load_class` can throw exceptions.

This PR has updated the `LoaderContext` to use an internal `jni_try!` macro as documented earlier.

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Change is covered by [automated tests](https://github.com/jni-rs/jni-rs/blob/master/CONTRIBUTING.md#tests)
- [x] The [coding guidelines](https://github.com/jni-rs/jni-rs/blob/master/CONTRIBUTING.md#the-code-style) are followed
- [x] Public API has documentation
- [x] User-visible changes are mentioned in the Changelog
- [x] The continuous integration build passes
