### PR TITLE
Add `objects::JCharSequence` binding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `JCharSequence` bindings for `java.lang.CharSequence` (including `AsRef<JCharSequence>` + `.as_char_sequence()` for `JString`) ([#793](https://github.com/jni-rs/jni-rs/pull/793))
+
 ## [0.22.3] — 2026-03-05
 
 #### Fixed

--- a/crates/jni-macros/src/types.rs
+++ b/crates/jni-macros/src/types.rs
@@ -597,6 +597,12 @@ impl TypeMappings {
                 false,
             ),
             (
+                "JCharSequence",
+                "java.lang.CharSequence",
+                "objects::JCharSequence",
+                false,
+            ),
+            (
                 "JClassLoader",
                 "java.lang.ClassLoader",
                 "objects::JClassLoader",

--- a/crates/jni/src/lib.rs
+++ b/crates/jni/src/lib.rs
@@ -441,6 +441,8 @@ pub fn __test_bindings_init(env: &crate::Env, loader: &crate::refs::LoaderContex
     objects::JClassLoaderAPI::get(env, loader)
         .expect("Failed to initialize JClassLoaderAPI bindings");
     objects::JClassAPI::get(env, loader).expect("Failed to initialize JClassAPI bindings");
+    objects::JCharSequenceAPI::get(env, loader)
+        .expect("Failed to initialize JCharSequenceAPI bindings");
     objects::JCollectionAPI::get(env, loader)
         .expect("Failed to initialize JCollectionAPI bindings");
     objects::JIteratorAPI::get(env, loader).expect("Failed to initialize JIteratorAPI bindings");

--- a/crates/jni/src/objects/jchar_sequence.rs
+++ b/crates/jni/src/objects/jchar_sequence.rs
@@ -1,0 +1,22 @@
+crate::bind_java_type! {
+    pub JCharSequence => "java.lang.CharSequence",
+    methods {
+        /// Returns the character at the specified index.
+        ///
+        /// # Throws
+        /// - `IndexOutOfBoundsException` - if the index is negative or not less than the length of
+        ///   this sequence.
+        fn char_at(index: jint) -> jchar,
+        /// Returns the length of this character sequence.
+        fn length() -> jint,
+        /// Returns a new character sequence that is a subsequence of this sequence.
+        ///
+        /// The subsequence starts with the character at the specified index and ends with the
+        /// character at index end - 1.
+        ///
+        /// # Throws
+        /// - `IndexOutOfBoundsException` - if start or end are negative, if end is greater than
+        ///   length(), or if start is greater than end.
+        fn sub_sequence(start: jint, end: jint) -> JCharSequence,
+    }
+}

--- a/crates/jni/src/objects/jstring.rs
+++ b/crates/jni/src/objects/jstring.rs
@@ -12,6 +12,9 @@ crate::bind_java_type! {
     pub JString => "java.lang.String",
     __jni_core = true,
     __sys_type = jstring,
+    is_instance_of {
+        collection = JCharSequence,
+    },
     methods {
         /// Returns a canonical, interned version of this string.
         fn intern() -> JString,

--- a/crates/jni/src/objects/mod.rs
+++ b/crates/jni/src/objects/mod.rs
@@ -13,6 +13,9 @@ pub use self::jclass::*;
 mod jclass_loader;
 pub use self::jclass_loader::*;
 
+mod jchar_sequence;
+pub use self::jchar_sequence::*;
+
 mod jstring;
 pub use self::jstring::*;
 


### PR DESCRIPTION
This adds a `java.lang.CharSequence` binding and declared `JString` to be an instance of a `JCharSequence`

For example this is useful in the context of Android bindings where it's quite common for APIs to accept a `CharSequence` instead of a `String`.

Note: this does not mark `JCharSequence` as a "core" type in jni-macros and so this should not break external code that may have already defined custom `java.lang.CharSequence` bindings. Still it would probably be best for external bindings to prefer to use this built-in type because `JString` now implements `AsRef<JCharSequence>`, which won't be true for any external `CharSequence` binding.
