### PR TITLE
bind_java_type: support non_null methods/fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - `JCharSequence` bindings for `java.lang.CharSequence` (including `AsRef<JCharSequence>` + `.as_char_sequence()` for `JString`) ([#793](https://github.com/jni-rs/jni-rs/pull/793))
+- `bind_java_type` supports `non_null` qualifier/property for methods and fields to map null references to `Error::NullPtr` ([#794](https://github.com/jni-rs/jni-rs/pull/794))
 
 ## [0.22.3] — 2026-03-05
 

--- a/crates/jni-macros/src/bind_java_type.rs
+++ b/crates/jni-macros/src/bind_java_type.rs
@@ -57,6 +57,7 @@ custom_keyword!(priv_type);
 custom_keyword!(is_instance_of);
 custom_keyword!(__jni_core);
 custom_keyword!(raw);
+custom_keyword!(non_null);
 
 /// Represents a visibility modifier
 #[derive(Clone)]
@@ -136,6 +137,7 @@ struct Method {
     method_signature: MethodSignature,
     attrs: Vec<syn::Attribute>,
     is_static: bool,
+    non_null: bool,
 }
 
 /// Represents a field definition
@@ -153,6 +155,7 @@ struct Field {
     getter_attrs: Vec<syn::Attribute>,
     setter_attrs: Vec<syn::Attribute>,
     is_static: bool,
+    non_null: bool,
 }
 
 /// Represents an entry in the is_instance_of list
@@ -205,6 +208,7 @@ struct ParsedMethod {
     is_static: bool,              // Set for both Method and NativeMethod
     abi_check: Option<AbiCheck>,  // Only set for NativeMethod
     catch_unwind: Option<bool>,   // Only set for NativeMethod
+    non_null: bool,               // Set for Method and NativeMethod (not Constructor)
 }
 
 /// Parse an optional visibility specifier
@@ -283,13 +287,14 @@ fn parse_method(
     let visibility = parse_visibility(input)?;
 
     // Parse qualifiers that can appear after visibility and before the fn keyword
-    // For shorthand: [vis] [static] [raw] [extern] fn name(params) -> ret
+    // For shorthand: [vis] [static] [raw] [extern] [non_null] fn name(params) -> ret
     // For block: [vis] [static] [extern] fn name { ... }
     let mut is_static = false;
     let mut is_raw = false;
     let mut is_extern = false;
+    let mut is_non_null = false;
 
-    // Parse qualifiers in any order (static, raw, extern)
+    // Parse qualifiers in any order (static, raw, extern, non_null)
     loop {
         if input.peek(Token![static]) {
             input.parse::<Token![static]>()?;
@@ -300,6 +305,9 @@ fn parse_method(
         } else if input.peek(raw) {
             input.parse::<raw>()?;
             is_raw = true;
+        } else if input.peek(non_null) {
+            input.parse::<non_null>()?;
+            is_non_null = true;
         } else {
             break;
         }
@@ -424,6 +432,11 @@ fn parse_method(
                 body_content.parse::<Token![=]>()?;
                 let lit_bool = body_content.parse::<LitBool>()?;
                 catch_unwind = Some(lit_bool.value());
+            } else if lookahead.peek(self::non_null) {
+                body_content.parse::<non_null>()?;
+                body_content.parse::<Token![=]>()?;
+                let lit_bool = body_content.parse::<LitBool>()?;
+                is_non_null = lit_bool.value();
             } else {
                 return Err(lookahead.error());
             }
@@ -491,6 +504,14 @@ fn parse_method(
                     "Constructors cannot be static",
                 ));
             }
+
+            // Constructors cannot use non_null
+            if is_non_null {
+                return Err(syn::Error::new(
+                    rust_name.span(),
+                    "Constructors cannot use 'non_null' - use it on methods that can return null instead",
+                ));
+            }
         }
         MethodKind::Method => {
             // See !NativeMethod validation below
@@ -509,6 +530,12 @@ fn parse_method(
                     return Err(syn::Error::new(
                         rust_name.span(),
                         "Cannot specify 'catch_unwind' when using 'raw' - catch_unwind only applies to safe wrappers",
+                    ));
+                }
+                if is_non_null {
+                    return Err(syn::Error::new(
+                        rust_name.span(),
+                        "Cannot specify 'non_null' when using 'raw' - non_null only applies to safe wrappers that return Result",
                     ));
                 }
             }
@@ -564,6 +591,26 @@ fn parse_method(
         }
     }
 
+    // Validate non_null usage
+    if is_non_null {
+        // Check if the return type is a primitive or void
+        let is_primitive_or_void = method_signature
+            .return_type
+            .try_as_primitive(type_mappings)
+            .is_some()
+            || matches!(
+                method_signature.return_type,
+                SigType::Alias(ref name) if name == "void"
+            );
+
+        if is_primitive_or_void {
+            return Err(syn::Error::new(
+                rust_name.span(),
+                "Cannot use 'non_null' with methods that return primitive types or void - non_null is only valid for object/reference return types",
+            ));
+        }
+    }
+
     Ok(ParsedMethod {
         rust_name,
         java_name,
@@ -577,6 +624,7 @@ fn parse_method(
         is_static,
         abi_check,
         catch_unwind,
+        non_null: is_non_null,
     })
 }
 
@@ -618,6 +666,7 @@ fn parse_methods(input: ParseStream, type_mappings: &TypeMappings) -> Result<Vec
             method_signature: parsed.method_signature,
             attrs: parsed.attrs,
             is_static: parsed.is_static,
+            non_null: parsed.non_null,
         });
 
         if !input.is_empty() {
@@ -647,6 +696,7 @@ fn parse_native_methods(
                 method_signature: parsed.method_signature.clone(),
                 attrs: parsed.attrs.clone(),
                 is_static: parsed.is_static,
+                non_null: parsed.non_null,
             });
         }
         native_methods.push(NativeMethod {
@@ -683,13 +733,22 @@ fn parse_field(input: ParseStream, type_mappings: &TypeMappings) -> Result<Field
     let mut setter_visibility = field_visibility.unwrap_or(VisibilitySpec::Public);
 
     // Parse qualifiers that can appear after visibility and before the field name
-    // For shorthand: [vis] [static] name: Type
+    // For shorthand: [vis] [static] [non_null] name: Type
     // For block: [vis] [static] name { ... }
     let mut is_static = false;
+    let mut is_non_null = false;
 
-    if input.peek(Token![static]) {
-        input.parse::<Token![static]>()?;
-        is_static = true;
+    // Parse qualifiers in any order (static, non_null)
+    loop {
+        if input.peek(Token![static]) {
+            input.parse::<Token![static]>()?;
+            is_static = true;
+        } else if input.peek(non_null) {
+            input.parse::<non_null>()?;
+            is_non_null = true;
+        } else {
+            break;
+        }
     }
 
     let rust_name = input.parse::<Ident>()?;
@@ -719,6 +778,20 @@ fn parse_field(input: ParseStream, type_mappings: &TypeMappings) -> Result<Field
 
         let field_signature = FieldSignature { field_type };
 
+        // Validate non_null usage
+        if is_non_null {
+            let is_primitive = field_signature
+                .field_type
+                .try_as_primitive(type_mappings)
+                .is_some();
+            if is_primitive {
+                return Err(syn::Error::new(
+                    rust_name.span(),
+                    "Cannot use 'non_null' with fields of primitive types - non_null is only valid for object/reference field types",
+                ));
+            }
+        }
+
         Ok(Field {
             java_name,
             rust_name,
@@ -731,6 +804,7 @@ fn parse_field(input: ParseStream, type_mappings: &TypeMappings) -> Result<Field
             getter_attrs: Vec::new(),
             setter_attrs: Vec::new(),
             is_static,
+            non_null: is_non_null,
         })
     } else if input.peek(syn::token::Brace) || input.peek(Token![=]) {
         // Block syntax: field_name [=] { name = "javaName", sig = Type, ... }
@@ -797,6 +871,11 @@ fn parse_field(input: ParseStream, type_mappings: &TypeMappings) -> Result<Field
                     body_content.parse::<Token![=]>()?;
                     let lit_bool = body_content.parse::<LitBool>()?;
                     is_static = lit_bool.value();
+                } else if lookahead.peek(non_null) {
+                    body_content.parse::<non_null>()?;
+                    body_content.parse::<Token![=]>()?;
+                    let lit_bool = body_content.parse::<LitBool>()?;
+                    is_non_null = lit_bool.value();
                 } else {
                     return Err(lookahead.error());
                 }
@@ -819,6 +898,20 @@ fn parse_field(input: ParseStream, type_mappings: &TypeMappings) -> Result<Field
                 (Some(default_getter_name), Some(default_setter_name))
             };
 
+        // Validate non_null usage
+        if is_non_null {
+            let is_primitive = field_signature
+                .field_type
+                .try_as_primitive(type_mappings)
+                .is_some();
+            if is_primitive {
+                return Err(syn::Error::new(
+                    rust_name.span(),
+                    "Cannot use 'non_null' with fields of primitive types - non_null is only valid for object/reference field types",
+                ));
+            }
+        }
+
         Ok(Field {
             java_name,
             rust_name,
@@ -831,6 +924,7 @@ fn parse_field(input: ParseStream, type_mappings: &TypeMappings) -> Result<Field
             getter_attrs,
             setter_attrs,
             is_static,
+            non_null: is_non_null,
         })
     } else {
         Err(syn::Error::new(
@@ -2685,6 +2779,24 @@ fn generate_methods(
         // Apply attributes to the method
         let attrs = &method.attrs;
 
+        // Generate null check if non_null is true
+        let null_check_and_return = if method.non_null {
+            quote! {
+                #jni_call.and_then(|__result| {
+                    use #jni::refs::Reference as _;
+                    if __result.is_null() {
+                        Err(#jni::errors::Error::NullPtr("Null Object"))
+                    } else {
+                        Ok(__result)
+                    }
+                })
+            }
+        } else {
+            quote! {
+                #jni_call
+            }
+        };
+
         method_impls.push(quote! {
             #(#attrs)*
             #visibility fn #rust_name #lifetime_decls (
@@ -2696,7 +2808,7 @@ fn generate_methods(
                 let jni_args #jni_args_type = [#(#jvalue_conversions),*];
 
                 #class_def
-                #jni_call
+                #null_check_and_return
             }
         });
     }
@@ -3043,6 +3155,24 @@ fn generate_fields(
                 type_mappings,
             );
 
+            // Generate null check if non_null is true
+            let get_null_check_and_return = if field.non_null {
+                quote! {
+                    #get_call.and_then(|__result| {
+                        use #jni::refs::Reference as _;
+                        if __result.is_null() {
+                            Err(#jni::errors::Error::NullPtr("Null Object"))
+                        } else {
+                            Ok(__result)
+                        }
+                    })
+                }
+            } else {
+                quote! {
+                    #get_call
+                }
+            };
+
             field_impls.push(quote! {
                 #(#getter_attributes)*
                 #getter_visibility fn #getter_name<'env_local>(
@@ -3051,7 +3181,7 @@ fn generate_fields(
                 ) -> #jni::errors::Result<#return_type> {
                     let api = #api_name::get(env, &#jni::refs::LoaderContext::None)?;
                     #class_def
-                    #get_call
+                    #get_null_check_and_return
                 }
             });
         }
