### PR TITLE
bind_java_type: emit `env.assert_top()` checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,7 @@ Added `AttachmentExceptionPolicy` enum to control how Java exceptions are handle
 - Ensure that the `Env::throw*` APIs _actually_ return `Err(JavaException)` as the docs state ([#755](https://github.com/jni-rs/jni-rs/pull/755))
 - `JStackTraceElement` binding fixed to lookup `isNativeMethod` instead of `isNative` ([#760](https://github.com/jni-rs/jni-rs/pull/760))
 - `bind_java_type` emits `exception_checks` before JNI calls to avoid undefined behaviour from calling non-exception-safe JNI functions with pending exceptions. ([#757](https://github.com/jni-rs/jni-rs/pull/757))
+- `bind_java_type` emits `env.assert_top()` checks to ensure that any new local reference has a lifetime that's associated with the top JNI stack frame ([#776](https://github.com/jni-rs/jni-rs/pull/776))
 
 ## [0.22.1] — 2026-02-20
 

--- a/crates/jni/tests/bind_with_assert_top.rs
+++ b/crates/jni/tests/bind_with_assert_top.rs
@@ -1,0 +1,33 @@
+#![cfg(feature = "invocation")]
+// Test that `bind_java_type` is emitting `env.assert_top` runtime checks
+
+mod util;
+
+jni::bind_java_type! {
+    pub JBoolean => "java.lang.Boolean",
+    constructors {
+        fn new(arg0: jboolean),
+    },
+    methods {
+        fn value {
+            name = "booleanValue",
+            sig = () -> jboolean,
+        },
+    },
+}
+
+// Covers https://github.com/jni-rs/jni-rs/issues/774 bug
+#[test]
+#[should_panic = "jni runtime check failure"]
+fn test_bind_java_type_constructor_emits_assert_top() {
+    let jvm = util::jvm();
+    jvm.attach_current_thread(|env| {
+        let _bad_obj = env.get_java_vm()?.with_local_frame(16, |_| {
+            //let s = env.new_string("s")?; // triggers the runtime error
+            JBoolean::new(env, true)
+        })?;
+        eprintln!("ERROR: Should not have reached here without a runtime check!");
+        Ok::<_, jni::errors::Error>(())
+    })
+    .unwrap();
+}


### PR DESCRIPTION
There are a few places where `bind_java_type` code directly calls through `JNINativeInterface_` to call APIs that can allocate new local references, namely:

- `NewObjectA`
- `Call[Static]ObjectMethdA`
- `Get[Static]ObjectField`

Before making these calls it needs to call `env.assert_top()` to ensure that the lifetime that will be used is associated with the top JNI stack frame.

This adds a unit test, based on the example from #774

Fixes: #774

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Change is covered by [automated tests](https://github.com/jni-rs/jni-rs/blob/master/CONTRIBUTING.md#tests)
- [x] The [coding guidelines](https://github.com/jni-rs/jni-rs/blob/master/CONTRIBUTING.md#the-code-style) are followed
- [x] Public API has documentation
- [x] User-visible changes are mentioned in the Changelog
- [x] The continuous integration build passes
