### PR TITLE
Extend docs for jni_mangle macro

### DIFF
--- a/crates/jni/docs/macros/jni_mangle.md
+++ b/crates/jni/docs/macros/jni_mangle.md
@@ -138,6 +138,24 @@ pub fn another_function<'local>(env: EnvUnowned<'local>, _: JObject<'local>) { }
 // Note: Only argument types are encoded, return type (V) is ignored
 ```
 
+With class not contained in package name:
+```
+# use jni::{ EnvUnowned, objects::JObject };
+# use jni_macros::jni_mangle;
+#[jni_mangle("com.example.with_underscore.RustBindings")]
+pub fn some_rust_function<'local>(env: EnvUnowned<'local>, _: JObject<'local>) { }
+// Generates: Java_com_example_with_1underscore_RustBindings_someRustFunction
+```
+
+Which can for example be accessed from Kotlin like this:
+```kotlin
+package com.example.with_underscore
+
+class RustBindings {
+    private external fun someRustFunction()
+}
+```
+
 Pre-existing "system" ABI is preserved:
 ```
 # use jni::{ EnvUnowned, objects::JObject };


### PR DESCRIPTION
## Overview

Adds a section to the documentation of the [`jni_mangle`](https://docs.rs/jni/latest/jni/attr.jni_mangle.html) macro, that demonstrates how to use the attribute when the *class name* is not already part of the *package name*.

This bit me when I first attempted to use the macro, therefore I thought this might help.

While at it I decided to also demonstrate how package names are mangled (which was my original assumption as to why the macro initially did not work as expected for me).