@@ -3095,6 +3225,21 @@ fn generate_fields(
                 type_mappings,
             );
 
+            // Generate null check if non_null is true
+            let set_null_check_and_call = if field.non_null {
+                quote! {
+                    use #jni::refs::Reference as _;
+                    if val.as_ref().is_null() {
+                        return Err(#jni::errors::Error::NullPtr("Null Object"));
+                    }
+                    #set_call
+                }
+            } else {
+                quote! {
+                    #set_call
+                }
+            };
+
             field_impls.push(quote! {
                 #(#setter_attributes)*
                 #setter_visibility fn #setter_name #field_lifetime_decl (
@@ -3104,7 +3249,7 @@ fn generate_fields(
                 ) -> #jni::errors::Result<()> {
                     let api = #api_name::get(env, &#jni::refs::LoaderContext::None)?;
                     #class_def
-                    #set_call
+                    #set_null_check_and_call
                 }
             });
         }

--- a/crates/jni/docs/macros/bind_java_type_1_properties.md
+++ b/crates/jni/docs/macros/bind_java_type_1_properties.md
@@ -140,7 +140,7 @@ The `fields` block defines bindings for instance and static fields, generating g
 
 **Shorthand syntax:**
 ```text
-[visibility] [static] name: type
+[visibility] [static] [non_null] name: type
 ```
 
 **Block syntax:**
