### PR TITLE
Add bindings for various exceptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+Adds bindings for the following `java.lang` errors / exceptions ([#767](https://github.com/jni-rs/jni-rs/pull/767)):
+- `JArrayIndexOutOfBoundsException` (`java.lang.ArrayIndexOutOfBoundsException`)
+- `JArrayStoreException` (`java.lang.ArrayStoreException`)
+- `JClassCircularityError` (`java.lang.ClassCircularityError`)
+- `JClassFormatError` (`java.lang.ClassFormatError`)
+- `JExceptionInInitializerError` (`java.lang.ExceptionInInitializerError`)
+- `JClassNotFoundException` (`java.lang.ClassNotFoundException`)
+- `JIllegalArgumentException` (`java.lang.IllegalArgumentException`)
+- `JIllegalMonitorStateException` (`java.lang.IllegalMonitorStateException`)
+- `JInstantiationException` (`java.lang.InstantiationException`)
+- `JLinkageError` (`java.lang.LinkageError`)
+- `JNoClassDefFoundError` (`java.lang.NoClassDefFoundError`)
+- `JNoSuchFieldError` (`java.lang.NoSuchFieldError`)
+- `JNoSuchMethodError` (`java.lang.NoSuchMethodError`)
+- `JNumberFormatException` (`java.lang.NumberFormatException`)
+- `JOutOfMemoryError` (`java.lang.OutOfMemoryError`)
+- `JRuntimeException` (`java.lang.RuntimeException`)
+- `JSecurityException` (`java.lang.SecurityException`)
+- `JStringIndexOutOfBoundsException` (`java.lang.StringIndexOutOfBoundsException`)
+
 ### Changed
 
 - Removed dependency on `paste` crate ([#752](https://github.com/jni-rs/jni-rs/pull/752))

--- a/crates/jni/src/env.rs
+++ b/crates/jni/src/env.rs
@@ -767,7 +767,7 @@ See the jni-rs Env documentation for more details.
     // Desc for the class and doesn't need a mutable Env reference since it never
     // needs to allocate a new local reference.
     /// Returns true if the object reference can be cast to the given type.
-    fn is_instance_of_class<'other_local_1, 'other_local_2, O, C>(
+    pub(crate) fn is_instance_of_class<'other_local_1, 'other_local_2, O, C>(
         &self,
         object: O,
         class: C,

--- a/crates/jni/src/exceptions.rs
+++ b/crates/jni/src/exceptions.rs
@@ -1,0 +1,180 @@
+#[cfg(doc)]
+use crate::errors::Error;
+
+macro_rules! bind_exception {
+    ($rust_type:ident => $java_type:literal $($rest:tt)*) => {
+        $crate::bind_java_type! {
+            pub $rust_type => $java_type,
+            is_instance_of = {
+                throwable: JThrowable
+            }
+            $($rest)*
+        }
+
+        impl<'local> $rust_type<'local> {
+            /// Checks if the given throwable is an instance of this exception type.
+            ///
+            #[doc = concat!("Returns `Some(Cast<", stringify!($rust_type), ">)` if the throwable is an instance of this exception type")]
+            /// or returns `None` if it is not.
+            ///
+            /// Returns [Error::NullPtr] if the throwable is null.
+            pub fn matches<'any, 'from>(
+                env: &crate::Env,
+                throwable: &'from crate::objects::JThrowable<'any>,
+            ) -> $crate::errors::Result<Option<$crate::refs::Cast<'any, 'from, $rust_type<'any>>>>
+            {
+                if throwable.is_null() {
+                    return Err($crate::errors::Error::NullPtr("Invalid null Throwable"));
+                }
+                let class = <$rust_type as $crate::refs::Reference>::lookup_class(
+                    env,
+                    &Default::default(),
+                )?;
+                let class: &$crate::objects::JClass = &class;
+                if env.is_instance_of_class(throwable, class)? {
+                    return Ok(Some(unsafe {
+                        $crate::refs::Cast::new_unchecked(throwable)
+                    }));
+                } else {
+                    return Ok(None);
+                }
+            }
+        }
+    };
+}
+
+/// Binds a simple exception that just has a void constructor and message constructor
+macro_rules! bind_basic_exception {
+    ($rust_type:ident => $java_type:literal $($rest:tt)*) => {
+        bind_exception! {
+            $rust_type => $java_type,
+            constructors {
+                /// Construct without any message
+                fn new_null(),
+                /// Construct with a message
+                fn new(msg: JString),
+            }
+            $($rest)*
+        }
+    };
+}
+
+bind_exception! {
+    JArrayIndexOutOfBoundsException => "java.lang.ArrayIndexOutOfBoundsException",
+    constructors {
+        /// Construct without any message
+        fn new_null(),
+        /// Construct with a message
+        fn new(msg: JString),
+        /// Construct with a message that indicates the illegal index
+        fn new_for_index(index: jint),
+    }
+}
+bind_basic_exception! { JArrayStoreException => "java.lang.ArrayStoreException" }
+bind_basic_exception! { JClassCircularityError => "java.lang.ClassCircularityError" }
+bind_basic_exception! { JClassFormatError => "java.lang.ClassFormatError" }
+bind_exception! {
+    JExceptionInInitializerError => "java.lang.ExceptionInInitializerError",
+    constructors {
+        /// Construct without any message
+        fn new_null(),
+        /// Construct with a message
+        fn new(msg: JString),
+        /// Construct with only an exception cause and a `null` message
+        fn new_with_exception(cause: JThrowable)
+    },
+    methods {
+        /// Returns the exception that was thrown during static initialization.
+        fn get_cause() -> JThrowable,
+
+        /// Returns the exception that was thrown during static initialization.
+        fn get_exception() -> JThrowable
+    }
+}
+bind_basic_exception! {
+    JClassNotFoundException => "java.lang.ClassNotFoundException",
+    constructors {
+        /// Construct without any message
+        fn new_null(),
+        /// Construct with a message
+        fn new(msg: JString),
+        /// Construct with a message and a cause
+        fn new_with_cause(msg: JString, cause: JThrowable),
+    },
+    methods {
+        /// Returns the exception that was raised if an error occurred while attempting to load the class (the cause)
+        fn get_cause() -> JThrowable,
+    }
+}
+bind_exception! {
+    JIllegalArgumentException => "java.lang.IllegalArgumentException",
+    constructors {
+        /// Construct without any message
+        fn new_null(),
+        /// Construct with a message
+        fn new(msg: JString),
+        /// Construct with a message and a cause
+        fn new_with_cause(msg: JString, cause: JThrowable),
+        /// Construct with only a cause
+        ///
+        /// The message will be `null` if the cause is `null` or the message
+        /// will come from the cause.
+        fn new_with_only_cause(cause: JThrowable)
+    }
+}
+bind_basic_exception! { JIllegalMonitorStateException => "java.lang.IllegalMonitorStateException" }
+bind_basic_exception! { JInstantiationException => "java.lang.InstantiationException" }
+bind_exception! {
+    JLinkageError => "java.lang.LinkageError",
+    constructors {
+        /// Construct without any message
+        fn new_null(),
+        /// Construct with a message
+        fn new(msg: JString),
+        /// Construct with a message and a cause
+        fn new_with_cause(msg: JString, cause: JThrowable),
+    },
+}
+bind_basic_exception! { JNoClassDefFoundError => "java.lang.NoClassDefFoundError" }
+bind_basic_exception! { JNoSuchFieldError => "java.lang.NoSuchFieldError" }
+bind_basic_exception! { JNoSuchMethodError => "java.lang.NoSuchMethodError" }
+bind_basic_exception! { JNumberFormatException => "java.lang.NumberFormatException" }
+bind_basic_exception! { JOutOfMemoryError => "java.lang.OutOfMemoryError" }
+bind_exception! {
+    JRuntimeException => "java.lang.RuntimeException",
+    constructors {
+        /// Construct without any message
+        fn new_null(),
+        /// Construct with a message
+        fn new(msg: JString),
+        /// Construct with a message and a cause
+        fn new_with_cause(msg: JString, cause: JThrowable)
+    }
+}
+bind_exception! {
+    JSecurityException => "java.lang.SecurityException",
+    constructors {
+        /// Construct without any message
+        fn new_null(),
+        /// Construct with a message
+        fn new(msg: JString),
+        /// Construct with a message and a cause
+        fn new_with_cause(msg: JString, cause: JThrowable),
+        /// Construct with only a cause
+        ///
+        /// The message will be `null` if the cause is `null` or the message
+        /// will come from the cause.
+        fn new_with_only_cause(cause: JThrowable)
+    }
+}
+bind_exception! {
+    JStringIndexOutOfBoundsException => "java.lang.StringIndexOutOfBoundsException",
+    constructors {
+        /// Construct without any message
+        fn new_null(),
+        /// Construct with a message
+        fn new(msg: JString),
+        /// Construct with a message that indicates the illegal index
+        fn new_for_index(index: jint),
+    }
+}

--- a/crates/jni/src/lib.rs
+++ b/crates/jni/src/lib.rs
@@ -330,6 +330,9 @@ pub mod refs;
 /// Reference type implementations and API bindings for various `java.lang` Objects
 pub mod objects;
 
+/// Reference type implementations and API bindings for various `java.lang` Exceptions
+pub mod exceptions;
+
 /// Helpers for accessing array elements
 pub mod elements;
 
@@ -424,4 +427,64 @@ pub use jni_macros::native_method;
 #[must_use]
 pub fn __must_use<T>(v: T) -> T {
     v
+}
+
+// Provides a way to validate all our object bindings in a unit test, considering
+// that the `J<Foo>API::get` functions are only exported with `pub(crate)` visibility.
+//
+// If any typos in method names or incorrect method or field signatures will result
+// in a panic here when the binding initialization fails.
+#[doc(hidden)]
+pub fn __test_bindings_init(env: &crate::Env, loader: &crate::refs::LoaderContext) {
+    objects::JByteBufferAPI::get(env, loader)
+        .expect("Failed to initialize JByteBufferAPI bindings");
+    objects::JClassLoaderAPI::get(env, loader)
+        .expect("Failed to initialize JClassLoaderAPI bindings");
+    objects::JClassAPI::get(env, loader).expect("Failed to initialize JClassAPI bindings");
+    objects::JCollectionAPI::get(env, loader)
+        .expect("Failed to initialize JCollectionAPI bindings");
+    objects::JIteratorAPI::get(env, loader).expect("Failed to initialize JIteratorAPI bindings");
+    objects::JListAPI::get(env, loader).expect("Failed to initialize JListAPI bindings");
+    objects::JMapAPI::get(env, loader).expect("Failed to initialize JMapAPI bindings");
+    objects::JMapEntryAPI::get(env, loader).expect("Failed to initialize JMapEntryAPI bindings");
+    objects::JObjectArrayAPI::<objects::JString>::get(env, loader)
+        .expect("Failed to initialize JObjectArrayAPI<JString> bindings");
+    objects::JObjectAPI::get(env).expect("Failed to initialize JObjectAPI bindings");
+    objects::JPrimitiveArrayAPI_jboolean::get(env, loader)
+        .expect("Failed to initialize JPrimitiveArrayAPI_jboolean bindings");
+    objects::JSetAPI::get(env, loader).expect("Failed to initialize JSetAPI bindings");
+    objects::JStackTraceElementAPI::get(env, loader)
+        .expect("Failed to initialize JStackTraceElementAPI bindings");
+    objects::JStringAPI::get(env, loader).expect("Failed to initialize JStringAPI bindings");
+    objects::JThreadAPI::get(env, loader).expect("Failed to initialize JThreadAPI bindings");
+    objects::JThrowableAPI::get(env, loader).expect("Failed to initialize JThrowableAPI bindings");
+
+    exceptions::JArrayIndexOutOfBoundsExceptionAPI::get(env, loader)
+        .expect("Failed to initialize JArrayIndexOutOfBoundsException bindings");
+    exceptions::JArrayStoreExceptionAPI::get(env, loader)
+        .expect("Failed to initialize JArrayStoreException bindings");
+    exceptions::JClassCircularityErrorAPI::get(env, loader)
+        .expect("Failed to initialize JClassCircularityError bindings");
+    exceptions::JClassFormatErrorAPI::get(env, loader)
+        .expect("Failed to initialize JClassFormatError bindings");
+    exceptions::JExceptionInInitializerErrorAPI::get(env, loader)
+        .expect("Failed to initialize JExceptionInInitializerError bindings");
+    exceptions::JIllegalArgumentExceptionAPI::get(env, loader)
+        .expect("Failed to initialize JIllegalArgumentException bindings");
+    exceptions::JIllegalMonitorStateExceptionAPI::get(env, loader)
+        .expect("Failed to initialize JIllegalMonitorStateException bindings");
+    exceptions::JInstantiationExceptionAPI::get(env, loader)
+        .expect("Failed to initialize JInstantiationException bindings");
+    exceptions::JNoClassDefFoundErrorAPI::get(env, loader)
+        .expect("Failed to initialize JNoClassDefFoundError bindings");
+    exceptions::JNoSuchFieldErrorAPI::get(env, loader)
+        .expect("Failed to initialize JNoSuchFieldError bindings");
+    exceptions::JNoSuchMethodErrorAPI::get(env, loader)
+        .expect("Failed to initialize JNoSuchMethodError bindings");
+    exceptions::JOutOfMemoryErrorAPI::get(env, loader)
+        .expect("Failed to initialize JOutOfMemoryError bindings");
+    exceptions::JSecurityExceptionAPI::get(env, loader)
+        .expect("Failed to initialize JSecurityException bindings");
+    exceptions::JStringIndexOutOfBoundsExceptionAPI::get(env, loader)
+        .expect("Failed to initialize JStringIndexOutOfBoundsException bindings");
 }

--- a/crates/jni/src/objects/jthrowable.rs
+++ b/crates/jni/src/objects/jthrowable.rs
@@ -10,6 +10,18 @@ crate::bind_java_type! {
         fn get_cause() -> JThrowable,
 
         /// Gets the stack trace of the throwable by calling the `getStackTrace` method.
-        fn get_stack_trace() -> JStackTraceElement[]
+        fn get_stack_trace() -> JStackTraceElement[],
+
+        /// Associate a suppressed throwable with this throwable by calling the `addSuppressed`
+        /// method.
+        ///
+        /// A suppressed exception is one that was thrown but not propagated because another
+        /// exception was thrown with a higher precedence. This is distinct from the "cause" of the
+        /// exception because it's not assumed to be the direct cause of the higher-precedence
+        /// exception.
+        fn add_suppressed(throwable: JThrowable),
+
+        /// Get the list of throwables that were suppressed by this throwable.
+        fn get_suppressed() -> JThrowable[],
     }
 }

--- a/crates/jni/src/objects/mod.rs
+++ b/crates/jni/src/objects/mod.rs
@@ -75,31 +75,3 @@ pub use crate::refs::*;
     note = "Please use array elements types under `jni::elements::*` instead of `jni::objects::*`."
 )]
 pub use crate::elements::*;
-
-// Provides a way to validate all our object bindings in a unit test, considering
-// that the `J<Foo>API::get` functions are only exported with `pub(crate)` visibility.
-//
-// If any typos in method names or incorrect method or field signatures will result
-// in a panic here when the binding initialization fails.
-#[doc(hidden)]
-pub fn _test_jni_init(env: &crate::Env, loader: &crate::refs::LoaderContext) {
-    JByteBufferAPI::get(env, loader).expect("Failed to initialize JByteBufferAPI bindings");
-    JClassLoaderAPI::get(env, loader).expect("Failed to initialize JClassLoaderAPI bindings");
-    JClassAPI::get(env, loader).expect("Failed to initialize JClassAPI bindings");
-    JCollectionAPI::get(env, loader).expect("Failed to initialize JCollectionAPI bindings");
-    JIteratorAPI::get(env, loader).expect("Failed to initialize JIteratorAPI bindings");
-    JListAPI::get(env, loader).expect("Failed to initialize JListAPI bindings");
-    JMapAPI::get(env, loader).expect("Failed to initialize JMapAPI bindings");
-    JMapEntryAPI::get(env, loader).expect("Failed to initialize JMapEntryAPI bindings");
-    JObjectArrayAPI::<JString>::get(env, loader)
-        .expect("Failed to initialize JObjectArrayAPI<JString> bindings");
-    JObjectAPI::get(env).expect("Failed to initialize JObjectAPI bindings");
-    JPrimitiveArrayAPI_jboolean::get(env, loader)
-        .expect("Failed to initialize JPrimitiveArrayAPI_jboolean bindings");
-    JSetAPI::get(env, loader).expect("Failed to initialize JSetAPI bindings");
-    JStackTraceElementAPI::get(env, loader)
-        .expect("Failed to initialize JStackTraceElementAPI bindings");
-    JStringAPI::get(env, loader).expect("Failed to initialize JStringAPI bindings");
-    JThreadAPI::get(env, loader).expect("Failed to initialize JThreadAPI bindings");
-    JThrowableAPI::get(env, loader).expect("Failed to initialize JThrowableAPI bindings");
-}

--- a/crates/jni/tests/builtin_bindings.rs
+++ b/crates/jni/tests/builtin_bindings.rs
@@ -7,7 +7,7 @@ fn test_builtin_bindings() {
     let jvm = util::jvm();
 
     jvm.attach_current_thread(|env| -> jni::errors::Result<()> {
-        jni::objects::_test_jni_init(env, &Default::default());
+        jni::__test_bindings_init(env, &Default::default());
         Ok(())
     })
     .unwrap();


### PR DESCRIPTION
This adds a series of `bind_java_type` bindings for common `java.lang` exceptions that can be throw by various JNI functions.

An internal `bind_exception` macro is used in order to give all of these bindings a common `match()` method that can be used to match a `JThrowable` against a specific exception and get a `Cast<Ex>` when it matches.

This allows exceptions to be caught and handled with a pattern like this:

```rust
if env.exception_check() {
    env.with_local_frame(16, |env| -> jni::errors::Result<()> {
        let e = env
            .exception_occurred()
            .expect("Expected an exception after ExceptionCheck");
        env.exception_clear();

        if let Some(_oom) = jni::exceptions::JOutOfMemoryError::matches(env, &e)? {
            Err(jni::errors::Error::JniCall(JniError::NoMemory))
        } else if let Some(eformat) =
            jni::exceptions::JNumberFormatException::matches(env, &e)?
        {
            let msg = eformat.as_throwable().get_message(env).unwrap_or_default();
            let msg = msg.to_string();
            Err(Error::ParseFailed(msg))
        } else {
            eprintln!("Unexpected exception: {:?}", e);
            Err(Error::JniCall(JniError::Unknown))
        }
    })
} else {
    Ok(())
}
```

Fixes: #753

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Change is covered by [automated tests](https://github.com/jni-rs/jni-rs/blob/master/CONTRIBUTING.md#tests)
- [x] The [coding guidelines](https://github.com/jni-rs/jni-rs/blob/master/CONTRIBUTING.md#the-code-style) are followed
- [x] Public API has documentation
- [x] User-visible changes are mentioned in the Changelog
- [x] The continuous integration build passes
