### PR TITLE
Avoid JNI call in PrimitiveArrayCritical section

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,10 +17,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-#### Fixed
+### Fixed
 
-- `Env::{set_field, set_static_field}` no longer throw `WrongJValueType` when passed array values for array signatures
-- Some `std` paths emitted by `bind_java_type` were not fully qualified with a `::` prefix
+- `Env::{set_field, set_static_field}` no longer throw `WrongJValueType` when passed array values for array signatures ([#811](https://github.com/jni-rs/jni-rs/pull/811))
+- Some `std` paths emitted by `bind_java_type` were not fully qualified with a `::` prefix ([#816](https://github.com/jni-rs/jni-rs/pull/816))
+- Avoid `ExceptionCheck` calls within `GetPrimitiveArrayCritical` section (avoiding Hotspot warnings about JNI calls not being allowed in critical sections) ([#817](https://github.com/jni-rs/jni-rs/pull/817))
 
 ## [0.22.4] — 2026-03-16
 

--- a/crates/jni/src/elements/auto_elements_critical.rs
+++ b/crates/jni/src/elements/auto_elements_critical.rs
@@ -43,13 +43,20 @@ where
     ) -> Result<Self> {
         let mut is_copy: jboolean = true;
 
+        // We use jni_call_no_post_check_ex! (not jni_call_with_catch_and_null_check!)
+        // because once GetPrimitiveArrayCritical succeeds we're immediately in a
+        // critical section where no other JNI calls are allowed (including
+        // exception_check or exception_clear).
+        //
+        // jni_call_no_post_check_ex! only does a pre-check for pending exceptions,
+        // then calls GetPrimitiveArrayCritical without any post-call exception
+        // checking.
+        //
+        // GetPrimitiveArrayCritical can return NULL on OutOfMemory and may throw
+        // OutOfMemoryError. If it returns NULL, no critical section has been
+        // created, so it's safe to make JNI calls to check/clear exceptions.
         let ptr = unsafe {
-            jni_call_with_catch_and_null_check!(
-                catch |env| {
-                    crate::exceptions::JOutOfMemoryError =>
-                        Err(Error::JniCall(JniError::NoMemory)),
-                    else => Err(Error::NullPtr("Unexpected Exception")),
-                },
+            jni_call_no_post_check_ex!(
                 env,
                 v1_2,
                 GetPrimitiveArrayCritical,
@@ -58,10 +65,22 @@ where
             )? as *mut T
         };
 
+        // Check for NULL return (indicates OutOfMemory)
+        // If we got NULL, no critical section was created, so we can safely
+        // make JNI calls to clear any pending exception.
+        let ptr = match NonNull::new(ptr) {
+            Some(ptr) => ptr,
+            None => {
+                // Clear any pending OutOfMemoryError before returning
+                env.exception_clear();
+                return Err(Error::JniCall(JniError::NoMemory));
+            }
+        };
+
         Ok(AutoElementsCritical {
             array,
             len,
-            ptr: NonNull::new(ptr).ok_or(Error::NullPtr("Non-null ptr expected"))?,
+            ptr,
             mode,
             is_copy: is_copy == sys::JNI_TRUE,
             _lifetime: PhantomData,


### PR DESCRIPTION
In #762 we made sure that all internal JNI calls for the `jni` crate would catch thrown exceptions and map those to suitable errors (instead of simply returning `JavaException`), and we introduced a `jni_call_with_catch_and_null_check` macro to help with this.

After making a JNI call, `jni_call_with_catch_and_null_check` will check for pending exceptions with a higher precedence than the `null` pointer check (avoiding assuming that all exceptions imply a `null` pointer will be returned) but this is problematic after calling `GetPrimitiveArrayCritical` because once we have opened a critical section we not allowed to make _any_ JNI calls until the critical section is closed.

As a special case, we now use `jni_call_no_post_check_ex` when calling `GetPrimitiveArrayCritical` and we check for a `null` pointer with a higher precedence to make sure we don't call `ExceptionCheck` within a new critical section.

This fix avoids having Hotspot log warnings when testing the `get_elements_critical` APIs due to making JNI calls within the critical section.