@@ -155,6 +155,7 @@ The `fields` block defines bindings for instance and static fields, generating g
 
 - **`visibility`** - `pub`, `priv`, `pub(crate)`, etc. (defaults to `pub`)
 - **`static`** - Static field (class-level field)
+- **`non_null`** - Validate that field is never null (shorthand implies `non_null = true`)
 
 **Example:**
 
@@ -312,6 +313,50 @@ bind_java_type! {
 }
 ```
 
+## `non_null` - Null Validation for Fields
+
+The `non_null` property validates that field getters return non-null values and field setters
+do not accept null values, treating `null` as an error.
+
+**Syntax:**
+```text
+non_null = true | false   // In block syntax (default: false)
+non_null field_name: Type // In shorthand syntax (implies non_null = true)
+```
+
+**Behavior:**
+- If `non_null = true` and the field getter returns `null`, it returns `Err(Error::NullPtr("Null Object"))`
+- If `non_null = true` and you try to set the field to `null`, it returns `Err(Error::NullPtr("Null Object"))`
+- `Error::JavaException` has higher precedence - Java exceptions are always returned first
+
+```rust,ignore
+# use jni::bind_java_type;
+# use jni::objects::JString;
+# bind_java_type! { pub MyType => com.example.MyClass,
+# fields {
+// Shorthand syntax - non_null qualifier
+non_null required_name: JString,
+
+// Block syntax - explicit property
+optional_name {
+    sig = JString,
+    non_null = false,  // Default - null is allowed
+},
+
+validated_name {
+    sig = JString,
+    non_null = true,   // Null causes Error::NullPtr
+},
+# }}
+```
+
+**Restrictions:**
+
+- Cannot be used with fields of primitive types
+
+This is useful when Java fields are not expected to be `null` normally and it's logically an error
+if they are but the implementation may not throw an exception in this case.
+
 # Method Blocks Common Reference
 
 This section documents properties and syntax common to all method blocks.
@@ -328,7 +373,7 @@ All three method blocks support two syntax forms with common qualifiers:
 
 **Shorthand syntax:**
 ```text
