### PR TITLE
refactor(deps): replace cesu8 with simd_cesu8 for MUTF-8 encoding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ Added `AttachmentExceptionPolicy` enum to control how Java exceptions are handle
 
 ### Changed
 
+- Replaced `cesu8` crate with `simd_cesu8` for MUTF-8 encoding, gaining SIMD acceleration and `no_std` compatibility
 - Removed dependency on `paste` crate ([#752](https://github.com/jni-rs/jni-rs/pull/752))
 - `attach_current_thread*` APIs immediately return `Err(JavaException)` if a Java exception is pending, so they don't have the side effect of clearing exceptions not thrown in the given closure ([#756](https://github.com/jni-rs/jni-rs/pull/756))
 - Removed `proc-macro-crate` dependency from the `jni-macros` crate ([#758](https://github.com/jni-rs/jni-rs/pull/758))

--- a/crates/jni-macros/Cargo.toml
+++ b/crates/jni-macros/Cargo.toml
@@ -20,7 +20,7 @@ rustc_version = "0.4"
 syn = { version = "2.0", features = ["full"] }
 quote = "1.0"
 proc-macro2 = "1.0"
-cesu8 = "1.1.0"
+simd_cesu8 = "1.0.1"
 
 [dev-dependencies]
 javac.workspace = true

--- a/crates/jni-macros/src/lib.rs
+++ b/crates/jni-macros/src/lib.rs
@@ -64,7 +64,7 @@ pub fn jni_sig_str(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
 /// This macro is similar to `jni_sig!` but returns a C string literal (e.g., `c"(IZ)V"`)
 /// with MUTF-8 encoding instead of a `MethodSignature` or `FieldSignature` struct.
 ///
-/// The output is encoded using Java's modified UTF-8 (MUTF-8) format via `cesu8::to_java_cesu8`.
+/// The output is encoded using Java's modified UTF-8 (MUTF-8) format via `simd_cesu8::mutf8::encode`.
 ///
 /// See the `jni_sig!` macro documentation for detailed syntax and examples.
 ///
@@ -89,7 +89,7 @@ pub fn jni_sig_cstr(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
 /// This macro is similar to `jni_sig!` but returns a `&'static JNIStr` with MUTF-8 encoding
 /// instead of a `MethodSignature` or `FieldSignature` struct.
 ///
-/// The output is encoded using Java's modified UTF-8 (MUTF-8) format via `cesu8::to_java_cesu8`
+/// The output is encoded using Java's modified UTF-8 (MUTF-8) format via `simd_cesu8::mutf8::encode`
 /// and wrapped in a `JNIStr` via `jni::strings::JNIStr::from_cstr_unchecked()`.
 ///
 /// See the `jni_sig!` macro documentation for detailed syntax and examples.

--- a/crates/jni-macros/src/str.rs
+++ b/crates/jni-macros/src/str.rs
@@ -22,7 +22,7 @@ use syn::LitCStr;
 /// // Emoji encoded as surrogate pairs in MUTF-8
 /// ```
 pub fn encode_mutf8(s: &str) -> Vec<u8> {
-    cesu8::to_java_cesu8(s).into_owned()
+    simd_cesu8::mutf8::encode(s).into_owned()
 }
 
 /// Create a LitCStr from a string with MUTF-8 encoding

--- a/crates/jni/Cargo.toml
+++ b/crates/jni/Cargo.toml
@@ -57,7 +57,7 @@ log.workspace = true
 thiserror.workspace = true
 
 cfg-if = "1.0.0"
-cesu8 = "1.1.0"
+simd_cesu8 = "1.0.1"
 combine = "4.1.0"
 
 [target.'cfg(windows)'.dependencies]

--- a/crates/jni/src/strings/ffi_str.rs
+++ b/crates/jni/src/strings/ffi_str.rs
@@ -4,8 +4,8 @@ use std::{
     os::raw::c_char,
 };
 
-use cesu8::{from_java_cesu8, to_java_cesu8};
 use log::debug;
+use simd_cesu8::mutf8;
 
 #[cfg(doc)]
 use crate::strings::MUTF8Chars;
@@ -93,7 +93,7 @@ where
     T: AsRef<str>,
 {
     fn from(other: T) -> Self {
-        let enc = to_java_cesu8(other.as_ref()).into_owned();
+        let enc = mutf8::encode(other.as_ref()).into_owned();
         JNIString {
             internal: unsafe { CString::from_vec_unchecked(enc) },
         }
@@ -109,7 +109,7 @@ impl From<JNIString> for CString {
 impl<'str_ref> From<&'str_ref JNIStr> for Cow<'str_ref, str> {
     fn from(other: &'str_ref JNIStr) -> Cow<'str_ref, str> {
         let bytes = other.as_cstr().to_bytes();
-        match from_java_cesu8(bytes) {
+        match mutf8::decode(bytes) {
             Ok(s) => s,
             Err(e) => {
                 debug!("error decoding java cesu8: {:#?}", e);

--- a/crates/jni/tests/signature.rs
+++ b/crates/jni/tests/signature.rs
@@ -833,7 +833,8 @@ fn test_jni_cstr_unicode_emoji() {
     );
 
     // Verify roundtrip decode
-    let decoded = cesu8::from_java_cesu8(EMOJI_CLASS.to_bytes()).expect("Failed to decode MUTF-8");
+    let decoded =
+        simd_cesu8::mutf8::decode(EMOJI_CLASS.to_bytes()).expect("Failed to decode MUTF-8");
     assert_eq!(decoded, "unicode.Type😀");
 }
 
@@ -859,7 +860,8 @@ fn test_jni_str_unicode_emoji() {
     );
 
     // Verify roundtrip decode
-    let decoded = cesu8::from_java_cesu8(EMOJI_CLASS.to_bytes()).expect("Failed to decode MUTF-8");
+    let decoded =
+        simd_cesu8::mutf8::decode(EMOJI_CLASS.to_bytes()).expect("Failed to decode MUTF-8");
     assert_eq!(decoded, "unicode.Type😀");
 }
 

--- a/crates/jni/tests/string-macros.rs
+++ b/crates/jni/tests/string-macros.rs
@@ -15,7 +15,7 @@ use std::ffi::CStr;
 
 // Helper function to verify MUTF-8 roundtrip encoding
 fn verify_roundtrip(original: &str, mutf8_bytes: &[u8]) {
-    match cesu8::from_java_cesu8(mutf8_bytes) {
+    match simd_cesu8::mutf8::decode(mutf8_bytes) {
         Ok(decoded) => {
             assert_eq!(
                 decoded, original,


### PR DESCRIPTION
reopen https://github.com/jni-rs/jni-rs/pull/779

## Overview

Swap out the unmaintained cesu8 crate (last published 2016) for simd_cesu8 1.0.1, a SIMD-accelerated drop-in replacement by an active maintainer. The API maps directly:

- cesu8::to_java_cesu8() → simd_cesu8::mutf8::encode()
- cesu8::from_java_cesu8() → simd_cesu8::mutf8::decode()

Set to 1.0.1 (MSRV 1.79) to stay within the project's Rust 1.85 toolchain constraint since 1.1.0 requires Rust 1.88.

simd_cesu8 supports no_std out of the box, laying groundwork for potential no_std compatibility in jni-rs.

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Change is covered by [automated tests](https://github.com/jni-rs/jni-rs/blob/master/CONTRIBUTING.md#tests)
- [x] The [coding guidelines](https://github.com/jni-rs/jni-rs/blob/master/CONTRIBUTING.md#the-code-style) are followed
- [x] Public API has documentation
- [x] User-visible changes are mentioned in the Changelog
- [x] The continuous integration build passes
