### PR TITLE
Import docs/macros/jni_mangle.md docs for jni_mangle macro

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `JValueOwned::check_null()` + `::is_null()` methods for ergonomic null checks on owned (returned) values ([#798](https://github.com/jni-rs/jni-rs/pull/798))
 - More readable type accessors for `JValueOwned`, like `.into_bool()` instead of `.z()`, `.into_object()` instead of `.l()`, etc ([#798](https://github.com/jni-rs/jni-rs/pull/798))
 
+#### Fixed
+
+- `jni_mangle` now includes `docs/macros/jni_mangle.md` in the crate documentation, so the macro's documentation is visible on docs.rs and in IDEs ([#799](https://github.com/jni-rs/jni-rs/pull/799))
+
 ## [0.22.3] — 2026-03-05
 
 #### Fixed

--- a/crates/jni/src/lib.rs
+++ b/crates/jni/src/lib.rs
@@ -401,7 +401,7 @@ pub use jni_macros::jni_cstr;
 #[doc = include_str!("../docs/macros/jni_str.md")]
 pub use jni_macros::jni_str;
 
-#[doc(inline)]
+#[doc = include_str!("../docs/macros/jni_mangle.md")]
 pub use jni_macros::jni_mangle;
 
 #[doc = include_str!("../docs/macros/jni_sig.md")]


### PR DESCRIPTION
The `jni_mangle` wasn't getting any generated docs because it had a `#[doc(inline)]` attribute, but the `jni-macros` crate assumes that the `jni` crate is responsible for the documentation.

There was already documentation under `docs/macros/jni_mangle.md` and so this uses `#[doc =include_str!("../docs/macros/jni_mangle.md")]` to include the markdown docs, consistent with the other jni-macros.

