### PR TITLE
bind_java_type: clamp API + NativeInterface trait visibility to type visibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,7 @@ Added `AttachmentExceptionPolicy` enum to control how Java exceptions are handle
 - `bind_java_type` emits `env.assert_top()` checks to ensure that any new local reference has a lifetime that's associated with the top JNI stack frame ([#776](https://github.com/jni-rs/jni-rs/pull/776))
 - Unsound `AsRef` pointer cast for `is_instance_of` types emitted by `bind_java_type` ([#777](https://github.com/jni-rs/jni-rs/pull/777))
 - `bind_java_type` emits `null` object checks to prevent calling methods or accessing fields on null objects ([#782](https://github.com/jni-rs/jni-rs/pull/782))
+- `bind_java_type` clamps the `*API` struct and native methods trait visibility to that of the binding type ([#785](https://github.com/jni-rs/jni-rs/pull/785))
 
 ## [0.22.1] — 2026-02-20
 


### PR DESCRIPTION
PR #726 made is so the API structs have `pub(crate)` visibility, which makes sense for the common case where you're making a `pub` visibility binding type, but if your binding type has a more restricted visibility then the API shouldn't be more-visible than the binding type.

Related to this, the `*NativeInterface` trait that's generated by `bind_java_type` always had `pub` visibility which could be more-visible than the `*API` struct the trait should be implemented for, and also more visible than the binding type itself.

This makes it so both the `*API` struct and `*NativeInterface` traits have a default visibility of `pub(crate)` which is then clamped to the visibility of the binding type itself. So if a binding type is only visible to `pub(self)` then the `API` struct and native methods trait will also only be visible to `pub(self)`.

Fixes: #775

### Definition of Done

- [x] There are no TODOs left in the code
- [ ] Change is covered by [automated tests](https://github.com/jni-rs/jni-rs/blob/master/CONTRIBUTING.md#tests)
- [x] The [coding guidelines](https://github.com/jni-rs/jni-rs/blob/master/CONTRIBUTING.md#the-code-style) are followed
- [x] Public API has documentation
- [x] User-visible changes are mentioned in the Changelog
- [x] The continuous integration build passes
