### PR TITLE
Release jni 0.22.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.22.3] — 2026-03-05
+
+#### Fixed
+
+- docs.rs build: Bumps `simd_cesu8` dep to >= 1.1.1 which no longer has an automatically-enabled
+"nightly" feature that may affect the docs.rs build (1.1.x is now also MSRV compatible) ([#790](https://github.com/jni-rs/jni-rs/pull/790))
+
 ## [0.22.2] — 2026-03-01
 
 _*Note*: although no breaking API change was made in this release there were some important fixes
@@ -77,7 +84,7 @@ Added `AttachmentExceptionPolicy` enum to control how Java exceptions are handle
 - `bind_java_type` emits `exception_checks` before JNI calls to avoid undefined behaviour from calling non-exception-safe JNI functions with pending exceptions. ([#757](https://github.com/jni-rs/jni-rs/pull/757))
 - `bind_java_type` emits `env.assert_top()` checks to ensure that any new local reference has a lifetime that's associated with the top JNI stack frame ([#776](https://github.com/jni-rs/jni-rs/pull/776))
 - Unsound `AsRef` pointer cast for `is_instance_of` types emitted by `bind_java_type` ([#777](https://github.com/jni-rs/jni-rs/pull/777))
-- `bind_java_type` emits `null` object checks to prevent calling methods or accessing fields on null objects ([#782](https://github.com/jni-rs/jni-rs/pull/782))
+- `bind_java_type` emits `null` object checks to prevent calling methods or accessing fields on null objects ([#781](https://github.com/jni-rs/jni-rs/pull/781))
 - `bind_java_type` clamps the `*API` struct and native methods trait visibility to that of the binding type ([#785](https://github.com/jni-rs/jni-rs/pull/785))
 
 ## [0.22.1] — 2026-02-20 (YANKED)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,15 +15,16 @@ repository = "https://github.com/jni-rs/jni-rs"
 [workspace.dependencies]
 jni-macros = { path = "./crates/jni-macros", version = "=0.22.2" }
 javac = { path = "./crates/javac", version = "0.1.0" }
-jni = { path = "./crates/jni", version = "0.22.0" }
+jni = { path = "./crates/jni", version = "0.22.3" }
 
 jni-sys = "0.4.1"
+simd_cesu8 = "1.1.1"
+libloading = "0.8"
+java-locator = "0.1.3"
 
 log = "0.4.4"
 thiserror = "2"
-libloading = "0.8"
-java-locator = "0.1.3"
-cafebabe = "0.9"
 
 trybuild = "1"
 rusty-fork = "0.3.0"
+cafebabe = "0.9"

--- a/crates/jni/Cargo.toml
+++ b/crates/jni/Cargo.toml
@@ -7,8 +7,8 @@ categories = ["api-bindings"]
 name = "jni"
 repository = "https://github.com/jni-rs/jni-rs"
 # ¡When bumping version please also update it in examples and documentation!
-version = "0.22.2"
-exclude = ["/benches", "/example", "/tests", "/test_profile"]
+version = "0.22.3"
+exclude = ["/benches", "/examples", "/mylib-example", "/tests"]
 
 authors.workspace = true
 edition.workspace = true
@@ -52,12 +52,12 @@ required-features = ["invocation"]
 [dependencies]
 jni-macros.workspace = true
 jni-sys.workspace = true
+simd_cesu8.workspace = true
 
 log.workspace = true
 thiserror.workspace = true
 
 cfg-if = "1.0.0"
-simd_cesu8 = "1.0.1"
 combine = "4.1.0"
 
 [target.'cfg(windows)'.dependencies]


### PR DESCRIPTION
This fixes the docs.rs build by bumping the `simd_cesu8` dep to >= 1.1.1 which no longer has an automatically-enabled
"nightly" feature that may affect the docs.rs build (1.1.x is now also MSRV compatible).

_*Note*: Technically we shouldn't need this release (since the `simd_cesu8` release alone will have fixed the build issue) but the other reason for the release is that the crates.io feature for queuing docs.rs rebuilds is not currently usable in our situation. docs.rs is currently fighting through a _huge_ backlog of low-priority build jobs that will likely to take over a week to clear (we moved about 500 spots in two days, out of ~3k crates queued)._

Addresses: #789