### PR TITLE
Release jni 0.22.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+
+## [0.22.4] — 2026-03-16
+
 ### Added
 
 - `JCharSequence` bindings for `java.lang.CharSequence` (including `AsRef<JCharSequence>` + `.as_char_sequence()` for `JString`) ([#793](https://github.com/jni-rs/jni-rs/pull/793))
@@ -645,7 +648,9 @@ to call if there is a pending exception (#124):
 ## [0.10.1]
 - No changes has been made to the Changelog until this release.
 
-[Unreleased]: https://github.com/jni-rs/jni-rs/compare/v0.22.2...HEAD
+[Unreleased]: https://github.com/jni-rs/jni-rs/compare/v0.22.4...HEAD
+[0.22.4]: https://github.com/jni-rs/jni-rs/compare/v0.22.3...v0.22.4
+[0.22.3]: https://github.com/jni-rs/jni-rs/compare/v0.22.2...v0.22.3
 [0.22.2]: https://github.com/jni-rs/jni-rs/compare/v0.22.1...v0.22.2
 [0.22.1]: https://github.com/jni-rs/jni-rs/compare/v0.22.0...v0.22.1
 [0.22.0]: https://github.com/jni-rs/jni-rs/compare/v0.21.1...v0.22.0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ repository = "https://github.com/jni-rs/jni-rs"
 [workspace.dependencies]
 jni-macros = { path = "./crates/jni-macros", version = "=0.22.4" }
 javac = { path = "./crates/javac", version = "0.1.0" }
-jni = { path = "./crates/jni", version = "0.22.3" }
+jni = { path = "./crates/jni", version = "0.22.4" }
 
 jni-sys = "0.4.1"
 simd_cesu8 = "1.1.1"

--- a/crates/jni/Cargo.toml
+++ b/crates/jni/Cargo.toml
@@ -7,7 +7,7 @@ categories = ["api-bindings"]
 name = "jni"
 repository = "https://github.com/jni-rs/jni-rs"
 # ¡When bumping version please also update it in examples and documentation!
-version = "0.22.3"
+version = "0.22.4"
 exclude = ["/benches", "/examples", "/mylib-example", "/tests"]
 
 authors.workspace = true


### PR DESCRIPTION
### Added

- `JCharSequence` bindings for `java.lang.CharSequence` (including `AsRef<JCharSequence>` + `.as_char_sequence()` for `JString`) ([#793](https://github.com/jni-rs/jni-rs/pull/793))
- `bind_java_type` supports `non_null` qualifier/property for methods and fields to map null references to `Error::NullPtr` ([#795](https://github.com/jni-rs/jni-rs/pull/795))
- `bind_java_type` supports `#[cfg()]` attributes on methods and fields, to conditionally compile them based on features or other cfg conditions ([#797](https://github.com/jni-rs/jni-rs/pull/795))
- `JValueOwned::check_null()` + `::is_null()` methods for ergonomic null checks on owned (returned) values ([#798](https://github.com/jni-rs/jni-rs/pull/798))
- More readable type accessors for `JValueOwned`, like `.into_bool()` instead of `.z()`, `.into_object()` instead of `.l()`, etc ([#798](https://github.com/jni-rs/jni-rs/pull/798))

#### Fixed

- `jni_mangle` now includes `docs/macros/jni_mangle.md` in the crate documentation, so the macro's documentation is visible on docs.rs and in IDEs ([#799](https://github.com/jni-rs/jni-rs/pull/799))
