### PR TITLE
bind_java_type: fix (unsound) pointer cast in `AsRef` code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,7 @@ Added `AttachmentExceptionPolicy` enum to control how Java exceptions are handle
 - `JStackTraceElement` binding fixed to lookup `isNativeMethod` instead of `isNative` ([#760](https://github.com/jni-rs/jni-rs/pull/760))
 - `bind_java_type` emits `exception_checks` before JNI calls to avoid undefined behaviour from calling non-exception-safe JNI functions with pending exceptions. ([#757](https://github.com/jni-rs/jni-rs/pull/757))
 - `bind_java_type` emits `env.assert_top()` checks to ensure that any new local reference has a lifetime that's associated with the top JNI stack frame ([#776](https://github.com/jni-rs/jni-rs/pull/776))
+- Unsound `AsRef` pointer cast for `is_instance_of` types emitted by `bind_java_type` ([#777](https://github.com/jni-rs/jni-rs/pull/777))
 
 ## [0.22.1] — 2026-02-20
 

--- a/crates/jni-macros/src/bind_java_type.rs
+++ b/crates/jni-macros/src/bind_java_type.rs
@@ -2007,12 +2007,13 @@ This does not require a runtime type check since any `"#, stringify!(#type_name)
                         }
 
                         // Assuming #type_name<'local> is a transparent wrapper around JObject
-                        // (asserted) we can implement AsRef by casting the raw `jni_sys::jobject`
+                        // (asserted) we can implement `AsRef` by transmuting `&self` to
+                        // `&#type_path<'local>`.
                         impl<'local> ::core::convert::AsRef<#type_path<'local>> for #type_name<'local> {
                             fn as_ref(&self) -> &#type_path<'local> {
                                 const fn assert_is_instance_of_type_is_ffi_safe<T: #jni::refs::TransparentReference>() {}
                                 const _: () = assert_is_instance_of_type_is_ffi_safe::<#type_path<'_>>();
-                                unsafe { &*self.as_raw().cast() }
+                                unsafe { std::mem::transmute(self) }
                             }
                         }
                     });


### PR DESCRIPTION
The `AsRef` implementations from `bind_java_type` were using completely bogus pointer casting that was casting the raw object pointer instead of trying to cast the pointer for the `&self` reference.

Instead of casting pointers, this updates the implementation to use `transmute` to transmute the `&Self` reference into the `&IsInstanceOf` reference type - based on the (asserted) knowledge that both types are transparent wrappers around the same `JObject` type.

This also adds two `AsRef` checks to `test_generated_aliases.rs` to firstly check that `AsRef` with a `JList::null()` reference works, and then tests `AsRef` with a non-null local reference.

Both tests triggered different crashes with the previous implementation and are now fixed.

Fixes: #773

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Change is covered by [automated tests](https://github.com/jni-rs/jni-rs/blob/master/CONTRIBUTING.md#tests)
- [x] The [coding guidelines](https://github.com/jni-rs/jni-rs/blob/master/CONTRIBUTING.md#the-code-style) are followed
- [x] Public API has documentation
- [x] User-visible changes are mentioned in the Changelog
- [x] The continuous integration build passes