-[visibility] [static] [raw] [extern] fn name(args...) -> return_type
+[visibility] [static] [raw] [extern] [non_null] fn name(args...) -> return_type
 ```
 
 **Block syntax:**
@@ -345,6 +390,7 @@ All three method blocks support two syntax forms with common qualifiers:
 - **`static`** - Static method (for `methods` and `native_methods` only)
 - **`raw`** - Raw JNI method (for `native_methods` only)
 - **`extern`** - Export JNI symbol (for `native_methods` only, equivalent to `export = true`)
+- **`non_null`** - Validate that method returns non-null (for `methods` and `native_methods` only, shorthand implies `non_null = true`)
 
 **Example:**
 
@@ -433,6 +479,57 @@ fn rust_name {
 ```
 
 This is useful when the Java method name conflicts with Rust keywords or conventions.
+
+## `non_null` - Null Validation for Methods
+
+The `non_null` property validates that methods return non-null object references, treating `null` as
+an error even when no Java exception was thrown.
+
+**Syntax:**
+
+```text
+non_null = true | false  // In block syntax (default: false)
+non_null fn name(...)     // In shorthand syntax (implies non_null = true)
+```
+
+**Behavior:**
+
+- If `non_null = true` and the method returns `null`, it returns `Err(Error::NullPtr("Null Object"))`
+- `Error::JavaException` has higher precedence - Java exceptions are always returned first
+
+```rust,no_run
+# use jni::bind_java_type;
+# use jni::objects::JString;
+# bind_java_type! { pub MyType => com.example.MyClass,
+# methods {
+// Shorthand syntax - non_null qualifier
+non_null fn get_required_name() -> JString,
+
+// Block syntax - explicit property
+fn get_optional_name {
+    sig = () -> JString,
+    non_null = false,  // Default - null is allowed
+},
+
+fn get_validated_name {
+    sig = () -> JString,
+    non_null = true,   // Null causes Error::NullPtr
+},
+# }}
+```
+
+**Restrictions:**
+
+- Cannot be used with constructors
+- Cannot be used with methods that return primitive types or void
+- For native methods: only affects bindings with a visibility specifier (callable from Rust), not the implementation
+
+This is useful when Java APIs are not expected to return `null` normally and it's logically an error
+if they do, but they also may not throw an exception in this case.
+
+**Note for native methods:** The `non_null` property only affects the generated Rust API for calling
+the native method (when a visibility specifier is present). It does not affect the implementation of
+the native method itself.
 
 # Constructor Blocks Reference (`constructors`)
 
