### PR TITLE
javac: set `-Duser.language=en` in order to parse `"[wrote ..]"` lines

### DIFF
--- a/crates/javac/src/lib.rs
+++ b/crates/javac/src/lib.rs
@@ -858,6 +858,9 @@ impl JavaCompiler {
         // Always set file.encoding=UTF-8 so @file lists are read as UTF-8 on all platforms
         cmd.arg("-J-Dfile.encoding=UTF-8");
 
+        // Always set the user language to English to make output parsing work on all platforms (#765)
+        cmd.arg("-J-Duser.language=en");
+
         // JDK 18 workaround for stdout/stderr encoding
         cmd.arg("-J-Dsun.stdout.encoding=UTF-8");
         cmd.arg("-J-Dsun.stderr.encoding=UTF-8");


### PR DESCRIPTION
The `javac` command-line compiler doesn't have a well-specified way to get feedback about the files it has written and this `javac` crate instead relies on a de facto standard where by the compiler outputs lines like:

```
[wrote = /path/to/File.class]
```

This output format depends on Java running with an english language locale.

This patch ensures we pass `-Duser.language=en` to force the locale to be english when running the compiler.

Thanks to @wuwbobo2021 for the [fix](https://github.com/jni-rs/jni-rs/issues/765#issuecomment-3968569442)

Fixes: #765

