### PR TITLE
Fix array/object type check in Env::{set_field, set_static_field}

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+#### Fixed
+
+- `Env::{set_field, set_static_field}` no longer throw `WrongJValueType` when passed array values for array signatures
+
 
 ## [0.22.4] — 2026-03-16
 

--- a/crates/jni/src/env.rs
+++ b/crates/jni/src/env.rs
@@ -3997,9 +3997,8 @@ See the jni-rs Env documentation for more details.
         let obj = obj.as_ref();
         let obj = null_check!(obj, "set_field obj argument")?;
         let sig = sig.as_ref();
-        let field_ty = sig.ty();
 
-        if value.java_type() != field_ty {
+        if !sig.type_is_compatible_with(value.java_type()) {
             return Err(Error::WrongJValueType(value.type_name(), "see java field"));
         }
 
@@ -4173,9 +4172,8 @@ See the jni-rs Env documentation for more details.
         S: AsRef<FieldSignature<'sig>>,
     {
         let sig = sig.as_ref();
-        let field_ty = sig.ty();
 
-        if value.java_type() != field_ty {
+        if !sig.type_is_compatible_with(value.java_type()) {
             return Err(Error::WrongJValueType(value.type_name(), "see java field"));
         }
 

--- a/crates/jni/src/signature.rs
+++ b/crates/jni/src/signature.rs
@@ -196,6 +196,17 @@ impl<'sig> FieldSignature<'sig> {
     pub fn ty(&self) -> JavaType {
         self.ty
     }
+
+    /// Check if the type of this field is compatible with the given type. This
+    /// is not quite an equality check on `Self::ty()` because `JavaType::Array`
+    /// signatures are considered compatible with `JavaType::Object` values
+    pub fn type_is_compatible_with(&self, ty: JavaType) -> bool {
+        match (self.ty, ty) {
+            (JavaType::Array | JavaType::Object, JavaType::Array | JavaType::Object) => true,
+            (a, b) if a == b => true,
+            _ => false,
+        }
+    }
 }
 
 /// A runtime-parsed JNI method signature.

--- a/crates/jni/tests/java/com/example/TestFields.java
+++ b/crates/jni/tests/java/com/example/TestFields.java
@@ -5,6 +5,7 @@ package com.example;
  * bindings.
  */
 public class TestFields {
+
     // Static primitive fields
     public static int staticIntField = 42;
     public static long staticLongField = 9876543210L;
@@ -14,6 +15,7 @@ public class TestFields {
     public static float staticFloatField = 3.14f;
     public static double staticDoubleField = 2.71828;
     public static char staticCharField = 'X';
+    public static byte[] staticByteArray = new byte[0];
 
     // Static String field
     public static String staticStringField = "static string value";
@@ -27,13 +29,14 @@ public class TestFields {
     public float floatField;
     public double doubleField;
     public char charField;
+    public byte[] byteArrayField;
 
     // Instance String field
     public String stringField;
 
     // Fields for testing non_null validation
-    public String nullableStringField;  // Can be null
-    public String requiredStringField;  // Should be validated with non_null
+    public String nullableStringField; // Can be null
+    public String requiredStringField; // Should be validated with non_null
     public String validatedStringField; // Should be validated with non_null (block syntax)
 
     // Fields guarded by _cfg_test feature (never enabled in tests)
@@ -54,9 +57,10 @@ public class TestFields {
         this.floatField = 1.5f;
         this.doubleField = 2.5;
         this.charField = 'A';
+        this.byteArrayField = new byte[0];
         this.stringField = "instance string";
-        this.nullableStringField = null;  // Initialize to null for testing
-        this.requiredStringField = null;  // Initialize to null to test validation
+        this.nullableStringField = null; // Initialize to null for testing
+        this.requiredStringField = null; // Initialize to null to test validation
         this.validatedStringField = null; // Initialize to null to test validation
         this.instanceCfgTestField = 77;
         this.instanceInvocationField = 88;

--- a/crates/jni/tests/jni_api.rs
+++ b/crates/jni/tests/jni_api.rs
@@ -340,6 +340,76 @@ pub fn set_public_field_by_id() {
     .unwrap();
 }
 
+rusty_fork::rusty_fork_test! {
+    #[test]
+    fn set_array_field() {
+        // This test reproduces an issue where the `set_field` threw an error when
+        // setting an array field. The reason this was happening is that `set_field`
+        // checks that the type of the incoming `JValue` matches the type of the
+        // field, but the type of an array returned by `new_byte_array` is
+        // `JavaType::Object` whilst the type of an array signature is
+        // `JavaType::Array`.
+        let out_dir = util::setup_test_output("set_array_field");
+
+        javac::Build::new()
+            .file("tests/java/com/example/TestFields.java")
+            .output_dir(&out_dir)
+            .compile();
+        attach_current_thread(|env| {
+            util::load_test_class(env, &out_dir, "TestFields")?;
+
+            let instance = env.new_object(jni_str!("com/example/TestFields"), jni_sig!("()V"), &[])?;
+
+            // Set the `staticByteArray` field to a new value
+            let arr = env.new_byte_array(1)?;
+            env.set_field(
+                instance,
+                jni_str!("byteArrayField"),
+                jni_sig!("[B"),
+                JValue::Object(&arr),
+            )?;
+
+            Ok(())
+        })
+        .unwrap();
+    }
+
+    #[test]
+    fn set_static_array_field() {
+        // This test reproduces an issue where the `set_static_field` threw an error when
+        // setting an array field. The reason this was happening is that `set_static_field`
+        // checks that the type of the incoming `JValue` matches the type of the
+        // field, but the type of an array returned by `new_byte_array` is
+        // `JavaType::Object` whilst the type of an array signature is
+        // `JavaType::Array`.
+        let out_dir = util::setup_test_output("set_static_array_field");
+
+        javac::Build::new()
+            .file("tests/java/com/example/TestFields.java")
+            .output_dir(&out_dir)
+            .compile();
+
+        attach_current_thread(|env| {
+            util::load_test_class(env, &out_dir, "TestFields")?;
+
+            // let instance = env.new_object(jni_str!("com/example/TestFields"), jni_sig!("()V"), &[])?;
+            let class = env.load_class(jni_str!("com/example/TestFields"))?;
+
+            // Set the `staticByteArray` field to a new value
+            let arr = env.new_byte_array(1)?;
+            env.set_static_field(
+                class,
+                jni_str!("staticByteArray"),
+                jni_sig!("[B"),
+                JValue::Object(&arr),
+            )?;
+
+            Ok(())
+        })
+        .unwrap();
+    }
+}
+
 #[test]
 pub fn get_static_public_field() {
     attach_current_thread(|env| {


### PR DESCRIPTION
## Overview

`Env::{set_static_field, set_field}` throw a `WrongJValueType` error when passing an array value to a field with an array signature. This is due to a check that the signature type matches the incoming value type which appears to not take account of the fact that an array signature will have type `JavaType::Array` whilst a newly created array will have `JavaType::Object`. In this PR I've modified the logic so that object values are acceptable for array signatures. This behavior seems to be compatible with the behavior of `call_method` so it seems like it's the right direction.

## Details

In `Env::{set_static_field, set_field}` we perform a check that the incoming `JValue` matches the `FieldSignature::ty()` of the `FieldSignature` we were passed. When passing an array as the value this check is inconsistent with the JNI spec.

For example, given this class

    class Example {
        public byte[] byteArrayField;
    }

The following code will fail with a WrongJValueType error:

    let instance = env.new_object(..)?; // Create a new Example

    // Set the `byteArrayField` field to a new value
    let arr = env.new_byte_array(1)?;
    env.set_field(
        instance,
        jni_str!("byteArrayField"),
        jni_sig!("[B"),
        JValue::Object(&arr),
    )?;

The reason this fails is that the type check in `set_field` and `set_static_field` looks like this:

    if value.java_type() != sig.ty() {
        return Err(Error::WrongJValueType(value.type_name(), "see java field"));
    }

But for an array the `JValue::java_type()` returns `JavaType::Object` whilst for a `[B` signature `FieldSignature::ty()` returns `JavaType::Array`

This commit adds a `FieldSignature::type_is_compatible_with(JavaType)` method which accepts either a `JavaType::Object` or `JavaType::Array` for array signatures.