@@ -530,6 +627,53 @@ bind_java_type! {
 
 1. **Via trait** (default): Implement the generated `{Type}NativeInterface` trait
 2. **Direct function**: Provide `fn = path::to::function` to bypass the trait
+
+## Visibility - Making Native Methods Callable from Rust
+
+Native methods can optionally include a visibility specifier (`pub`, `pub(crate)`, etc.) to generate
+a Rust API for calling the native method from Rust code. Without a visibility specifier, the method
+will only have a Rust implementation that can be called from Java or dynamically via JNI.
+
+**With visibility** - Generates both implementation and callable API:
+```rust
+# use jni::sys::jint;
+# use jni::bind_java_type;
+# bind_java_type! { pub MyType => com.example.MyClass,
+# native_methods {
+pub extern fn native_method(value: jint) -> jint,
+# }}
+# impl MyTypeNativeInterface for MyTypeAPI {
+#     type Error = jni::errors::Error;
+#     fn native_method<'local>(_: &mut jni::Env<'local>, _: MyType<'local>, _: jint) -> Result<jint, Self::Error> { Ok(0) }
+# }
+```
+
+This generates:
+- Trait method for implementation: `fn native_method(...) -> Result<jint, Error>`
+- Callable Rust API: `pub fn native_method(&self, env: &mut Env, value: jint) -> Result<jint>`
+- JNI export symbol (due to `extern`)
+
+**Without visibility** - Implementation only:
+```rust
+# use jni::sys::jint;
+# use jni::bind_java_type;
+# bind_java_type! { pub MyType => com.example.MyClass,
+# native_methods {
+extern fn native_method(value: jint) -> jint,
+# }}
+# impl MyTypeNativeInterface for MyTypeAPI {
+#     type Error = jni::errors::Error;
+#     fn native_method<'local>(_: &mut jni::Env<'local>, _: MyType<'local>, _: jint) -> Result<jint, Self::Error> { Ok(0) }
+# }
+```
+
+This generates:
+- Trait method for implementation: `fn native_method(...) -> Result<jint, Error>`
+- JNI export symbol (due to `extern`)
+- **No** callable Rust API (can only be called from Java)
+
+This distinction is important because some properties like `non_null` only affect the callable Rust API,
+not the implementation.
 
 ## `fn` - Direct Function Implementation
 

--- a/crates/jni/docs/macros/bind_java_type_2_examples.md
+++ b/crates/jni/docs/macros/bind_java_type_2_examples.md
@@ -549,6 +549,83 @@ bind_java_type! {
 }
 ```
 
+## Null Validation
+
+Use `non_null` to validate that methods and fields never return null, converting null values into errors:
+
+```rust,no_run
+use jni::bind_java_type;
+use jni::Env;
+use jni::objects::JString;
+use jni::refs::Reference;
+
+bind_java_type! {
+    pub UserProfile => com.example.UserProfile,
+    constructors {
+        fn new(),
+    },
+    methods {
+        // Shorthand syntax - non_null qualifier
+        non_null fn get_username() -> JString,
+        non_null fn get_email() -> JString,
+
+        // Optional field that can be null
+        fn get_nickname() -> JString,
+
+        // Block syntax with explicit non_null property
+        fn get_display_name {
+            sig = () -> JString,
+            non_null = true,
+        },
+    },
+    fields {
+        // Shorthand syntax - non_null qualifier for fields
+        non_null username: JString,
+        non_null email: JString,
+
+        // Optional field that can be null
+        nickname: JString,
+
+        // Block syntax
+        display_name {
+            sig = JString,
+            non_null = true,
+        },
+    },
+}
+
+fn validate_non_null(env: &mut Env) -> jni::errors::Result<()> {
+    let profile = UserProfile::new(env)?;
+
+    // These will return Error::NullPtr("Null Object") if the Java method returns null
+    let username = profile.get_username(env)?;  // non_null method
+    assert!(!username.is_null());
+    let email_field = profile.username(env)?;   // non_null field getter
+    assert!(!email_field.is_null());
+
+    // This can return null without error
+    let nickname = profile.get_nickname(env)?;
+    if !nickname.is_null() {
+        println!("Nickname: {}", nickname.try_to_string(env)?);
+    }
+
+    // Setting a non_null field to null will also return an error
+    let null_string = JString::null();
+    let res = profile.set_username(env, &null_string);
+    assert!(res.is_err()); // Error::NullPtr("Null Object")
+
+    Ok(())
+}
+```
+
+**When to use `non_null`:**
+
+- APIs where null is logically an error but may not throw an exception
+- Required fields that should always have a value
+- Methods that are documented to never return null under normal circumstances
+
+**Note:** `Error::JavaException` always takes precedence - if a Java exception is thrown, that will be returned regardless of the `non_null` setting.
+
 ## Complete Example
 
 A comprehensive example combining multiple features:

--- a/crates/jni/tests/bind_fields.rs
+++ b/crates/jni/tests/bind_fields.rs
@@ -35,6 +35,14 @@ bind_java_type! {
         double_field: jdouble,
         char_field: jchar,
         string_field: JString,
+
+        // Fields for testing non_null validation
+        nullable_string_field: JString,  // Can be null
+        non_null required_string_field: JString,  // Shorthand syntax - must not be null
+        validated_string_field {  // Block syntax with explicit non_null
+            sig = JString,
+            non_null = true,
+        },
     },
     methods {
         fn get_int_field() -> jint,
@@ -321,4 +329,84 @@ fn setup_test_output(test_name: &str) -> PathBuf {
     fs::create_dir_all(&out_dir).expect("Failed to create test output directory");
 
     out_dir
+}
+
+rusty_fork_test! {
+#[test]
+fn test_non_null_field_validation() {
+    let out_dir = setup_test_output("bind_fields_non_null");
+
+    javac::Build::new()
+        .file("tests/java/com/example/TestFields.java")
+        .output_dir(&out_dir)
+        .compile();
+
+    util::attach_current_thread(|env| {
+        load_test_fields_class(env, &out_dir)?;
+
+        let obj = TestFields::new(env)?;
+
+        // Test nullable field - should allow null without error
+        // We know from TestFields constructor that this field is initialized to null
+        let nullable = obj.nullable_string_field(env)?;
+        assert!(nullable.is_null(), "Expected nullable field to initially be null");
+
+        // Test getter with non_null (shorthand syntax)
+        // We know this field is initialized to null, so getting it should fail
+        let result = obj.required_string_field(env);
+        assert!(
+            matches!(result, Err(jni::errors::Error::NullPtr(_))),
+            "Expected Error::NullPtr when getting non_null field that is null"
+        );
+
+        // Test getter with non_null (block syntax)
+        // We know this field is initialized to null, so getting it should fail
+        let result = obj.validated_string_field(env);
+        assert!(
+            matches!(result, Err(jni::errors::Error::NullPtr(_))),
+            "Expected Error::NullPtr when getting non_null field that is null"
+        );
+
+        // Test setting a non_null field to null should also fail
+        let null_string = JString::null();
+        let result = obj.set_required_string_field(env, &null_string);
+        assert!(
+            matches!(result, Err(jni::errors::Error::NullPtr(_))),
+            "Setting non_null field to null should return NullPtr error"
+        );
+
+        // Test setting a non_null field to a non-null value should succeed
+        let valid_string = JString::from_str(env, "valid value")?;
+        obj.set_required_string_field(env, &valid_string)?;
+
+        // Now getting the field should succeed
+        let result = obj.required_string_field(env)?;
+        assert!(!result.is_null());
+        assert_eq!(result.to_string(), "valid value");
+
+        // Test setting validated_string_field (block syntax) to null should also fail
+        let result = obj.set_validated_string_field(env, &null_string);
+        assert!(
+            matches!(result, Err(jni::errors::Error::NullPtr(_))),
+            "Setting non_null field to null should return NullPtr error"
+        );
+
+        // Test setting validated_string_field to a non-null value should succeed
+        let another_valid = JString::from_str(env, "another valid")?;
+        obj.set_validated_string_field(env, &another_valid)?;
+
+        // Now getting the field should succeed
+        let result = obj.validated_string_field(env)?;
+        assert!(!result.is_null());
+        assert_eq!(result.to_string(), "another valid");
+
+        // Test that nullable field allows setting null (doesn't fail)
+        obj.set_nullable_string_field(env, &null_string)?;
+        let result = obj.nullable_string_field(env)?;
+        assert!(result.is_null(), "Expected nullable field to be null after setting to null");
+
+        Ok(())
+    })
+    .expect("Non-null field validation test failed");
+}
 }

--- a/crates/jni/tests/bind_methods.rs
+++ b/crates/jni/tests/bind_methods.rs
@@ -33,6 +33,14 @@ bind_java_type! {
         fn calculate(a: jint, b: jlong, c: jfloat, d: jdouble) -> jdouble,
         fn to_string_custom() -> JString,
         fn reset() -> void,
+
+        // Methods for testing non_null validation
+        fn get_nullable_message() -> JString,  // Can return null
+        non_null fn get_required_message() -> JString,  // Shorthand syntax - must not return null
+        fn get_validated_message {  // Block syntax with explicit non_null
+            sig = () -> JString,
+            non_null = true,
+        },
     }
 }
 
@@ -293,6 +301,45 @@ fn test_reset_method() {
         Ok(())
     })
     .expect("Reset test failed");
+}
+}
+
+rusty_fork_test! {
+#[test]
+fn test_non_null_validation() {
+    let out_dir = setup_test_output("bind_methods_non_null");
+
+    javac::Build::new()
+        .file("tests/java/com/example/TestMethods.java")
+        .output_dir(&out_dir)
+        .compile();
+
+    util::attach_current_thread(|env| {
+        load_test_methods_class(env, &out_dir)?;
+
+        let obj = TestMethods::new(env)?;
+
+        // Test nullable method - should allow null without error
+        let nullable = obj.get_nullable_message(env)?;
+        assert!(nullable.is_null(), "Expected get_nullable_message to return null");
+
+        // Test non_null method with shorthand syntax
+        let result = obj.get_required_message(env);
+        assert!(
+            matches!(result, Err(jni::errors::Error::NullPtr(_))),
+            "Expected Error::NullPtr when non_null method returns null"
+        );
+
+        // Test non_null method with block syntax
+        let result = obj.get_validated_message(env);
+        assert!(
+            matches!(result, Err(jni::errors::Error::NullPtr(_))),
+            "Expected Error::NullPtr when non_null method returns null"
+        );
+
+        Ok(())
+    })
+    .expect("Non-null validation test failed");
 }
 }
 

--- a/crates/jni/tests/java/com/example/TestFields.java
+++ b/crates/jni/tests/java/com/example/TestFields.java
@@ -31,6 +31,11 @@ public class TestFields {
     // Instance String field
     public String stringField;
 
+    // Fields for testing non_null validation
+    public String nullableStringField;  // Can be null
+    public String requiredStringField;  // Should be validated with non_null
+    public String validatedStringField; // Should be validated with non_null (block syntax)
+
     // Constructor
     public TestFields() {
         this.intField = 10;
@@ -42,6 +47,9 @@ public class TestFields {
         this.doubleField = 2.5;
         this.charField = 'A';
         this.stringField = "instance string";
+        this.nullableStringField = null;  // Initialize to null for testing
+        this.requiredStringField = null;  // Initialize to null to test validation
+        this.validatedStringField = null; // Initialize to null to test validation
     }
 
     public TestFields(int intValue, String stringValue) {

--- a/crates/jni/tests/java/com/example/TestMethods.java
+++ b/crates/jni/tests/java/com/example/TestMethods.java
@@ -92,4 +92,20 @@ public class TestMethods {
         message = "default";
         counter = 0;
     }
+
+    // Methods for testing non_null validation
+    public String getNullableMessage() {
+        // This method returns null to test nullable (default) behavior
+        return null;
+    }
+
+    public String getRequiredMessage() {
+        // This method returns null to test that non_null validation catches it
+        return null;
+    }
+
+    public String getValidatedMessage() {
+        // This method returns null to test that non_null validation (block syntax) catches it
+        return null;
+    }
 }


### PR DESCRIPTION
This adds support for a `non_null` method/field qualifier and a `non_null = true/false` block property that will map null object references into `Error::NullPtr`.

This can be used for methods/fields where a null value represents an error even though no exception is thrown.

Typically Java APIs would throw an exception if a null really represented an error but in case you're writing bindings for an API that returns null error values without an exception then you can now easily ensure these will also be mapped to a Rust error.

Example:

```rust
bind_java_type! {
    pub UserProfile => com.example.UserProfile,
    methods {
        // Shorthand syntax - non_null qualifier
        non_null fn get_username() -> JString,

        // Block syntax with explicit non_null property
        fn get_email {
            sig = () -> JString,
            non_null = true,
        },
    },
    fields {
        // Shorthand syntax for fields
        non_null username: JString,

        // Block syntax for fields
        email {
            sig = JString,
            non_null = true,
        },
    },
}
```

If the Java methods/fields return null, the generated Rust code will return `Err(Error::NullPtr("Null Object"))` instead of allowing the null value through.
