### PR TITLE
bind_java_type: add `null` reference checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,7 @@ Added `AttachmentExceptionPolicy` enum to control how Java exceptions are handle
 - `bind_java_type` emits `exception_checks` before JNI calls to avoid undefined behaviour from calling non-exception-safe JNI functions with pending exceptions. ([#757](https://github.com/jni-rs/jni-rs/pull/757))
 - `bind_java_type` emits `env.assert_top()` checks to ensure that any new local reference has a lifetime that's associated with the top JNI stack frame ([#776](https://github.com/jni-rs/jni-rs/pull/776))
 - Unsound `AsRef` pointer cast for `is_instance_of` types emitted by `bind_java_type` ([#777](https://github.com/jni-rs/jni-rs/pull/777))
+- `bind_java_type` emits `null` object checks to prevent calling methods or accessing fields on null objects ([#782](https://github.com/jni-rs/jni-rs/pull/782))
 
 ## [0.22.1] — 2026-02-20
 

--- a/crates/jni/src/env.rs
+++ b/crates/jni/src/env.rs
@@ -3914,7 +3914,6 @@ See the jni-rs Env documentation for more details.
         }
 
         let obj = obj.as_ref();
-        let obj = null_check!(obj, "set_field_typed obj argument")?;
 
         let field = field.lookup(self)?.as_ref().into_raw();
         let obj = obj.as_raw();
@@ -3956,6 +3955,7 @@ See the jni-rs Env documentation for more details.
         // Env lifetime for the top JNI stack frame
         self.assert_top();
         let obj = obj.as_ref();
+        let obj = null_check!(obj, "get_field obj argument")?;
         let class = self.get_object_class(obj)?.auto();
 
         let sig = sig.as_ref();
@@ -3982,6 +3982,7 @@ See the jni-rs Env documentation for more details.
         S: AsRef<FieldSignature<'sig>>,
     {
         let obj = obj.as_ref();
+        let obj = null_check!(obj, "set_field obj argument")?;
         let sig = sig.as_ref();
         let field_ty = sig.ty();
 

--- a/crates/jni/tests/bind_methods.rs
+++ b/crates/jni/tests/bind_methods.rs
@@ -131,6 +131,10 @@ fn test_instance_methods_getters_setters() {
     util::attach_current_thread(|env| {
         load_test_methods_class(env, &out_dir)?;
 
+        // First attempt to make a call with a null object reference
+        let res = TestMethods::null().get_message(env);
+        assert!(matches!(res, Err(jni::errors::Error::NullPtr(_))));
+
         let obj = TestMethods::new(env)?;
 
         // Test initial values


### PR DESCRIPTION
The JNI spec asserts that the `Get/Set<Type>Field` and `Call<Type>MethodA` functions _must_ not be called with `null` object references.

In practice we've seen this result in a `NullPointerException` which is safe but there's no guarantee that all implementations need to throw an exception and they could instead abort/crash.

This ensures we check for null object references when getting/setting non-static fields or calling non-static methods.

(Note: `Env::call_method` already has the required check)

For consistency, this also moves the `null` checks from `Env::get/set_field_unchecked` into the _checked_ methods - i.e. `Env::get/set_field`.

Note that `bind_java_type` doesn't emit `null` reference checks when making static calls or getting/setting static fields because we assume there would have been an earlier error when looking up the class and so the class references are implicitly never null.

Fixes: #781

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Change is covered by [automated tests](https://github.com/jni-rs/jni-rs/blob/master/CONTRIBUTING.md#tests)
- [x] The [coding guidelines](https://github.com/jni-rs/jni-rs/blob/master/CONTRIBUTING.md#the-code-style) are followed
- [x] Public API has documentation
- [x] User-visible changes are mentioned in the Changelog
- [x] The continuous integration build passes
