### PR TITLE
Add `AttachConfig::exception_policy` control + fix default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,12 +39,15 @@ Adds bindings for the following `java.lang` errors / exceptions ([#767](https://
 - `JSecurityException` (`java.lang.SecurityException`)
 - `JStringIndexOutOfBoundsException` (`java.lang.StringIndexOutOfBoundsException`)
 
+Added `AttachmentExceptionPolicy` enum to control how Java exceptions are handled when attaching a thread ([#768](https://github.com/jni-rs/jni-rs/pull/768)).
+
 ### Changed
 
 - Removed dependency on `paste` crate ([#752](https://github.com/jni-rs/jni-rs/pull/752))
 - `attach_current_thread*` APIs immediately return `Err(JavaException)` if a Java exception is pending, so they don't have the side effect of clearing exceptions not thrown in the given closure ([#756](https://github.com/jni-rs/jni-rs/pull/756))
 - Removed `proc-macro-crate` dependency from the `jni-macros` crate ([#758](https://github.com/jni-rs/jni-rs/pull/758))
 - All internal use of JNI functions (not general calls into Java code) now catch exceptions and map to `jni::errors::Error` ([#762](https://github.com/jni-rs/jni-rs/pull/762))
+- `JavaVM::attach_current_thread*` APIs stash + re-throw pending exceptions so they can be run reliably, instead of bailing early with a `JavaException` error (e.g. needed in `Drop` implementations) ([#768](https://github.com/jni-rs/jni-rs/pull/768))
 
 ### Fixed
 

--- a/crates/jni/tests/threads_attach_config.rs
+++ b/crates/jni/tests/threads_attach_config.rs
@@ -15,7 +15,7 @@ fn attach_config() {
     let thread = spawn({
         move || {
             jvm.attach_current_thread_with_config(
-                || AttachConfig::new().name("test-thread"),
+                || AttachConfig::new().thread_name(jni_str!("test-thread")),
                 None,
                 |env| -> jni::errors::Result<_> {
                     // Get the current Thread and query the name


### PR DESCRIPTION
This enables some control over how exceptions are handled, before and after running a thread attachment closure.

This affects:
- `JavaVM::attach_current_thread`
- `JavaVM::attach_current_thread_for_scope`
- `JavaVM::attach_current_thread_with_config`

The new default behaviour is to:
1. catch any pending exception before running the closure
2. run the closure
3. catch any exception from the run closure
4. re-throw any pre-existing exception from (1)
5. return `Error::CaughtJavaException` for any closure exception

This aims to give much more predictable behaviour, since:
- The attachment closure is now **always run** (important if you're relying on it to release resources via a `Drop` implementation)
- Any closure exception is always caught and returned as a `CaughtJavaException` (i.e. your exception doesn't get lost because of the original exception)

After returning then any exception that was previously pending will still be pending afterwards too and although `Error::JavaException` is not returned, the assumption is that the caller should already be aware of this pending exception.

Although this is not a breaking API change, it does change the behaviour of `attach_current_thread*` APIs in an important way.

The assumption currently though is that this is far more likely to be a positive fix than it is to break anything.

Especially considering the common use of `attach_current_thread*` within `Drop` implementations this change will ensure that your `drop()` code runs reliably/consistently, regardless of whether there are pending exceptions. Without this change then it's very likely that attempts to use JNI within `Drop` implementations may leak resources if the code can't run due to pending exceptions.

# AttachConfig changes

This adds an `AttachmentExceptionPolicy` enum that can be associated with an `AttachConfig` via `AttachConfig::exception_policy()`

The default (as described above) is `PreReThrowPostCatch` (i.e. any pre-existing exception is re-thrown and any post-callback exception is caught).

For reference; it is possible to opt back in to the current 0.22.1 behaviour by setting the exception_policy to `PreCheckPostCatch`.

Additionally there is now an `Ignore` policy that can be used in rare circumstances where you might want to run purely exception-safe code that is not affected by the existence of any pending exception.

The `AttachConfig` closure that's passed to the `attach_current_thread*` APIs is now evaluated unconditionally (previously it was only run if the thread was not already attached).

Note: This was `AttachConfig` closure API was designed before the `jni_str!` macro was added to make it easier to use `JNIString` for naming the thread without allocating/encoding the name redundantly. This design is no longer necessary but it wasn't re-visted before releasing jni 0.22

Since we unconditionally run the `AttachConfig` closure now, this PR also deprecated the `::name()` API that takes a `JNIString` and replaces it with a `thread_name()` API that takes a `&JNIStr` that can be encoded at compile-time via `jni_str!`.


### Definition of Done

- [x] There are no TODOs left in the code
- [x] Change is covered by [automated tests](https://github.com/jni-rs/jni-rs/blob/master/CONTRIBUTING.md#tests)
- [x] The [coding guidelines](https://github.com/jni-rs/jni-rs/blob/master/CONTRIBUTING.md#the-code-style) are followed
- [x] Public API has documentation
- [x] User-visible changes are mentioned in the Changelog
- [x] The continuous integration build passes

