### PR TITLE
bind_java_type: support `#[jni(requires = <expr>)]` attributes for runtime version/requirement checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `bind_java_type` now supports `#[jni(requires = ...)]` attributes on optional methods and fields, to conditionally enable them based on runtime checks like version checks ([#800](https://github.com/jni-rs/jni-rs/pull/800))
 
 ## [0.22.4] — 2026-03-16
 

--- a/crates/jni-macros/src/bind_java_type.rs
+++ b/crates/jni-macros/src/bind_java_type.rs
@@ -59,6 +59,18 @@ custom_keyword!(__jni_core);
 custom_keyword!(raw);
 custom_keyword!(non_null);
 
+/// Represents a requires expression for conditional binding
+#[derive(Clone)]
+enum RequiresExpression {
+    /// A function call with optional integer arguments: path::to::func(1, 2, 3)
+    FunctionCall {
+        function: syn::Path,
+        args: Vec<syn::LitInt>,
+    },
+    /// An arbitrary expression: "some_expr()"
+    Literal(syn::LitStr),
+}
+
 /// Represents a visibility modifier
 #[derive(Clone)]
 enum VisibilitySpec {
@@ -126,6 +138,7 @@ struct Constructor {
     name: Ident,
     method_signature: MethodSignature,
     attrs: Vec<syn::Attribute>,
+    requires: Vec<RequiresExpression>,
 }
 
 /// Represents a method definition
@@ -138,6 +151,7 @@ struct Method {
     attrs: Vec<syn::Attribute>,
     is_static: bool,
     non_null: bool,
+    requires: Vec<RequiresExpression>,
 }
 
 /// Represents a field definition
@@ -156,6 +170,7 @@ struct Field {
     setter_attrs: Vec<syn::Attribute>,
     is_static: bool,
     non_null: bool,
+    requires: Vec<RequiresExpression>,
 }
 
 /// Represents an entry in the is_instance_of list
@@ -184,6 +199,7 @@ struct NativeMethod {
     is_static: bool,
     abi_check: Option<AbiCheck>,
     catch_unwind: Option<bool>,
+    requires: Vec<RequiresExpression>,
 }
 
 /// The kind of method being parsed (determines validation rules)
@@ -203,12 +219,13 @@ struct ParsedMethod {
     error_policy: Option<syn::Path>,    // Only set for NativeMethod
     export: Option<NativeMethodExport>, // Only set for NativeMethod
     attrs: Vec<syn::Attribute>,
-    native_fn: Option<syn::Path>, // Only set for NativeMethod
-    is_raw: bool,                 // Only set for NativeMethod
-    is_static: bool,              // Set for both Method and NativeMethod
-    abi_check: Option<AbiCheck>,  // Only set for NativeMethod
-    catch_unwind: Option<bool>,   // Only set for NativeMethod
-    non_null: bool,               // Set for Method and NativeMethod (not Constructor)
+    native_fn: Option<syn::Path>,      // Only set for NativeMethod
+    is_raw: bool,                      // Only set for NativeMethod
+    is_static: bool,                   // Set for both Method and NativeMethod
+    abi_check: Option<AbiCheck>,       // Only set for NativeMethod
+    catch_unwind: Option<bool>,        // Only set for NativeMethod
+    non_null: bool,                    // Set for Method and NativeMethod (not Constructor)
+    requires: Vec<RequiresExpression>, // Optional conditional binding
 }
 
 /// Parse an optional visibility specifier
@@ -270,6 +287,68 @@ fn parse_name_spec(input: ParseStream) -> Result<(String, Ident)> {
     }
 }
 
+/// Parse #[jni(requires = ...)] attributes and filter out all #[jni(...)] attributes
+/// Returns (requires_expressions, filtered_attributes) where:
+/// - requires_expressions: Vec of RequiresExpression parsed from #[jni(requires = ...)]
+/// - filtered_attributes: All attributes except #[jni(...)] attributes
+fn parse_and_filter_jni_attrs(
+    attrs: &[syn::Attribute],
+) -> Result<(Vec<RequiresExpression>, Vec<syn::Attribute>)> {
+    let mut expressions = Vec::new();
+    let mut filtered = Vec::new();
+
+    for attr in attrs {
+        if !attr.path().is_ident("jni") {
+            // Not a jni attribute, keep it
+            filtered.push(attr.clone());
+            continue;
+        }
+
+        // Parse jni attribute to extract requires expressions
+        attr.parse_nested_meta(|meta| {
+            if meta.path.is_ident("requires") {
+                meta.input.parse::<Token![=]>()?;
+
+                // Check if it's a string literal (quoted expression)
+                let expr = if meta.input.peek(LitStr) {
+                    let lit = meta.input.parse::<LitStr>()?;
+                    RequiresExpression::Literal(lit)
+                } else {
+                    // Otherwise, parse as a function call: path::to::func(arg1, arg2, ...)
+                    let function = meta.input.parse::<syn::Path>()?;
+
+                    // Check if there are parentheses (function call syntax)
+                    let args = if meta.input.peek(syn::token::Paren) {
+                        let content;
+                        parenthesized!(content in meta.input);
+
+                        let mut args = Vec::new();
+                        while !content.is_empty() {
+                            args.push(content.parse::<syn::LitInt>()?);
+                            if !content.is_empty() {
+                                content.parse::<Token![,]>()?;
+                            }
+                        }
+                        args
+                    } else {
+                        Vec::new()
+                    };
+
+                    RequiresExpression::FunctionCall { function, args }
+                };
+
+                expressions.push(expr);
+                Ok(())
+            } else {
+                Err(meta.error("unknown jni attribute"))
+            }
+        })?;
+        // Don't add jni attributes to filtered list
+    }
+
+    Ok((expressions, filtered))
+}
+
 /// Unified parser for method blocks (constructors, methods, and native methods)
 /// Parses both shorthand syntax: `[vis] [static] [raw] [extern] fn name(params) -> ret`
 /// and block syntax: `[vis] [static] [raw] [extern] fn name [=] { ... }`
@@ -282,6 +361,9 @@ fn parse_method(
 ) -> Result<ParsedMethod> {
     // Parse attributes first
     let attrs = input.call(syn::Attribute::parse_outer)?;
+
+    // Extract requires expressions and filter out #[jni(...)] attributes
+    let (requires, attrs) = parse_and_filter_jni_attrs(&attrs)?;
 
     // Parse optional visibility specifier before the method name
     let visibility = parse_visibility(input)?;
@@ -625,6 +707,7 @@ fn parse_method(
         abi_check,
         catch_unwind,
         non_null: is_non_null,
+        requires,
     })
 }
 
@@ -642,6 +725,7 @@ fn parse_constructors(
             name: parsed.rust_name,
             method_signature: parsed.method_signature,
             attrs: parsed.attrs,
+            requires: parsed.requires,
         });
 
         if input.peek(Token![,]) {
@@ -667,6 +751,7 @@ fn parse_methods(input: ParseStream, type_mappings: &TypeMappings) -> Result<Vec
             attrs: parsed.attrs,
             is_static: parsed.is_static,
             non_null: parsed.non_null,
+            requires: parsed.requires,
         });
 
         if !input.is_empty() {
@@ -697,6 +782,7 @@ fn parse_native_methods(
                 attrs: parsed.attrs.clone(),
                 is_static: parsed.is_static,
                 non_null: parsed.non_null,
+                requires: parsed.requires.clone(),
             });
         }
         native_methods.push(NativeMethod {
@@ -711,6 +797,7 @@ fn parse_native_methods(
             is_static: parsed.is_static,
             abi_check: parsed.abi_check,
             catch_unwind: parsed.catch_unwind,
+            requires: parsed.requires,
         });
 
         if !input.is_empty() {
@@ -725,6 +812,9 @@ fn parse_native_methods(
 fn parse_field(input: ParseStream, type_mappings: &TypeMappings) -> Result<Field> {
     // Parse attributes first (for the field itself)
     let field_attrs = input.call(syn::Attribute::parse_outer)?;
+
+    // Extract requires expressions and filter out #[jni(...)] attributes
+    let (requires, field_attrs) = parse_and_filter_jni_attrs(&field_attrs)?;
 
     // Parse optional visibility specifier before the field name
     let field_visibility = parse_visibility(input)?;
@@ -805,6 +895,7 @@ fn parse_field(input: ParseStream, type_mappings: &TypeMappings) -> Result<Field
             setter_attrs: Vec::new(),
             is_static,
             non_null: is_non_null,
+            requires,
         })
     } else if input.peek(syn::token::Brace) || input.peek(Token![=]) {
         // Block syntax: field_name [=] { name = "javaName", sig = Type, ... }
@@ -824,6 +915,9 @@ fn parse_field(input: ParseStream, type_mappings: &TypeMappings) -> Result<Field
 
         while !body_content.is_empty() {
             let prop_attrs = body_content.call(syn::Attribute::parse_outer)?;
+            // Filter out #[jni(...)] attributes from property attributes
+            // (requires expressions are not supported on getter/setter properties)
+            let (_, prop_attrs) = parse_and_filter_jni_attrs(&prop_attrs)?;
 
             // Try to parse visibility first (handles pub, pub(...), and priv)
             let vis = parse_visibility(&body_content)?;
@@ -925,6 +1019,7 @@ fn parse_field(input: ParseStream, type_mappings: &TypeMappings) -> Result<Field
             setter_attrs,
             is_static,
             non_null: is_non_null,
+            requires,
         })
     } else {
         Err(syn::Error::new(
@@ -2183,6 +2278,36 @@ fn extract_cfg_attrs(attrs: &[syn::Attribute]) -> Vec<syn::Attribute> {
         .collect()
 }
 
+/// Convert a slice of RequiresExpression to a TokenStream for code generation
+/// Returns None for an empty slice, otherwise generates the combined expression with &&
+fn requires_to_token_stream(requires: &[RequiresExpression]) -> Option<TokenStream> {
+    if requires.is_empty() {
+        return None;
+    }
+
+    let expr_tokens: Vec<_> = requires
+        .iter()
+        .map(|expr| match expr {
+            RequiresExpression::FunctionCall { function, args } => {
+                if args.is_empty() {
+                    quote! { #function() }
+                } else {
+                    quote! { #function(#(#args),*) }
+                }
+            }
+            RequiresExpression::Literal(lit) => {
+                let expr_str = lit.value();
+                let expr: syn::Expr =
+                    syn::parse_str(&expr_str).expect("Failed to parse requires expression");
+                quote! { #expr }
+            }
+        })
+        .map(|tokens| quote! { (#tokens) })
+        .collect();
+
+    Some(quote! { #(#expr_tokens)&&* })
+}
+
 /// Intermediate representation for ID lookups (method IDs or field IDs)
 struct IdLookup {
     /// The field name in the API struct (e.g., "new_method_id", "get_value_field_id")
@@ -2197,9 +2322,16 @@ struct IdLookup {
     lookup_fn: Ident,
     /// The cfg attributes to apply to this ID (e.g., #[cfg(feature = "foo")])
     cfg_attrs: Vec<syn::Attribute>,
+    /// Whether this is an optional binding (uses Option<T>)
+    is_optional: bool,
+    /// The requires expression for optional bindings
+    requires_expr: Option<TokenStream>,
 }
 
 /// Generate field and initialization code from IdLookup descriptors
+///
+/// Note: 'field' in this context refers to the `<Type>API` struct fields. This function generates
+/// code for both method ID and field ID lookups.
 fn generate_id_fields_and_inits(
     lookups: Vec<IdLookup>,
     jni: &syn::Path,
@@ -2214,21 +2346,50 @@ fn generate_id_fields_and_inits(
         let signature = &lookup.signature;
         let lookup_fn = lookup.lookup_fn;
         let cfg_attrs = &lookup.cfg_attrs;
+        let is_optional = lookup.is_optional;
+        let requires_expr = lookup.requires_expr;
 
         // Create CStr literals for both the name and signature
         let name_cstr = lit_cstr_mutf8(java_name);
 
         // Add field to API struct with cfg guards
-        fields.push(quote! {
-            #(#cfg_attrs)*
-            #field_name: #field_type,
-        });
+        if is_optional {
+            fields.push(quote! {
+                #(#cfg_attrs)*
+                #field_name: Option<#field_type>,
+            });
+        } else {
+            fields.push(quote! {
+                #(#cfg_attrs)*
+                #field_name: #field_type,
+            });
+        }
 
         // Add initialization with cfg guards
-        inits.push(quote! {
-            #(#cfg_attrs)*
-            #field_name: env.#lookup_fn(class, #jni::strings::JNIStr::from_cstr_unchecked(#name_cstr), #jni::jni_sig!(jni=#jni, #signature))?,
-        });
+        if is_optional {
+            // For optional bindings, evaluate the requires expression and conditionally perform lookup
+            let requires_check = requires_expr.expect("Optional binding must have requires_expr");
+            inits.push(quote! {
+                #(#cfg_attrs)*
+                #field_name: {
+                    // Make sure expression can't accidentally capture any variables from the
+                    // surrounding scope by evaluating it in a separate function.
+                    fn __eval_requires() -> bool {
+                        #requires_check
+                    }
+                    if __eval_requires() {
+                        Some(env.#lookup_fn(class, #jni::strings::JNIStr::from_cstr_unchecked(#name_cstr), #jni::jni_sig!(jni=#jni, #signature))?)
+                    } else {
+                        None
+                    }
+                },
+            });
+        } else {
+            inits.push(quote! {
+                #(#cfg_attrs)*
+                #field_name: env.#lookup_fn(class, #jni::strings::JNIStr::from_cstr_unchecked(#name_cstr), #jni::jni_sig!(jni=#jni, #signature))?,
+            });
+        }
     }
 
     (fields, inits)
@@ -2261,6 +2422,8 @@ fn generate_constructor_method_ids(
             })?;
 
         let cfg_attrs = extract_cfg_attrs(&constructor.attrs);
+        let is_optional = !constructor.requires.is_empty();
+        let requires_expr = requires_to_token_stream(&constructor.requires);
 
         lookups.push(IdLookup {
             field_name: method_id_field,
@@ -2269,6 +2432,8 @@ fn generate_constructor_method_ids(
             signature: jni_sig_str,
             lookup_fn: format_ident!("get_method_id"),
             cfg_attrs,
+            is_optional,
+            requires_expr,
         });
     }
 
@@ -2332,6 +2497,7 @@ fn generate_constructors(
     for constructor in constructors {
         let name = &constructor.name;
         let method_id_field = format_ident!("{}_method_id", name);
+        let is_optional = !constructor.requires.is_empty();
 
         // Generate JNI call arguments data
         let args =
@@ -2358,6 +2524,17 @@ fn generate_constructors(
         // Apply attributes to the constructor
         let attrs = &constructor.attrs;
 
+        // Get the method ID (with optional check)
+        let get_method_id = if is_optional {
+            quote! {
+                let method_id = api.#method_id_field.ok_or_else(|| #jni::errors::Error::UnsupportedVersion)?;
+            }
+        } else {
+            quote! {
+                let method_id = api.#method_id_field;
+            }
+        };
+
         constructor_impls.push(quote! {
             #(#attrs)*
             pub fn #name #lifetime_decls (
@@ -2365,6 +2542,7 @@ fn generate_constructors(
                 #(#decls),*
             ) -> #jni::errors::Result<#type_name<'env_local>> {
                 let api = #api_name::get(env, &#jni::refs::LoaderContext::None)?;
+                #get_method_id
                 let jni_args #jni_args_type = [#(#jvalue_conversions),*];
 
                 unsafe {
@@ -2388,7 +2566,7 @@ fn generate_constructors(
                     let ret_obj: #jni::sys::jobject = ((*interface).v1_1.NewObjectA)(
                         env_ptr,
                         class.as_raw(),
-                        api.#method_id_field.into_raw(),
+                        method_id.into_raw(),
                         jni_args.as_ptr()
                     );
 
@@ -2455,6 +2633,8 @@ fn generate_method_ids(
         };
 
         let cfg_attrs = extract_cfg_attrs(&method.attrs);
+        let is_optional = !method.requires.is_empty();
+        let requires_expr = requires_to_token_stream(&method.requires);
 
         lookups.push(IdLookup {
             field_name: method_id_field,
@@ -2463,6 +2643,8 @@ fn generate_method_ids(
             signature: jni_sig_str,
             lookup_fn,
             cfg_attrs,
+            is_optional,
+            requires_expr,
         });
     }
 
@@ -2509,6 +2691,8 @@ fn generate_field_ids(
         };
 
         let cfg_attrs = extract_cfg_attrs(&field.attrs);
+        let is_optional = !field.requires.is_empty();
+        let requires_expr = requires_to_token_stream(&field.requires);
 
         lookups.push(IdLookup {
             field_name: field_id_field,
@@ -2517,6 +2701,8 @@ fn generate_field_ids(
             signature: field_sig,
             lookup_fn,
             cfg_attrs,
+            is_optional,
+            requires_expr,
         });
     }
 
@@ -2723,6 +2909,7 @@ fn generate_methods(
         let method_id_field = format_ident!("{}_method_id", rust_name);
         let visibility = method.visibility.to_tokens();
         let is_static = method.is_static;
+        let is_optional = !method.requires.is_empty();
 
         // Generate JNI call arguments data
         let args = generate_jni_call_args(&method.method_signature.parameters, type_mappings, jni);
@@ -2778,6 +2965,16 @@ fn generate_methods(
             quote! { self }
         };
 
+        // Get the method ID (with optional check)
+        let get_method_id = if is_optional {
+            quote! {
+                let method_id = api.#method_id_field.ok_or_else(|| #jni::errors::Error::UnsupportedVersion)?;
+            }
+        } else {
+            quote! { let method_id = api.#method_id_field; }
+        };
+        let method_id_expr = quote! { method_id.into_raw() };
+
         // Generate the method body with JNI call
         let jni_call = generate_jni_call_for_return_type(
             &method.java_name,
@@ -2785,7 +2982,7 @@ fn generate_methods(
             is_static,
             jni,
             &this_or_class,
-            &quote! { api.#method_id_field.into_raw() },
+            &method_id_expr,
             &quote! { jni_args },
             type_mappings,
         );
@@ -2828,6 +3025,7 @@ fn generate_methods(
                 #(#decls),*
             ) -> #jni::errors::Result<#return_type> {
                 let api = #api_name::get(env, &#jni::refs::LoaderContext::None)?;
+                #get_method_id
                 let jni_args #jni_args_type = [#(#jvalue_conversions),*];
 
                 #class_def
@@ -3071,6 +3269,7 @@ fn generate_fields(
     for field in fields {
         let rust_name = &field.rust_name;
         let field_id_field = format_ident!("{}_field_id", rust_name);
+        let is_optional = !field.requires.is_empty();
 
         // Determine environment type based on field type (primitives use &Env, objects use &mut Env)
         let get_env_type = if field
@@ -3143,6 +3342,16 @@ fn generate_fields(
             quote! {}
         };
 
+        // Get the field ID (with optional check)
+        let get_field_id = if is_optional {
+            quote! {
+                let field_id = api.#field_id_field.ok_or_else(|| #jni::errors::Error::UnsupportedVersion)?;
+            }
+        } else {
+            quote! { let field_id = api.#field_id_field; }
+        };
+        let field_id_expr = quote! { field_id.into_raw() };
+
         if let Some(getter_name) = &field.getter_name {
             let getter_visibility = field.getter_visibility.to_tokens();
 
@@ -3180,7 +3389,7 @@ fn generate_fields(
                 field.is_static,
                 jni,
                 &this_or_class,
-                &quote! { api.#field_id_field.into_raw() },
+                &field_id_expr,
                 type_mappings,
             );
 
@@ -3209,6 +3418,7 @@ fn generate_fields(
                     env: #get_env_type
                 ) -> #jni::errors::Result<#return_type> {
                     let api = #api_name::get(env, &#jni::refs::LoaderContext::None)?;
+                    #get_field_id
                     #class_def
                     #get_null_check_and_return
                 }
@@ -3258,7 +3468,7 @@ fn generate_fields(
                 field.is_static,
                 jni,
                 &this_or_class,
-                &quote! { api.#field_id_field.into_raw() },
+                &field_id_expr,
                 &quote! { val },
                 type_mappings,
             );
@@ -3286,6 +3496,7 @@ fn generate_fields(
                     val: #arg_type
                 ) -> #jni::errors::Result<()> {
                     let api = #api_name::get(env, &#jni::refs::LoaderContext::None)?;
+                    #get_field_id
                     #class_def
                     #set_null_check_and_call
                 }
@@ -3708,7 +3919,8 @@ fn generate_native_registration_code(
         return Ok(quote! {});
     }
 
-    let mut native_method_descriptors = Vec::new();
+    let mut unconditional_descriptors = Vec::new();
+    let mut conditional_blocks = Vec::new();
 
     for method in native_methods {
         let java_name = &method.java_name;
@@ -3740,29 +3952,70 @@ fn generate_native_registration_code(
         // Extract cfg attributes to guard the registration descriptor
         let cfg_attrs = extract_cfg_attrs(&method.attrs);
 
-        native_method_descriptors.push(quote! {
+        let descriptor = quote! {
             #(#cfg_attrs)*
             #jni::NativeMethod::from_raw_parts(
                 #jni::strings::JNIStr::from_cstr_unchecked(#name_cstr),
                 #jni::strings::JNIStr::from_cstr_unchecked(#sig_cstr),
                 #fn_ptr,
             )
-        });
+        };
+
+        if !method.requires.is_empty() {
+            // Optional native method - conditionally register
+            let requires_check = requires_to_token_stream(&method.requires).unwrap();
+            conditional_blocks.push(quote! {
+                #(#cfg_attrs)*
+                {
+                    // Make sure expression can't accidentally capture any variables from the
+                    // surrounding scope by evaluating it in a separate function.
+                    fn __eval_requires() -> bool {
+                        #requires_check
+                    }
+                    if __eval_requires() {
+                        native_methods.push(#descriptor);
+                    }
+                }
+            });
+        } else {
+            // Unconditional native method
+            unconditional_descriptors.push(descriptor);
+        }
     }
 
-    Ok(quote! {
-        {
-            // Safety: All of the name and signature CStr literals have been validate
-            // at compile time and encoded as MUTF-8 - therefore they can be safely
-            // cast to a JNIStr unchecked at runtime.
-            unsafe {
-                let native_methods = &[
-                    #(#native_method_descriptors),*
-                ];
-                env.register_native_methods(class, native_methods)?;
+    // Generate the registration code
+    if conditional_blocks.is_empty() {
+        // All methods are unconditional - use simpler array syntax
+        Ok(quote! {
+            {
+                // Safety: All of the name and signature CStr literals have been validated
+                // at compile time and encoded as MUTF-8 - therefore they can be safely
+                // cast to a JNIStr unchecked at runtime.
+                unsafe {
+                    let native_methods = &[
+                        #(#unconditional_descriptors),*
+                    ];
+                    env.register_native_methods(class, native_methods)?;
+                }
             }
-        }
-    })
+        })
+    } else {
+        // We have conditional methods - build a Vec at runtime
+        Ok(quote! {
+            {
+                // Safety: All of the name and signature CStr literals have been validated
+                // at compile time and encoded as MUTF-8 - therefore they can be safely
+                // cast to a JNIStr unchecked at runtime.
+                unsafe {
+                    let mut native_methods = vec![
+                        #(#unconditional_descriptors),*
+                    ];
+                    #(#conditional_blocks)*
+                    env.register_native_methods(class, &native_methods)?;
+                }
+            }
+        })
+    }
 }
 
 /// Generate exported native method functions for methods marked with export = true

--- a/crates/jni/docs/macros/bind_java_type_0_overview.md
+++ b/crates/jni/docs/macros/bind_java_type_0_overview.md
@@ -32,6 +32,7 @@ use jni::bind_java_type;
 use jni::Env;
 use jni::objects::JString;
 use jni::sys::jint;
+# fn check_version(major: i32, minor: i32) -> bool { true } // Placeholder for runtime version check
 
 bind_java_type! {
     rust_type = Counter,
@@ -43,9 +44,11 @@ bind_java_type! {
     },
 
     methods {
-        fn increment(),
         fn get_value() -> jint,
-        static fn get_version() -> JString,
+        fn increment(),
+        #[jni(requires = check_version(1, 2))]
+        fn multiply(a: jint, b: jint) -> jint,
+        static fn get_pi() -> f64,
     },
 
     fields {
@@ -82,8 +85,10 @@ The `{Type}API::get(&mut Env, &LoaderContext)` method:
 
 - Loads and caches the Java class reference (using `LoaderContext` if needed)
 - Caches all method IDs and field IDs for fast access
+  - If methods/fields have `#[jni(requires = ...)]` attributes, only looks up IDs for methods/fields that meet the requirements
 - Validates type mappings and class relationships at runtime
 - Registers native methods with the JVM (if any are declared)
+  - If native methods have `#[jni(requires = ...)]` attributes, only registers those that meet the requirements
 
 This initialization happens lazily on the first call to `get()` and is thread-safe.
 
@@ -128,6 +133,10 @@ Methods and fields also support shorthand and block syntax.
 methods {
     fn add(a: jint, b: jint) -> jint,
     static fn get_version() -> jint,
+},
+fields {
+    count: jint,
+    static name: JString,
 }
 # }
 ```
@@ -141,6 +150,12 @@ methods {
     fn my_method {
         sig = (value: jint),
         name = "myJavaMethod",
+    },
+},
+fields {
+    my_field {
+        sig = JString,
+        name = "myJavaField",
     },
 }
 # }
@@ -190,6 +205,44 @@ methods {
 }
 # }
 ```
+
+# Runtime Requirements and Version Checks
+
+The `#[jni(requires = ...)]` attribute allows you to specify a Rust expression
+can be evaluated at runtime to determine if a method/field/native method is available.
+
+This is useful for conditional bindings based on runtime version checks (e.g., Android API level).
+
+When a method/field/native method has a `#[jni(requires = ...)]` attribute, the generated API will:
+- Only look up the method/field ID or register the native method if the requirement is met
+- Return an error (`Error::UnsupportedVersion`) if you try to call a method or
+  access a field that does not meet the requirement
+
+A requirement can either be given in the form of a function call that may only
+accept literal integer arguments (or no arguments), or a string literal can be
+used to quote an arbitrary Rust expression.
+
+For example:
+
+```rust
+# use jni::bind_java_type;
+# fn check_version(major: i32, minor: i32) -> bool { true } // Placeholder for runtime version check
+# bind_java_type! { pub MyType => com.example.MyClass,
+methods {
+    #[jni(requires = check_version(1, 2))]
+    fn new_method() -> jint,
+    #[jni(requires = "true")] // Always available, but shows how to use a string expression
+    fn another_method() -> jint,
+}
+# }
+```
+
+**Warning**: You must ensure that the expressions used in `#[jni(requires = ...)]`:
+- Can not lead to recursion by calling back into the `{Type}API::get()` method that is currently
+  initializing. I.e. don't call into a binding that itself has `#[jni(requires = ...)]` attributes
+  that could lead to a cycle when initializing the API.
+- Have no observable side effects, as they may be evaluated multiple times or not at all depending
+  on how the API is used.
 
 # == INDEX ==
 

--- a/crates/jni/tests/bind_fields.rs
+++ b/crates/jni/tests/bind_fields.rs
@@ -380,6 +380,44 @@ fn setup_test_output(test_name: &str) -> PathBuf {
     out_dir
 }
 
+// Version check function for testing requires attribute
+fn field_check_version_21() -> bool {
+    false // Simulate version < 21
+}
+
+fn field_check_version(version: u32) -> bool {
+    const CURRENT_VERSION: u32 = 20;
+    version <= CURRENT_VERSION
+}
+
+// Bindings for testing requires attribute with fields
+bind_java_type! {
+    rust_type = TestFieldsWithRequires,
+    java_type = "com.example.TestFields",
+    constructors {
+        fn new(),
+    },
+    fields {
+        int_field: jint,  // Should work (no requires)
+
+        // This field should fail at runtime
+        #[jni(requires = field_check_version_21())]
+        long_field: jlong,
+
+        // This field should work
+        #[jni(requires = field_check_version(19))]
+        string_field: JString,
+
+        // Test with literal expression
+        #[jni(requires = "true")]
+        boolean_field: jboolean,
+
+        // Test with literal expression false
+        #[jni(requires = "false")]
+        byte_field: jbyte,
+    }
+}
+
 rusty_fork_test! {
 #[test]
 fn test_non_null_field_validation() {
@@ -457,5 +495,74 @@ fn test_non_null_field_validation() {
         Ok(())
     })
     .expect("Non-null field validation test failed");
+}
+}
+
+rusty_fork_test! {
+#[test]
+fn test_requires_attribute_fields() {
+    let out_dir = setup_test_output("bind_fields_requires");
+
+    javac::Build::new()
+        .file("tests/java/com/example/TestFields.java")
+        .output_dir(&out_dir)
+        .compile();
+
+    util::attach_current_thread(|env| {
+        load_test_fields_class(env, &out_dir)?;
+
+        let obj = TestFieldsWithRequires::new(env)?;
+
+        // Test that int_field works (no requires)
+        let value = obj.int_field(env)?;
+        assert_eq!(value, 10); // default value from constructor
+
+        obj.set_int_field(env, 42)?;
+        let value = obj.int_field(env)?;
+        assert_eq!(value, 42);
+
+        // Test that long_field fails (requires = false)
+        let result = obj.long_field(env);
+        assert!(result.is_err());
+        if let Err(e) = result {
+            assert!(matches!(e, jni::errors::Error::UnsupportedVersion));
+        }
+
+        let result = obj.set_long_field(env, 123456);
+        assert!(result.is_err());
+        if let Err(e) = result {
+            assert!(matches!(e, jni::errors::Error::UnsupportedVersion));
+        }
+
+        // Test that string_field works (requires = true)
+        let _value = obj.string_field(env)?;
+        let new_string = JString::from_str(env, "test")?;
+        obj.set_string_field(env, &new_string)?;
+        let result = obj.string_field(env)?;
+        assert_eq!(result.to_string(), "test");
+
+        // Test that boolean_field works (requires = "true")
+        let value = obj.boolean_field(env)?;
+        assert!(!value); // default value
+        obj.set_boolean_field(env, true)?;
+        let value = obj.boolean_field(env)?;
+        assert!(value);
+
+        // Test that byte_field fails (requires = "false")
+        let result = obj.byte_field(env);
+        assert!(result.is_err());
+        if let Err(e) = result {
+            assert!(matches!(e, jni::errors::Error::UnsupportedVersion));
+        }
+
+        let result = obj.set_byte_field(env, 10);
+        assert!(result.is_err());
+        if let Err(e) = result {
+            assert!(matches!(e, jni::errors::Error::UnsupportedVersion));
+        }
+
+        Ok(())
+    })
+    .expect("Requires attribute fields test failed");
 }
 }

--- a/crates/jni/tests/bind_methods.rs
+++ b/crates/jni/tests/bind_methods.rs
@@ -2,11 +2,12 @@
 mod util;
 
 use jni::Env;
+use jni::bind_java_type;
 use jni::objects::JString;
-use jni::{bind_java_type, jni_str};
 use rusty_fork::rusty_fork_test;
 use std::fs;
 use std::path::{Path, PathBuf};
+use std::sync::OnceLock;
 
 // Create bindings for TestMethods class
 bind_java_type! {
@@ -407,23 +408,28 @@ fn test_cfg_guarded_methods() {
 }
 
 // Helper function to load the TestMethods class
-fn load_test_methods_class(env: &mut Env, out_dir: &Path) -> jni::errors::Result<()> {
-    let class_path = out_dir.join("com/example/TestMethods.class");
-    assert!(class_path.exists(), "TestMethods.class not found");
+fn load_test_class(env: &mut Env, out_dir: &Path, name: &str) -> jni::errors::Result<()> {
+    let class_path = out_dir.join(format!("com/example/{}.class", name));
+    assert!(class_path.exists(), "{}.class not found", name);
 
-    let class_bytes = fs::read(&class_path).expect("Failed to read TestMethods.class");
+    let class_bytes =
+        fs::read(&class_path).unwrap_or_else(|_| panic!("Failed to read {}.class", name));
 
     let class_loader = jni::objects::JClassLoader::get_system_class_loader(env)
         .expect("Failed to get system class loader");
 
     env.define_class(
-        Some(jni_str!("com/example/TestMethods")),
+        Option::<&jni::strings::JNIStr>::None, // Urgh, passing None was supposed to be the easy choice :)
         &class_loader,
         &class_bytes,
     )
     .expect("Failed to define TestMethods class");
 
     Ok(())
+}
+
+fn load_test_methods_class(env: &mut Env, out_dir: &Path) -> jni::errors::Result<()> {
+    load_test_class(env, out_dir, "TestMethods")
 }
 
 // Helper function to set up test output directory
@@ -437,4 +443,152 @@ fn setup_test_output(test_name: &str) -> PathBuf {
     fs::create_dir_all(&out_dir).expect("Failed to create test output directory");
 
     out_dir
+}
+
+bind_java_type! {
+    TestVersion => "com.example.TestVersion",
+    fields {
+        #[allow(non_snake_case)]
+        static VERSION: jint,
+    }
+}
+
+// Cache for the Java version, queried once from TestVersion.VERSION
+static TEST_VERSION: OnceLock<u32> = OnceLock::new();
+
+// Demonstrate checking some `#[jni(requires = )]` conditions at runtime by
+// querying a Java version field and caching it
+fn jni_check_version(required_version: u32) -> bool {
+    let version = TEST_VERSION.get_or_init(|| {
+        let jvm = jni::JavaVM::singleton().expect("JavaVM singleton not initialized");
+        jvm.attach_current_thread(|env| TestVersion::VERSION(env))
+            .expect("Failed to get Java version") as u32
+    });
+
+    println!(
+        "Checking Java version ({}) >= {}",
+        *version, required_version
+    );
+
+    *version >= required_version
+}
+
+fn check_version_21() -> bool {
+    jni_check_version(21)
+}
+
+fn check_version(version: u32) -> bool {
+    jni_check_version(version)
+}
+
+fn check_feature_enabled() -> bool {
+    true // Simulate feature is enabled
+}
+
+// Bindings for testing requires attribute with methods
+bind_java_type! {
+    rust_type = TestMethodsWithRequires,
+    java_type = "com.example.TestMethods",
+    constructors {
+        fn new(),
+        // This constructor should fail at runtime since check_version_21() returns false
+        #[jni(requires = check_version_21())]
+        fn new_v21_only(message: JString),
+    },
+    methods {
+        fn get_message() -> JString,
+        // This method should fail at runtime
+        #[jni(requires = check_version_21())]
+        fn get_counter() -> jint,
+        // This method should work
+        #[jni(requires = check_version(19))]
+        fn set_message(message: JString) -> void,
+        // Test with literal expression
+        #[jni(requires = "true")]
+        fn reset() -> void,
+        // Test with literal expression false
+        #[jni(requires = "false")]
+        fn increment() -> void,
+        // Test with multiple requires - all must be true (should work)
+        #[jni(requires = check_version(19))]
+        #[jni(requires = check_feature_enabled())]
+        fn combined_check_pass() -> void,
+        // Test with multiple requires - one is false (should fail)
+        #[jni(requires = check_version(19))]
+        #[jni(requires = check_version_21())]
+        fn combined_check_fail() -> void,
+    }
+}
+
+rusty_fork_test! {
+#[test]
+fn test_requires_attribute_methods() {
+    let out_dir = setup_test_output("bind_methods_requires");
+
+    javac::Build::new()
+        .file("tests/java/com/example/TestVersion.java")
+        .file("tests/java/com/example/TestMethods.java")
+        .output_dir(&out_dir)
+        .compile();
+
+    util::attach_current_thread(|env| {
+        load_test_class(env, &out_dir, "TestVersion")?;
+        load_test_methods_class(env, &out_dir)?;
+
+        // Test that new() works (no requires)
+        let obj = TestMethodsWithRequires::new(env)?;
+
+        // Test that constructor with requires = false fails
+        let msg = JString::from_str(env, "test")?;
+        let result = TestMethodsWithRequires::new_v21_only(env, &msg);
+        assert!(result.is_err());
+        if let Err(e) = result {
+            assert!(matches!(e, jni::errors::Error::UnsupportedVersion));
+        }
+
+        // Test that get_message() works (no requires)
+        let message = obj.get_message(env)?;
+        assert_eq!(message.to_string(), "default");
+
+        // Test that get_counter() fails (requires = false)
+        let result = obj.get_counter(env);
+        assert!(result.is_err());
+        if let Err(e) = result {
+            assert!(matches!(e, jni::errors::Error::UnsupportedVersion));
+        }
+
+        // Test that set_message() works (requires = true)
+        let new_msg = JString::from_str(env, "updated")?;
+        obj.set_message(env, &new_msg)?;
+        let message = obj.get_message(env)?;
+        assert_eq!(message.to_string(), "updated");
+
+        // Test that reset() works (requires = "true")
+        obj.reset(env)?;
+        let message = obj.get_message(env)?;
+        assert_eq!(message.to_string(), "default");
+
+        // Test that increment() fails (requires = "false")
+        let result = obj.increment(env);
+        assert!(result.is_err());
+        if let Err(e) = result {
+            assert!(matches!(e, jni::errors::Error::UnsupportedVersion));
+        }
+
+        // Test combined requires - all conditions true (should work)
+        obj.combined_check_pass(env)?;
+        let message = obj.get_message(env)?;
+        assert_eq!(message.to_string(), "combined pass");
+
+        // Test combined requires - one condition false (should fail)
+        let result = obj.combined_check_fail(env);
+        assert!(result.is_err());
+        if let Err(e) = result {
+            assert!(matches!(e, jni::errors::Error::UnsupportedVersion));
+        }
+
+        Ok(())
+    })
+    .expect("Requires attribute methods test failed");
+}
 }

--- a/crates/jni/tests/bind_native_methods.rs
+++ b/crates/jni/tests/bind_native_methods.rs
@@ -353,3 +353,131 @@ native_method_test! {
         Ok(())
     }
 }
+
+// Version check function for testing requires attribute
+fn native_check_version_21() -> bool {
+    false // Simulate version < 21
+}
+
+fn native_check_version_19() -> bool {
+    true // Simulate version >= 19
+}
+
+// Bindings for testing requires attribute with native methods
+bind_java_type! {
+    rust_type = TestNativeMethodsWithRequires,
+    java_type = "com.example.TestNativeMethods",
+    constructors {
+        fn new(),
+    },
+    methods {
+        fn get_counter() -> jint,
+    },
+    native_methods {
+        // This native method should work (no requires)
+        pub fn native_basic_add(a: jint, b: jint) -> jint,
+
+        // This native method should not be registered (requires = false)
+        #[jni(requires = native_check_version_21())]
+        pub fn native_v21_only(value: jint) -> jint,
+
+        // This native method should be registered ( requires = true)
+        #[jni(requires = native_check_version_19())]
+        pub fn native_v19_available(value: jint) -> jint,
+
+        // Test with literal expression
+        #[jni(requires = "true")]
+        pub fn native_literal_true(value: jint) -> jint,
+
+        // Test with literal expression false
+        #[jni(requires = "false")]
+        pub fn native_literal_false(value: jint) -> jint,
+    }
+}
+
+impl TestNativeMethodsWithRequiresNativeInterface for TestNativeMethodsWithRequiresAPI {
+    type Error = jni::errors::Error;
+
+    fn native_basic_add<'local>(
+        _env: &mut Env<'local>,
+        _this: TestNativeMethodsWithRequires<'local>,
+        a: jint,
+        b: jint,
+    ) -> Result<jint, Self::Error> {
+        Ok(a + b)
+    }
+
+    fn native_v21_only<'local>(
+        _env: &mut Env<'local>,
+        _this: TestNativeMethodsWithRequires<'local>,
+        value: jint,
+    ) -> Result<jint, Self::Error> {
+        Ok(value * 21)
+    }
+
+    fn native_v19_available<'local>(
+        _env: &mut Env<'local>,
+        _this: TestNativeMethodsWithRequires<'local>,
+        value: jint,
+    ) -> Result<jint, Self::Error> {
+        Ok(value * 19)
+    }
+
+    fn native_literal_true<'local>(
+        _env: &mut Env<'local>,
+        _this: TestNativeMethodsWithRequires<'local>,
+        value: jint,
+    ) -> Result<jint, Self::Error> {
+        Ok(value + 100)
+    }
+
+    fn native_literal_false<'local>(
+        _env: &mut Env<'local>,
+        _this: TestNativeMethodsWithRequires<'local>,
+        value: jint,
+    ) -> Result<jint, Self::Error> {
+        Ok(value - 100)
+    }
+}
+
+// Note: This test verifies that optional native methods with requires=false
+// are NOT registered. The test should pass if calling the Java method
+// throws a NoSuchMethodError (native method not found). Since we're just
+// checking registration behavior here, we simply verify that the API
+// initialization succeeds and that the registration logic works correctly.
+native_method_test! {
+    test_name: test_requires_attribute_native_methods,
+    java_class: "com/example/TestNativeMethods.java",
+    api: TestNativeMethodsWithRequiresAPI,
+    test_body: |env| {
+        let obj = TestNativeMethodsWithRequires::new(env)?;
+
+        // Basic method should work (no requires)
+        let result = obj.native_basic_add(env, 10, 20)?;
+        assert_eq!(result, 30);
+
+        // Method with requires = true should work
+        let result = obj.native_v19_available(env, 5)?;
+        assert_eq!(result, 95);
+
+        // Method with requires = "true" should work
+        let result = obj.native_literal_true(env, 50)?;
+        assert_eq!(result, 150);
+
+        // Methods with requires = false should return UnsupportedVersion error
+        // when called from Rust
+        let result = obj.native_v21_only(env, 10);
+        assert!(result.is_err());
+        if let Err(e) = result {
+            assert!(matches!(e, jni::errors::Error::UnsupportedVersion));
+        }
+
+        let result = obj.native_literal_false(env, 10);
+        assert!(result.is_err());
+        if let Err(e) = result {
+            assert!(matches!(e, jni::errors::Error::UnsupportedVersion));
+        }
+
+        Ok(())
+    }
+}

--- a/crates/jni/tests/java/com/example/TestMethods.java
+++ b/crates/jni/tests/java/com/example/TestMethods.java
@@ -99,6 +99,17 @@ public class TestMethods {
         return null;
     }
 
+    // Methods for testing combined requires attributes
+    public void combinedCheckPass() {
+        // This method should be accessible when all requires conditions are true
+        message = "combined pass";
+    }
+
+    public void combinedCheckFail() {
+        // This method should fail when any requires condition is false
+        message = "combined fail";
+    }
+
     public String getRequiredMessage() {
         // This method returns null to test that non_null validation catches it
         return null;

--- a/crates/jni/tests/java/com/example/TestNativeMethods.java
+++ b/crates/jni/tests/java/com/example/TestNativeMethods.java
@@ -41,6 +41,17 @@ public class TestNativeMethods {
 
     public native int nativeInvocationTest();
 
+    // Native methods to test requires attribute support
+    public native int nativeBasicAdd(int a, int b);
+
+    public native int nativeV21Only(int value);
+
+    public native int nativeV19Available(int value);
+
+    public native int nativeLiteralTrue(int value);
+
+    public native int nativeLiteralFalse(int value);
+
     // Non-native methods that can be used to test native method calls
     public int getCounter() {
         return counter;

--- a/crates/jni/tests/java/com/example/TestVersion.java
+++ b/crates/jni/tests/java/com/example/TestVersion.java
@@ -1,0 +1,13 @@
+package com.example;
+
+/**
+ * Test class for version checking in requires attribute tests.
+ */
+public class TestVersion {
+    // Static version field that can be queried
+    public static final int VERSION = 20;
+
+    private TestVersion() {
+        // Utility class, prevent instantiation
+    }
+}


### PR DESCRIPTION
This makes it possible to declare optional bindings with runtime-checked requirements.

For example, this can be used to add version checks to methods and fields like:

```rust
#[jni(requires = check_version(1, 2, 3)]
fn my_new_func() -> JString,
```

The 'requires' expression will be checked before `<Type>API::get()` does any corresponding method ID lookup or registers a native method implementation.

If multiple 'requires' attributes are given then the expressions will be logically chained together with `&&` to check that they are all true.

In the generated code, any 'requires' expressions are wrapped with an inner `fn __eval() -> bool {}` function before evaluation, so they can't capture any state from the scope in which they are evaluated (such as the `env`, `class` or `loader`).

If an API is called that depends on a missing ID (that failed its requirements check) then it will return `Error::UnsupportedVersion`.

This adds a '# Runtime Requirements and Version Checks' section to the `bind_java_type!` documentation to explain this functionality with a brief example.

The documentation also warns that it's the developer's responsibility to avoid any risk of recursion by attempting to use JNI within a check function to access a binding that itself needs to call the same check function.

Fixes: #764

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Change is covered by [automated tests](https://github.com/jni-rs/jni-rs/blob/master/CONTRIBUTING.md#tests)
- [x] The [coding guidelines](https://github.com/jni-rs/jni-rs/blob/master/CONTRIBUTING.md#the-code-style) are followed
- [x] Public API has documentation
- [x] User-visible changes are mentioned in the Changelog
- [x] The continuous integration build passes
