### PR TITLE
Add more-ergonomic JValueOwned accessors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `JCharSequence` bindings for `java.lang.CharSequence` (including `AsRef<JCharSequence>` + `.as_char_sequence()` for `JString`) ([#793](https://github.com/jni-rs/jni-rs/pull/793))
 - `bind_java_type` supports `non_null` qualifier/property for methods and fields to map null references to `Error::NullPtr` ([#795](https://github.com/jni-rs/jni-rs/pull/795))
 - `bind_java_type` supports `#[cfg()]` attributes on methods and fields, to conditionally compile them based on features or other cfg conditions ([#797](https://github.com/jni-rs/jni-rs/pull/795))
+- `JValueOwned::check_null()` + `::is_null()` methods for ergonomic null checks on owned (returned) values ([#798](https://github.com/jni-rs/jni-rs/pull/798))
+- More readable type accessors for `JValueOwned`, like `.into_bool()` instead of `.z()`, `.into_object()` instead of `.l()`, etc ([#798](https://github.com/jni-rs/jni-rs/pull/798))
 
 ## [0.22.3] — 2026-03-05
 

--- a/crates/jni/src/jvalue.rs
+++ b/crates/jni/src/jvalue.rs
@@ -75,7 +75,40 @@ impl<'local> JValueOwned<'local> {
         self.borrow().primitive_type()
     }
 
+    /// Check if the value is a `null` object reference.
+    pub fn is_null(&self) -> bool {
+        matches!(self, Self::Object(obj) if obj.as_raw().is_null())
+    }
+
+    /// Check if the value is a `null` object reference, and return a [Error::NullPtr] error if so,
+    /// otherwise, return the value unchanged.
+    ///
+    /// This can be useful with APIs where a null represents an error but the implementation doesn't
+    /// throw a Java exception.
+    ///
+    /// **Beware:** Since `null` object references may be a valid (and safe) in many contexts, you
+    /// should only use this method if you are sure that `null` represents an error in the specific
+    /// context where you're using it.
+    ///
+    /// **Note**: In many cases if `null` represents an error then the API would throw a Java
+    /// exception, which would be automatically translated to an [Error::JavaException] error by
+    /// this crate.
+    pub fn check_null(self) -> Result<Self> {
+        match self {
+            Self::Object(obj) => {
+                if obj.as_raw().is_null() {
+                    Err(Error::NullPtr("Null Object"))
+                } else {
+                    Ok(Self::Object(obj))
+                }
+            }
+            _ => Ok(self),
+        }
+    }
+
     /// Try to unwrap to an Object.
+    ///
+    /// See [`Self::into_object`] as a more-ergonomic alias.
     pub fn l(self) -> Result<JObject<'local>> {
         match self {
             Self::Object(obj) => Ok(obj),
@@ -83,18 +116,53 @@ impl<'local> JValueOwned<'local> {
         }
     }
 
+    /// Try to unwrap to an Object.
+    #[doc(alias = "l")]
+    pub fn into_object(self) -> Result<JObject<'local>> {
+        self.l()
+    }
+
     /// Try to unwrap to a boolean.
+    ///
+    /// See [`Self::into_bool`] as a more-ergonomic alias.
     pub fn z(self) -> Result<bool> {
         self.borrow().z()
     }
 
+    /// Try to unwrap to a boolean.
+    #[doc(alias = "z")]
+    pub fn into_bool(self) -> Result<bool> {
+        self.borrow().z()
+    }
+
     /// Try to unwrap to a byte.
+    ///
+    /// See [`Self::into_byte`] as a more-ergonomic alias.
     pub fn b(self) -> Result<jbyte> {
         self.borrow().b()
     }
 
-    /// Try to unwrap to a char.
+    /// Try to unwrap to a byte.
+    #[doc(alias = "b")]
+    pub fn into_byte(self) -> Result<jbyte> {
+        self.borrow().b()
+    }
+
+    /// Try to unwrap to a `jchar`.
+    ///
+    /// See [`Self::into_char`] as a more-ergonomic alias.
     pub fn c(self) -> Result<jchar> {
+        self.borrow().c()
+    }
+
+    /// Try to unwrap to a `jchar`.
+    ///
+    /// **Warning:** A Java `char` is a UTF-16 code unit, which cannot always be converted to a Rust
+    /// `char` (which is a Unicode scalar value).
+    ///
+    /// See [`char_from_java`] for more information.
+    #[doc(alias = "c")]
+    pub fn into_char(self) -> Result<jchar> {
         self.borrow().c()
     }
 
@@ -110,6 +178,7 @@ impl<'local> JValueOwned<'local> {
     /// * [`Error::WrongJValueType`]: `self` does not contain a Java `char`.
     /// * [`Error::InvalidUtf16`]: `self` contains a Java `char`, but it is one half of a surrogate
     ///   pair.
+    #[deprecated = "Use `into_char` to get the raw Java jchar, and then (attempt to) convert it to a Rust char using `char_from_java` if needed. This method is likely to fail and is not recommended."]
     pub fn c_char(self) -> Result<char> {
         let char = self.c()?;
 
@@ -117,17 +186,41 @@ impl<'local> JValueOwned<'local> {
     }
 
     /// Try to unwrap to a double.
+    ///
+    /// See [`Self::into_double`] as a more-ergonomic alias.
     pub fn d(self) -> Result<jdouble> {
         self.borrow().d()
     }
 
+    /// Try to unwrap to a double.
+    #[doc(alias = "d")]
+    pub fn into_double(self) -> Result<jdouble> {
+        self.borrow().d()
+    }
+
     /// Try to unwrap to a float.
+    ///
+    /// See [`Self::into_float`] as a more-ergonomic alias.
     pub fn f(self) -> Result<jfloat> {
         self.borrow().f()
     }
 
+    /// Try to unwrap to a float.
+    #[doc(alias = "f")]
+    pub fn into_float(self) -> Result<jfloat> {
+        self.borrow().f()
+    }
+
     /// Try to unwrap to an int.
+    ///
+    /// See [`Self::into_int`] as a more-ergonomic alias.
     pub fn i(self) -> Result<jint> {
+        self.borrow().i()
+    }
+
+    /// Try to unwrap to an int.
+    #[doc(alias = "i")]
+    pub fn into_int(self) -> Result<jint> {
         self.borrow().i()
     }
 
@@ -140,23 +233,60 @@ impl<'local> JValueOwned<'local> {
     /// * [`Error::WrongJValueType`]: `self` does not contain a Java `int`.
     /// * [`Error::InvalidUtf32`]: `self` contains a Java `int`, but it is not a valid UTF-32 unit.
     pub fn i_char(self) -> Result<char> {
+        self.i_into_char()
+    }
+
+    /// Try to unwrap a Rust `char` from a Java `int`. See [`char_from_java_int`] for details.
+    ///
+    /// # Errors
+    ///
+    /// This method can fail with two kinds of errors:
+    ///
+    /// * [`Error::WrongJValueType`]: `self` does not contain a Java `int`.
+    /// * [`Error::InvalidUtf32`]: `self` contains a Java `int`, but it is not a valid UTF-32 unit.
+    #[doc(alias = "i_char")]
+    pub fn i_into_char(self) -> Result<char> {
         let char = self.i()?;
 
         char_from_java_int(char).map_err(|source| Error::InvalidUtf32 { char, source })
     }
 
     /// Try to unwrap to a long.
+    ///
+    /// See [`Self::into_long`] as a more-ergonomic alias.
     pub fn j(self) -> Result<jlong> {
         self.borrow().j()
     }
 
+    /// Try to unwrap to a long.
+    #[doc(alias = "j")]
+    pub fn into_long(self) -> Result<jlong> {
+        self.borrow().j()
+    }
+
     /// Try to unwrap to a short.
+    ///
+    /// See [`Self::into_short`] as a more-ergonomic alias.
     pub fn s(self) -> Result<jshort> {
         self.borrow().s()
     }
 
+    /// Try to unwrap to a short.
+    #[doc(alias = "s")]
+    pub fn into_short(self) -> Result<jshort> {
+        self.borrow().s()
+    }
+
     /// Try to unwrap to a void.
+    ///
+    /// See [`Self::into_void`] as a more-ergonomic alias.
     pub fn v(self) -> Result<()> {
+        self.borrow().v()
+    }
+
+    /// Try to unwrap to a void.
+    #[doc(alias = "v")]
+    pub fn into_void(self) -> Result<()> {
         self.borrow().v()
     }
 
@@ -164,6 +294,7 @@ impl<'local> JValueOwned<'local> {
     ///
     /// If the value is a primitive type, it is copied. If the value is an
     /// object reference, it is borrowed.
+    #[inline]
     pub fn borrow(&'_ self) -> JValue<'_> {
         match self {
             Self::Object(o) => JValue::Object(o),

--- a/crates/jni/tests/jni_api.rs
+++ b/crates/jni/tests/jni_api.rs
@@ -1939,6 +1939,7 @@ fn test_java_char_conversion() {
             // The first character in the string is U+1F913, which is not representable in a single UTF-16 unit.
 
             // Get the first Java `char` and try to unwrap it to a Rust `char`.
+            #[allow(deprecated)]
             let c = unwrap(
                 env.call_method(&s, jni_str!("charAt"), jni_sig!("(I)C"), &[JValue::Int(0)]),
                 env,
@@ -1980,6 +1981,7 @@ fn test_java_char_conversion() {
             // The second character in the string *is* representable in a single UTF-16 unit.
 
             // Get it and unwrap it. It should succeed.
+            #[allow(deprecated)]
             let c = unwrap(
                 env.call_method(
                     &s,


### PR DESCRIPTION
In favor of the single-letter accessors like `.z() -> bool` or `j() -> jlong` this adds more-ergonomic methods like `.into_bool()` and `into_long()`.

The single letter methods are quite esoteric (only intuitive if you're familiar with the single-letter type names used in JNI signatures) so these methods should make code more readable.

Additionally this adds `.is_null() -> bool` and `.check_null() -> Result<Self>` methods to help when checking for null object references in case you need to treat those as errors.

Considering the loud warning that `.c_char()` is not recommended (and is likely to fail), this deprecates the API and links to the `char_from_java` API (I.e. it doesn't seem good to make it easy to do the (probably) wrong thing).

Fixes: #792 