### PR TITLE
macros: fully qualify `std`  paths like `::std::path`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 #### Fixed
 
 - `Env::{set_field, set_static_field}` no longer throw `WrongJValueType` when passed array values for array signatures
-
+- Some `std` paths emitted by `bind_java_type` were not fully qualified with a `::` prefix
 
 ## [0.22.4] — 2026-03-16
 

--- a/crates/jni-macros/src/bind_java_type.rs
+++ b/crates/jni-macros/src/bind_java_type.rs
@@ -2146,7 +2146,7 @@ This does not require a runtime type check since any `"#, stringify!(#type_name)
                             fn as_ref(&self) -> &#type_path<'local> {
                                 const fn assert_is_instance_of_type_is_ffi_safe<T: #jni::refs::TransparentReference>() {}
                                 const _: () = assert_is_instance_of_type_is_ffi_safe::<#type_path<'_>>();
-                                unsafe { std::mem::transmute(self) }
+                                unsafe { ::std::mem::transmute(self) }
                             }
                         }
                     });

--- a/crates/jni-macros/src/types.rs
+++ b/crates/jni-macros/src/types.rs
@@ -1374,8 +1374,8 @@ pub fn generate_type_mapping_checks(type_mappings: &TypeMappings, jni: &syn::Pat
         type_checks.push(quote! {
             {
                 const _: () =  {
-                    assert!(std::mem::size_of::<#jni::sys::#jni_sys_prim>() == std::mem::size_of::<#rust_path>(), concat!("Size mismatch for primitive type ", stringify!(#rust_path)));
-                    assert!(std::mem::align_of::<#jni::sys::#jni_sys_prim>() == std::mem::align_of::<#rust_path>(), concat!("Alignment mismatch for primitive type ", stringify!(#rust_path)));
+                    assert!(::std::mem::size_of::<#jni::sys::#jni_sys_prim>() == ::std::mem::size_of::<#rust_path>(), concat!("Size mismatch for primitive type ", stringify!(#rust_path)));
+                    assert!(::std::mem::align_of::<#jni::sys::#jni_sys_prim>() == ::std::mem::align_of::<#rust_path>(), concat!("Alignment mismatch for primitive type ", stringify!(#rust_path)));
                 };
             }
         });


### PR DESCRIPTION
When investigating #810, I found a couple of `std::` API paths that were not fully-qualified with a `::` prefix.

In case someone were to define a like `mod std` in their crate then we want to address the `std` crate and not try and reference the local module.
