### PR TITLE
Release jni 0.22.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.22.2] — 2026-03-01
+
+_*Note*: although no breaking API change was made in this release there were some important fixes
+made, including a few non-trivial changes to how exceptions are handled and some important safety /
+soundness fixes made in the re-exported `jni-macros`._
+
+_For these reasons I'm going to *again* yank the previous 0.22.1 release after this is published,
+again taking into account that 0.22.1 was itself only released very recently and it should still be
+relatively unlikely that anyone has strictly locked in a 0.22.1 dependency._
+
+_Another benefit to yanking 0.22.1 is that it allows me to pin the `jni-macros` dependency via
+`=0.22.2` in this release so that in future releases I don't need to be worried that a new
+`jni-macros` release needs to be backwards compatible with all prior `jni` releases (so macros can
+take advantage of new `jni` features)._
+
+_Hopefully things will be smoother moving forward, now that more people have been starting to update
+to 0.22.x and there are more people testing it._
+
 ### Added
 
 Adds bindings for the following `java.lang` errors / exceptions ([#767](https://github.com/jni-rs/jni-rs/pull/767)):
@@ -62,7 +80,7 @@ Added `AttachmentExceptionPolicy` enum to control how Java exceptions are handle
 - `bind_java_type` emits `null` object checks to prevent calling methods or accessing fields on null objects ([#782](https://github.com/jni-rs/jni-rs/pull/782))
 - `bind_java_type` clamps the `*API` struct and native methods trait visibility to that of the binding type ([#785](https://github.com/jni-rs/jni-rs/pull/785))
 
-## [0.22.1] — 2026-02-20
+## [0.22.1] — 2026-02-20 (YANKED)
 
 *Note:* This release fixes several issues found in 0.22.0 which unfortunately required a few breaking changes.
 Instead of bumping to 0.23 though, the assumption is that no one will yet be depending on the recently-released
@@ -608,7 +626,8 @@ to call if there is a pending exception (#124):
 ## [0.10.1]
 - No changes has been made to the Changelog until this release.
 
-[Unreleased]: https://github.com/jni-rs/jni-rs/compare/v0.22.1...HEAD
+[Unreleased]: https://github.com/jni-rs/jni-rs/compare/v0.22.2...HEAD
+[0.22.2]: https://github.com/jni-rs/jni-rs/compare/v0.22.1...v0.22.2
 [0.22.1]: https://github.com/jni-rs/jni-rs/compare/v0.22.0...v0.22.1
 [0.22.0]: https://github.com/jni-rs/jni-rs/compare/v0.21.1...v0.22.0
 [0.21.1]: https://github.com/jni-rs/jni-rs/compare/v0.21.0...v0.21.1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ repository = "https://github.com/jni-rs/jni-rs"
 
 
 [workspace.dependencies]
-jni-macros = { path = "./crates/jni-macros", version = "0.22.0" }
+jni-macros = { path = "./crates/jni-macros", version = "=0.22.2" }
 javac = { path = "./crates/javac", version = "0.1.0" }
 jni = { path = "./crates/jni", version = "0.22.0" }
 

--- a/crates/jni/Cargo.toml
+++ b/crates/jni/Cargo.toml
@@ -7,7 +7,7 @@ categories = ["api-bindings"]
 name = "jni"
 repository = "https://github.com/jni-rs/jni-rs"
 # ¡When bumping version please also update it in examples and documentation!
-version = "0.22.1"
+version = "0.22.2"
 exclude = ["/benches", "/example", "/tests", "/test_profile"]
 
 authors.workspace = true


### PR DESCRIPTION
_*Note*: although no breaking API change was made in this release there were some important fixes made, including a few non-trivial changes to how exceptions are handled and some important safety / soundness fixes made in the re-exported `jni-macros`._

_For these reasons I'm going to *again* yank the previous 0.22.1 release after this is published, again taking into account that 0.22.1 was itself only released very recently and it should still be relatively unlikely that anyone has strictly locked in a 0.22.1 dependency._

_Another benefit to yanking 0.22.1 is that it allows me to pin the `jni-macros` dependency via `=0.22.2` in this release so that in future releases I don't need to be worried that a new `jni-macros` release needs to be backwards compatible with all prior `jni` releases (so macros can take advantage of new `jni` features)._

_Hopefully things will be smoother moving forward, now that more people have been starting to update to 0.22.x and there are more people testing it._

### Added

Adds bindings for the following `java.lang` errors / exceptions ([#767](https://github.com/jni-rs/jni-rs/pull/767)):
- `JArrayIndexOutOfBoundsException` (`java.lang.ArrayIndexOutOfBoundsException`)
- `JArrayStoreException` (`java.lang.ArrayStoreException`)
- `JClassCircularityError` (`java.lang.ClassCircularityError`)
- `JClassFormatError` (`java.lang.ClassFormatError`)
- `JExceptionInInitializerError` (`java.lang.ExceptionInInitializerError`)
- `JClassNotFoundException` (`java.lang.ClassNotFoundException`)
- `JIllegalArgumentException` (`java.lang.IllegalArgumentException`)
- `JIllegalMonitorStateException` (`java.lang.IllegalMonitorStateException`)
- `JInstantiationException` (`java.lang.InstantiationException`)
- `JLinkageError` (`java.lang.LinkageError`)
- `JNoClassDefFoundError` (`java.lang.NoClassDefFoundError`)
- `JNoSuchFieldError` (`java.lang.NoSuchFieldError`)
- `JNoSuchMethodError` (`java.lang.NoSuchMethodError`)
- `JNumberFormatException` (`java.lang.NumberFormatException`)
- `JOutOfMemoryError` (`java.lang.OutOfMemoryError`)
- `JRuntimeException` (`java.lang.RuntimeException`)
- `JSecurityException` (`java.lang.SecurityException`)
- `JStringIndexOutOfBoundsException` (`java.lang.StringIndexOutOfBoundsException`)

Added `AttachmentExceptionPolicy` enum to control how Java exceptions are handled when attaching a thread ([#768](https://github.com/jni-rs/jni-rs/pull/768)).

### Changed

- Replaced `cesu8` crate with `simd_cesu8` for MUTF-8 encoding, gaining SIMD acceleration and `no_std` compatibility
- Removed dependency on `paste` crate ([#752](https://github.com/jni-rs/jni-rs/pull/752))
- `attach_current_thread*` APIs immediately return `Err(JavaException)` if a Java exception is pending, so they don't have the side effect of clearing exceptions not thrown in the given closure ([#756](https://github.com/jni-rs/jni-rs/pull/756))
- Removed `proc-macro-crate` dependency from the `jni-macros` crate ([#758](https://github.com/jni-rs/jni-rs/pull/758))
- All internal use of JNI functions (not general calls into Java code) now catch exceptions and map to `jni::errors::Error` ([#762](https://github.com/jni-rs/jni-rs/pull/762))
- `JavaVM::attach_current_thread*` APIs stash + re-throw pending exceptions so they can be run reliably, instead of bailing early with a `JavaException` error (e.g. needed in `Drop` implementations) ([#768](https://github.com/jni-rs/jni-rs/pull/768))

### Fixed

- `Env::get_[static_]method/field_id` APIs now correctly clear + map internal exceptions to `Error::Method/FieldNotFound` errors ([#748](https://github.com/jni-rs/jni-rs/pull/748))
- `Global/Weak::Drop` no longer have the side effect of catching/clearing pending exceptions ([#749](https://github.com/jni-rs/jni-rs/pull/749))
- Ensure that the `Env::throw*` APIs _actually_ return `Err(JavaException)` as the docs state ([#755](https://github.com/jni-rs/jni-rs/pull/755))
- `JStackTraceElement` binding fixed to lookup `isNativeMethod` instead of `isNative` ([#760](https://github.com/jni-rs/jni-rs/pull/760))
- `bind_java_type` emits `exception_checks` before JNI calls to avoid undefined behaviour from calling non-exception-safe JNI functions with pending exceptions. ([#757](https://github.com/jni-rs/jni-rs/pull/757))
- `bind_java_type` emits `env.assert_top()` checks to ensure that any new local reference has a lifetime that's associated with the top JNI stack frame ([#776](https://github.com/jni-rs/jni-rs/pull/776))
- Unsound `AsRef` pointer cast for `is_instance_of` types emitted by `bind_java_type` ([#777](https://github.com/jni-rs/jni-rs/pull/777))
- `bind_java_type` emits `null` object checks to prevent calling methods or accessing fields on null objects ([#781](https://github.com/jni-rs/jni-rs/pull/782))
- `bind_java_type` clamps the `*API` struct and native methods trait visibility to that of the binding type ([#785](https://github.com/jni-rs/jni-rs/pull/785))