### PR TITLE
bind_java_type: Support `#[cfg()]` guarded methods/fields

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,7 +106,9 @@ jobs:
         run: cargo build ${{ matrix.build_args }}
       - name: Test
         if: ${{ matrix.rust-version == 'stable' && matrix.target_os != 'android' && !cancelled() }}
-        run: cargo test --workspace --all-targets --all-features
+        # Intentionally don't pass --all-features so we don't enable the hidden `_cfg_test` feature
+        # that unit tests rely on to check that cfg guards work correctly with `bind_java_type!`
+        run: cargo test --workspace --all-targets --features=invocation
       - name: Test
         if: ${{ matrix.rust-version == 'stable' && matrix.target_os == 'android' && !cancelled() }}
         # Intentionally don't pass --all-features so we can check building with and without the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - `JCharSequence` bindings for `java.lang.CharSequence` (including `AsRef<JCharSequence>` + `.as_char_sequence()` for `JString`) ([#793](https://github.com/jni-rs/jni-rs/pull/793))
-- `bind_java_type` supports `non_null` qualifier/property for methods and fields to map null references to `Error::NullPtr` ([#794](https://github.com/jni-rs/jni-rs/pull/794))
+- `bind_java_type` supports `non_null` qualifier/property for methods and fields to map null references to `Error::NullPtr` ([#795](https://github.com/jni-rs/jni-rs/pull/795))
+- `bind_java_type` supports `#[cfg()]` attributes on methods and fields, to conditionally compile them based on features or other cfg conditions ([#797](https://github.com/jni-rs/jni-rs/pull/795))
 
 ## [0.22.3] — 2026-03-05
 

--- a/crates/jni-macros/src/bind_java_type.rs
+++ b/crates/jni-macros/src/bind_java_type.rs
@@ -2174,6 +2174,15 @@ This does not require a runtime type check since any `"#, stringify!(#type_name)
     })
 }
 
+/// Extract cfg attributes from a list of attributes
+fn extract_cfg_attrs(attrs: &[syn::Attribute]) -> Vec<syn::Attribute> {
+    attrs
+        .iter()
+        .filter(|attr| attr.path().is_ident("cfg"))
+        .cloned()
+        .collect()
+}
+
 /// Intermediate representation for ID lookups (method IDs or field IDs)
 struct IdLookup {
     /// The field name in the API struct (e.g., "new_method_id", "get_value_field_id")
@@ -2186,6 +2195,8 @@ struct IdLookup {
     signature: String,
     /// The function to call for lookup (e.g., "get_method_id", "get_static_field_id")
     lookup_fn: Ident,
+    /// The cfg attributes to apply to this ID (e.g., #[cfg(feature = "foo")])
+    cfg_attrs: Vec<syn::Attribute>,
 }
 
 /// Generate field and initialization code from IdLookup descriptors
@@ -2202,17 +2213,20 @@ fn generate_id_fields_and_inits(
         let java_name = &lookup.java_name;
         let signature = &lookup.signature;
         let lookup_fn = lookup.lookup_fn;
+        let cfg_attrs = &lookup.cfg_attrs;
 
         // Create CStr literals for both the name and signature
         let name_cstr = lit_cstr_mutf8(java_name);
 
-        // Add field to API struct
+        // Add field to API struct with cfg guards
         fields.push(quote! {
+            #(#cfg_attrs)*
             #field_name: #field_type,
         });
 
-        // Add initialization
+        // Add initialization with cfg guards
         inits.push(quote! {
+            #(#cfg_attrs)*
             #field_name: env.#lookup_fn(class, #jni::strings::JNIStr::from_cstr_unchecked(#name_cstr), #jni::jni_sig!(jni=#jni, #signature))?,
         });
     }
@@ -2246,12 +2260,15 @@ fn generate_constructor_method_ids(
                 )
             })?;
 
+        let cfg_attrs = extract_cfg_attrs(&constructor.attrs);
+
         lookups.push(IdLookup {
             field_name: method_id_field,
             field_type: quote! { #jni::ids::JMethodID },
             java_name: "<init>".to_string(),
             signature: jni_sig_str,
             lookup_fn: format_ident!("get_method_id"),
+            cfg_attrs,
         });
     }
 
@@ -2437,12 +2454,15 @@ fn generate_method_ids(
             quote! { #jni::ids::JMethodID }
         };
 
+        let cfg_attrs = extract_cfg_attrs(&method.attrs);
+
         lookups.push(IdLookup {
             field_name: method_id_field,
             field_type,
             java_name: java_name.clone(),
             signature: jni_sig_str,
             lookup_fn,
+            cfg_attrs,
         });
     }
 
@@ -2488,12 +2508,15 @@ fn generate_field_ids(
             quote! { #jni::ids::JFieldID }
         };
 
+        let cfg_attrs = extract_cfg_attrs(&field.attrs);
+
         lookups.push(IdLookup {
             field_name: field_id_field,
             field_type,
             java_name: java_name.clone(),
             signature: field_sig,
             lookup_fn,
+            cfg_attrs,
         });
     }
 
@@ -3123,11 +3146,17 @@ fn generate_fields(
         if let Some(getter_name) = &field.getter_name {
             let getter_visibility = field.getter_visibility.to_tokens();
 
-            // Determine which attributes to apply to getter and setter
-            // If getter_attrs or setter_attrs are explicitly set, use those
+            // Always start with cfg attributes from the field itself
+            let field_cfg_attrs = extract_cfg_attrs(&field.attrs);
+
+            // Determine which attributes to apply to getter
+            // If getter_attrs are explicitly set, use those (plus field cfg)
             // Otherwise, use the field's attrs
             let mut getter_attributes = if !field.getter_attrs.is_empty() {
-                field.getter_attrs.clone()
+                // Merge: field cfg attrs + explicit getter attrs
+                let mut attrs = field_cfg_attrs.clone();
+                attrs.extend(field.getter_attrs.clone());
+                attrs
             } else {
                 field.attrs.clone()
             };
@@ -3189,8 +3218,17 @@ fn generate_fields(
         if let Some(setter_name) = &field.setter_name {
             let setter_visibility = field.setter_visibility.to_tokens();
 
+            // Always start with cfg attributes from the field itself
+            let field_cfg_attrs = extract_cfg_attrs(&field.attrs);
+
+            // Determine which attributes to apply to setter
+            // If setter_attrs are explicitly set, use those (plus field cfg)
+            // Otherwise, use the field's attrs (excluding doc)
             let mut setter_attributes: Vec<syn::Attribute> = if !field.setter_attrs.is_empty() {
-                field.setter_attrs.clone()
+                // Merge: field cfg attrs + explicit setter attrs
+                let mut attrs = field_cfg_attrs.clone();
+                attrs.extend(field.setter_attrs.clone());
+                attrs
             } else {
                 field
                     .attrs
@@ -3396,17 +3434,18 @@ fn generate_native_trait(
             jni,
         );
 
-        let attrs = &method.attrs;
+        // Only emit cfg attributes on trait methods (not doc or other attributes)
+        let cfg_attrs = extract_cfg_attrs(&method.attrs);
 
         // Raw methods return the value directly, regular methods return Result
         if method.is_raw {
             method_sigs.push(quote! {
-                #(#attrs)*
+                #(#cfg_attrs)*
                 fn #rust_name<'local>(#(#params),*) -> #return_type;
             });
         } else {
             method_sigs.push(quote! {
-                #(#attrs)*
+                #(#cfg_attrs)*
                 fn #rust_name<'local>(#(#params),*) -> ::std::result::Result<#return_type, Self::Error>;
             });
         }
@@ -3643,7 +3682,11 @@ fn generate_single_native_wrapper(
         }
     };
 
+    // Extract cfg attributes to apply to the wrapper function
+    let cfg_attrs = extract_cfg_attrs(&method.attrs);
+
     quote! {
+        #(#cfg_attrs)*
         #[allow(unused)]
         extern "system" fn #wrapper_name<#lifetime>(
             #(#params),*
@@ -3694,7 +3737,11 @@ fn generate_native_registration_code(
         let wrapper_name = format_ident!("{}_native_method", rust_name);
         let fn_ptr = quote! { Self::#wrapper_name as *mut ::std::ffi::c_void };
 
+        // Extract cfg attributes to guard the registration descriptor
+        let cfg_attrs = extract_cfg_attrs(&method.attrs);
+
         native_method_descriptors.push(quote! {
+            #(#cfg_attrs)*
             #jni::NativeMethod::from_raw_parts(
                 #jni::strings::JNIStr::from_cstr_unchecked(#name_cstr),
                 #jni::strings::JNIStr::from_cstr_unchecked(#sig_cstr),
@@ -3851,7 +3898,10 @@ fn generate_single_native_export(
         quote! { #[no_mangle] }
     };
 
+    let cfg_attrs = extract_cfg_attrs(&method.attrs);
+
     Ok(quote! {
+        #(#cfg_attrs)*
         #[doc(hidden)]
         #no_mangle_attr
         #[allow(non_snake_case)]

--- a/crates/jni/Cargo.toml
+++ b/crates/jni/Cargo.toml
@@ -90,5 +90,8 @@ windows-sys = { version = "0.61", features = [
 invocation = ["dep:java-locator", "dep:libloading"]
 default = []
 
+# Hidden feature for testing cfg attribute support in bind_java_type macro
+_cfg_test = []
+
 [package.metadata.docs.rs]
 features = ["invocation"]

--- a/crates/jni/tests/bind_fields.rs
+++ b/crates/jni/tests/bind_fields.rs
@@ -43,12 +43,19 @@ bind_java_type! {
             sig = JString,
             non_null = true,
         },
-    },
-    methods {
-        fn get_int_field() -> jint,
-        fn get_string_field() -> JString,
-        static fn get_static_int_field() -> jint,
-        static fn get_static_string_field() -> JString,
+
+        // Fields for testing cfg attribute support
+        // These are guarded by _cfg_test which is never enabled in tests
+        #[cfg(feature = "_cfg_test")]
+        static static_cfg_test_field: jint,
+        #[cfg(feature = "_cfg_test")]
+        instance_cfg_test_field: jint,
+
+        // These are guarded by invocation which is always enabled in tests
+        #[cfg(feature = "invocation")]
+        static static_invocation_field: jint,
+        #[cfg(feature = "invocation")]
+        instance_invocation_field: jint,
     }
 }
 
@@ -113,10 +120,6 @@ fn test_static_string_field() {
         let string_val = TestFields::static_string_field(env)?;
         assert_eq!(string_val.to_string(), "static string value");
 
-        // Test method that returns static field
-        let string_val2 = TestFields::get_static_string_field(env)?;
-        assert_eq!(string_val2.to_string(), "static string value");
-
         Ok(())
     })
     .expect("Static string field test failed");
@@ -146,10 +149,6 @@ fn test_static_field_write() {
         // Read updated value
         let updated_val = TestFields::static_int_field(env)?;
         assert_eq!(updated_val, 100);
-
-        // Verify via method call
-        let method_val = TestFields::get_static_int_field(env)?;
-        assert_eq!(method_val, 100);
 
         Ok(())
     })
@@ -253,10 +252,6 @@ fn test_instance_string_field() {
         let string_val = obj.string_field(env)?;
         assert_eq!(string_val.to_string(), "instance string");
 
-        // Test method that returns instance field
-        let string_val2 = obj.get_string_field(env)?;
-        assert_eq!(string_val2.to_string(), "instance string");
-
         Ok(())
     })
     .expect("Instance string field test failed");
@@ -295,6 +290,60 @@ fn test_constructor_with_values() {
         Ok(())
     })
     .expect("Constructor with values test failed");
+}
+}
+
+rusty_fork_test! {
+#[test]
+fn test_cfg_guarded_fields() {
+    let out_dir = setup_test_output("bind_fields_cfg");
+
+    javac::Build::new()
+        .file("tests/java/com/example/TestFields.java")
+        .output_dir(&out_dir)
+        .compile();
+
+    util::attach_current_thread(|env| {
+        load_test_fields_class(env, &out_dir)?;
+
+        // The TestFields binding includes fields guarded by both:
+        // - invocation feature (always enabled in tests) - we test these
+        // - _cfg_test feature (never enabled in tests) - these are not available
+
+        // The following would fail to compile if uncommented:
+        // TestFields::static_cfg_test_field(env)?;
+        // obj.instance_cfg_test_field(env)?;
+        // Note: we have a separate ui / trybuild test to check this
+
+        let val = TestFields::static_invocation_field(env)?;
+        assert_eq!(val, 55);
+
+        TestFields::set_static_invocation_field(env, 111)?;
+        let val = TestFields::static_invocation_field(env)?;
+        assert_eq!(val, 111);
+
+        let obj = TestFields::new(env)?;
+        let val = obj.instance_invocation_field(env)?;
+        assert_eq!(val, 88);
+
+        obj.set_instance_invocation_field(env, 222)?;
+        let val = obj.instance_invocation_field(env)?;
+        assert_eq!(val, 222);
+
+        #[cfg(feature = "_cfg_test")]
+        {
+            // These should compile and run if _cfg_test feature is enabled
+            let val = TestFields::static_cfg_test_field(env)?;
+            assert_eq!(val, 99);
+
+            let obj = TestFields::new(env)?;
+            let val = obj.instance_cfg_test_field(env)?;
+            assert_eq!(val, 77);
+        }
+
+        Ok(())
+    })
+    .expect("Cfg-guarded fields test failed");
 }
 }
 

--- a/crates/jni/tests/bind_methods.rs
+++ b/crates/jni/tests/bind_methods.rs
@@ -41,6 +41,19 @@ bind_java_type! {
             sig = () -> JString,
             non_null = true,
         },
+
+        // Methods for testing cfg attribute support
+        // These are guarded by _cfg_test which is never enabled in tests
+        #[cfg(feature = "_cfg_test")]
+        static fn cfg_test_method() -> jint,
+        #[cfg(feature = "_cfg_test")]
+        fn instance_cfg_test_method() -> jint,
+
+        // These are guarded by invocation which is always enabled in tests
+        #[cfg(feature = "invocation")]
+        static fn invocation_method() -> jint,
+        #[cfg(feature = "invocation")]
+        fn instance_invocation_method() -> jint,
     }
 }
 
@@ -340,6 +353,56 @@ fn test_non_null_validation() {
         Ok(())
     })
     .expect("Non-null validation test failed");
+}
+}
+
+rusty_fork_test! {
+#[test]
+fn test_cfg_guarded_methods() {
+    let out_dir = setup_test_output("bind_methods_cfg");
+
+    // Compile Java class
+    javac::Build::new()
+        .file("tests/java/com/example/TestMethods.java")
+        .output_dir(&out_dir)
+        .compile();
+
+    util::attach_current_thread(|env| {
+        load_test_methods_class(env, &out_dir)?;
+
+        // The TestMethods binding includes methods guarded by both:
+        // - invocation feature (always enabled in tests) - we test these
+        // - _cfg_test feature (never enabled in tests) - these are not available
+
+        // The following would fail to compile if uncommented:
+        // TestMethods::cfg_test_method(env)?;
+        // obj.instance_cfg_test_method(env)?;
+        // Note: we have separate ui / trybuild tests to check that these are properly excluded from the bindings
+
+        let result = TestMethods::invocation_method(env)?;
+        assert_eq!(result, 99);
+
+        let message = JString::from_str(env, "test")?;
+        let obj = TestMethods::new_with_message_and_counter(
+            env,
+            &message,
+            15,
+        )?;
+        let result = obj.instance_invocation_method(env)?;
+        assert_eq!(result, 215); // counter (15) + 200
+
+        #[cfg(feature = "_cfg_test")]
+        {
+            let result = TestMethods::cfg_test_method(env)?;
+            assert_eq!(result, 42);
+
+            let result = obj.instance_cfg_test_method(env)?;
+            assert_eq!(result, 115); // counter (15) + 100
+        }
+
+        Ok(())
+    })
+    .expect("Cfg-guarded methods test failed");
 }
 }
 

--- a/crates/jni/tests/bind_native_methods.rs
+++ b/crates/jni/tests/bind_native_methods.rs
@@ -38,6 +38,11 @@ bind_java_type! {
         },
         pub static fn native_string_array_echo(arr: JString[]) -> JString[],
         pub static fn native_2d_string_array_echo(arr: JString[][]) -> JString[][],
+        // Methods to test cfg attribute support
+        #[cfg(feature = "_cfg_test")]
+        pub fn native_cfg_test() -> jint,
+        #[cfg(feature = "invocation")]
+        pub fn native_invocation_test() -> jint,
     }
 }
 
@@ -133,6 +138,22 @@ impl TestNativeMethodsNativeInterface for TestNativeMethodsAPI {
         arr: JObjectArray<'local, JObjectArray<'local, JString<'local>>>,
     ) -> Result<JObjectArray<'local, JObjectArray<'local, JString<'local>>>, Self::Error> {
         Ok(arr)
+    }
+
+    #[cfg(feature = "invocation")]
+    fn native_invocation_test<'local>(
+        _env: &mut Env<'local>,
+        _this: TestNativeMethods<'local>,
+    ) -> Result<jint, Self::Error> {
+        Ok(42)
+    }
+
+    #[cfg(feature = "_cfg_test")]
+    fn native_cfg_test<'local>(
+        _env: &mut Env<'local>,
+        _this: TestNativeMethods<'local>,
+    ) -> Result<jint, Self::Error> {
+        Ok(123)
     }
 }
 
@@ -309,6 +330,26 @@ native_method_test! {
         assert_eq!(r2c1.to_string(), "baz");
         assert_eq!(r2c2.to_string(), "qux");
 
+        Ok(())
+    }
+}
+
+native_method_test! {
+    test_name: test_cfg_guards,
+    java_class: "com/example/TestNativeMethods.java",
+    api: TestNativeMethodsAPI,
+    test_body: |env| {
+        let _obj = TestNativeMethods::new(env)?;
+
+        let result = _obj.native_invocation_test(env)?;
+        assert_eq!(result, 42);
+
+        #[cfg(feature = "_cfg_test")]
+        {
+            // This should compile and run if _cfg_test feature is enabled
+            let result = _obj.native_cfg_test(env)?;
+            assert_eq!(result, 123);
+        }
         Ok(())
     }
 }

--- a/crates/jni/tests/java/com/example/TestFields.java
+++ b/crates/jni/tests/java/com/example/TestFields.java
@@ -36,6 +36,14 @@ public class TestFields {
     public String requiredStringField;  // Should be validated with non_null
     public String validatedStringField; // Should be validated with non_null (block syntax)
 
+    // Fields guarded by _cfg_test feature (never enabled in tests)
+    public static int staticCfgTestField = 99;
+    public int instanceCfgTestField;
+
+    // Fields guarded by invocation feature (always available in tests)
+    public static int staticInvocationField = 55;
+    public int instanceInvocationField;
+
     // Constructor
     public TestFields() {
         this.intField = 10;
@@ -50,6 +58,8 @@ public class TestFields {
         this.nullableStringField = null;  // Initialize to null for testing
         this.requiredStringField = null;  // Initialize to null to test validation
         this.validatedStringField = null; // Initialize to null to test validation
+        this.instanceCfgTestField = 77;
+        this.instanceInvocationField = 88;
     }
 
     public TestFields(int intValue, String stringValue) {
@@ -62,22 +72,5 @@ public class TestFields {
         this.doubleField = intValue * 2.5;
         this.charField = 'B';
         this.stringField = stringValue;
-    }
-
-    // Helper methods to verify field access
-    public int getIntField() {
-        return intField;
-    }
-
-    public String getStringField() {
-        return stringField;
-    }
-
-    public static int getStaticIntField() {
-        return staticIntField;
-    }
-
-    public static String getStaticStringField() {
-        return staticStringField;
     }
 }

--- a/crates/jni/tests/java/com/example/TestMethods.java
+++ b/crates/jni/tests/java/com/example/TestMethods.java
@@ -108,4 +108,22 @@ public class TestMethods {
         // This method returns null to test that non_null validation (block syntax) catches it
         return null;
     }
+
+    // Methods for testing cfg attribute support
+    public static int cfgTestMethod() {
+        return 42;
+    }
+
+    public int instanceCfgTestMethod() {
+        return counter + 100;
+    }
+
+    // Methods guarded by invocation feature (always available in tests)
+    public static int invocationMethod() {
+        return 99;
+    }
+
+    public int instanceInvocationMethod() {
+        return counter + 200;
+    }
 }

--- a/crates/jni/tests/java/com/example/TestNativeMethods.java
+++ b/crates/jni/tests/java/com/example/TestNativeMethods.java
@@ -36,6 +36,11 @@ public class TestNativeMethods {
 
     public static native String[][] native2DStringArrayEcho(String[][] arr);
 
+    // Native methods to test cfg attribute support
+    public native int nativeCfgTest();
+
+    public native int nativeInvocationTest();
+
     // Non-native methods that can be used to test native method calls
     public int getCounter() {
         return counter;


### PR DESCRIPTION
This adds support for `#[cfg()]` guards above fields and methods so it's possible to conditionally enable bindings based on features or targets.

The cfg expressions aren't interpreted by the macro itself, they are simply replicated across each piece of generated code for a single method/field (such as the method/field ID member in the API struct and the generated Rust methods / trait members)

This adds an unused `_cfg_test` feature to `jni/Cargo.toml` so that the unit tests can include `#[cfg(feature = "_cfg_test")]` guards which the tests expect will never be set. Declaring the feature avoids warnings about referencing non-existent features.

