### PR TITLE
Release jni-macros 0.22.4

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ repository = "https://github.com/jni-rs/jni-rs"
 
 
 [workspace.dependencies]
-jni-macros = { path = "./crates/jni-macros", version = "=0.22.2" }
+jni-macros = { path = "./crates/jni-macros", version = "=0.22.4" }
 javac = { path = "./crates/javac", version = "0.1.0" }
 jni = { path = "./crates/jni", version = "0.22.3" }
 

--- a/crates/jni-macros/Cargo.toml
+++ b/crates/jni-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jni-macros"
-version = "0.22.2"
+version = "0.22.4"
 description = "Procedural macros for the jni crate"
 keywords = ["jni", "java", "jvm", "android", "ndk"]
 categories = ["api-bindings", "development-tools::procedural-macro-helpers"]


### PR DESCRIPTION
In preparation for a jni 0.22.4 release

## Added
- `JCharSequence` is a new builtin type ([#793](https://github.com/jni-rs/jni-rs/pull/793))
- `bind_java_type` supports `non_null` qualifier/property for methods and fields to map null references to `Error::NullPtr` ([#795](https://github.com/jni-rs/jni-rs/pull/795))
- `bind_java_type` supports `#[cfg()]` attributes on methods and fields, to conditionally compile them based on features or other cfg conditions ([#797](https://github.com/jni-rs/jni-rs/pull/795))
