### PR TITLE
CI: update trybuild stderr files for rustc 1.95.0

### DIFF
--- a/crates/jni/tests/ui/bind_java_type/fail/method_raw_fn.stderr
+++ b/crates/jni/tests/ui/bind_java_type/fail/method_raw_fn.stderr
@@ -3,9 +3,3 @@ error: Only native methods can have 'fn'
    |
 15 |         fn test_method {
    |            ^^^^^^^^^^^
-
-error[E0425]: cannot find type `TestClass` in this scope
- --> tests/ui/bind_java_type/fail/method_raw_fn.rs:7:72
-  |
-7 | extern "system" fn raw_method<'local>(_env: EnvUnowned<'local>, _this: TestClass<'local>) -> jint {
-  |                                                                        ^^^^^^^^^ not found in this scope

--- a/crates/jni/tests/ui/bind_java_type/fail/raw_fn_with_error_policy.stderr
+++ b/crates/jni/tests/ui/bind_java_type/fail/raw_fn_with_error_policy.stderr
@@ -3,9 +3,3 @@ error: Cannot specify 'error_policy' when using 'raw' - error_policy only applie
    |
 19 |         fn test_method {
    |            ^^^^^^^^^^^
-
-error[E0425]: cannot find type `TestClass` in this scope
- --> tests/ui/bind_java_type/fail/raw_fn_with_error_policy.rs:9:12
-  |
-9 |     _this: TestClass<'local>,
-  |            ^^^^^^^^^ not found in this scope


### PR DESCRIPTION
This fixes the CI builds since the latest toolchain generates a different output for some of the trybuild tests.