### PR TITLE
Add JPrimitiveArray::into_elements[_critical]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - `JNIVersion::V24` constant for JNI version 24.0 ([#819](https://github.com/jni-rs/jni-rs/pull/819))
+- `JPrimitiveArray::into_elements[_critical]` methods for accessing elements without borrowing the array reference. ([#818](https://github.com/jni-rs/jni-rs/pull/818))
 
 ### Fixed
 
@@ -43,7 +44,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.22.3] — 2026-03-05
 
-#### Fixed
+### Fixed
 
 - docs.rs build: Bumps `simd_cesu8` dep to >= 1.1.1 which no longer has an automatically-enabled
 "nightly" feature that may affect the docs.rs build (1.1.x is now also MSRV compatible) ([#790](https://github.com/jni-rs/jni-rs/pull/790))

--- a/crates/jni/src/env.rs
+++ b/crates/jni/src/env.rs
@@ -4540,7 +4540,7 @@ See the jni-rs Env documentation for more details.
     /// See: [JPrimitiveArray::get_elements] for more details
     #[deprecated(
         since = "0.22.0",
-        note = "use JPrimitiveArray::get_elements instead. This API will be removed in a future version"
+        note = "use JPrimitiveArray::get_elements or JPrimitiveArray::into_elements instead. This API will be removed in a future version"
     )]
     pub unsafe fn get_array_elements<'array_local, T, TArrayRef>(
         &self,
@@ -4561,7 +4561,7 @@ See the jni-rs Env documentation for more details.
     /// See: [JPrimitiveArray::get_elements_critical] for more details
     #[deprecated(
         since = "0.22.0",
-        note = "use JPrimitiveArray::get_elements_critical instead. This API will be removed in a future version"
+        note = "use JPrimitiveArray::get_elements_critical or JPrimitiveArray::into_elements_critical instead. This API will be removed in a future version"
     )]
     pub unsafe fn get_array_elements_critical<'array_local, T, TArrayRef>(
         &self,

--- a/crates/jni/src/objects/jprimitive_array.rs
+++ b/crates/jni/src/objects/jprimitive_array.rs
@@ -210,6 +210,30 @@ impl<'local, T: TypeArray> JPrimitiveArray<'local, T> {
         AutoElements::new(env, self, mode)
     }
 
+    /// Returns an [`AutoElements`] to access the elements of this array,
+    /// consuming `self`.
+    ///
+    /// This is an alternative to [`Self::get_elements`] that can be useful when
+    /// you want to avoid getting an [`AutoElements`] that borrows `self`
+    /// because you want to call other methods on `self` while the elements are
+    /// still accessible, or you want to move the returned [`AutoElements`] to
+    /// another scope that doesn't borrow `self`.
+    ///
+    /// # Safety
+    ///
+    /// See the safety requirements of [`Self::get_elements`].
+    ///
+    /// Most importantly, the no-aliasing rules must be adhered to, and there
+    /// must not be any other [`AutoElements`] or [`AutoElementsCritical`] for
+    /// the same array at the same time.
+    pub unsafe fn into_elements(
+        self,
+        env: &Env,
+        mode: ReleaseMode,
+    ) -> Result<AutoElements<'local, T, Self>> {
+        AutoElements::new(env, self, mode)
+    }
+
     /// Returns an [`AutoElementsCritical`] to access the elements of this
     /// array.
     ///
@@ -308,6 +332,31 @@ impl<'local, T: TypeArray> JPrimitiveArray<'local, T> {
         env: &Env<'_>,
         mode: ReleaseMode,
     ) -> Result<AutoElementsCritical<'local, T, &Self>> {
+        AutoElementsCritical::new(env, self, mode)
+    }
+
+    /// Returns an [`AutoElementsCritical`] to access the elements of this
+    /// array, consuming `self`.
+    ///
+    /// This is an alternative to [`Self::get_elements_critical`] that can be
+    /// useful when you want to avoid getting an [`AutoElementsCritical`] that
+    /// borrows `self` because you want to call other methods on `self` while
+    /// the elements are still accessible, or you want to move the returned
+    /// [`AutoElementsCritical`] to another scope that doesn't borrow `self`.
+    ///
+    /// # Safety
+    ///
+    /// See the safety requirements of [`Self::get_elements_critical`].
+    ///
+    /// Most importantly, the critical section restrictions and no-aliasing
+    /// rules must be adhered to, and there must not be any other
+    /// [`AutoElements`] or [`AutoElementsCritical`] for the same array at the
+    /// same time.
+    pub unsafe fn into_elements_critical(
+        self,
+        env: &Env<'_>,
+        mode: ReleaseMode,
+    ) -> Result<AutoElementsCritical<'local, T, Self>> {
         AutoElementsCritical::new(env, self, mode)
     }
 

--- a/crates/jni/tests/jni_api.rs
+++ b/crates/jni/tests/jni_api.rs
@@ -1323,6 +1323,81 @@ pub fn get_array_elements_critical() {
 }
 
 #[test]
+pub fn into_elements() {
+    attach_current_thread(|env| {
+        // Create an AutoElements in an inner scope and move it to outer scope
+        // This demonstrates that into_elements doesn't borrow from the array reference
+        let mut auto_elements = {
+            let java_array = env.new_int_array(3).unwrap();
+
+            // Call into_elements, consuming the array reference
+            // Safety: No other references to the array elements exist
+            unsafe {
+                java_array
+                    .into_elements(env, ReleaseMode::CopyBack)
+                    .unwrap()
+            }
+            // java_array is consumed here, but auto_elements can be returned
+        };
+
+        // We can still use auto_elements after the inner scope
+        assert_eq!(auto_elements.len(), 3);
+
+        // Write values
+        auto_elements[0] = 10;
+        auto_elements[1] = 20;
+        auto_elements[2] = 30;
+
+        // Read values back
+        assert_eq!(auto_elements[0], 10);
+        assert_eq!(auto_elements[1], 20);
+        assert_eq!(auto_elements[2], 30);
+
+        Ok(())
+    })
+    .unwrap();
+}
+
+#[test]
+pub fn into_elements_critical() {
+    attach_current_thread(|env| {
+        // Create AutoElementsCritical and move it out of the scope where array was created
+        // This demonstrates that into_elements_critical doesn't borrow from self
+        let mut auto_ptr = {
+            let java_array = env.new_int_array(3).unwrap();
+            let buf: &[i32] = &[1, 2, 3];
+            java_array.set_region(env, 0, buf).unwrap();
+
+            // Call into_elements_critical, which consumes the array reference
+            // This is key: into_elements_critical takes ownership, not a borrow
+            unsafe {
+                java_array
+                    .into_elements_critical(env, ReleaseMode::CopyBack)
+                    .unwrap()
+            }
+            // java_array is consumed here, but auto_ptr can be returned
+        };
+
+        // We can still use auto_ptr after the inner scope where java_array was created
+        assert_eq!(auto_ptr.len(), 3);
+        assert_eq!(auto_ptr[0], 1);
+        assert_eq!(auto_ptr[1], 2);
+        assert_eq!(auto_ptr[2], 3);
+
+        // Modify via `DerefMut`
+        auto_ptr[0] += 1;
+        auto_ptr[1] += 1;
+        auto_ptr[2] += 1;
+
+        // Explicitly drop to end critical section before Ok(()) is returned
+        drop(auto_ptr);
+
+        Ok(())
+    })
+    .unwrap();
+}
+
+#[test]
 pub fn get_object_class() {
     attach_current_thread(|env| {
         let string = env.new_string("test").unwrap();

--- a/crates/jni/tests/ui/fail/auto-elements-lifetime.stderr
+++ b/crates/jni/tests/ui/fail/auto-elements-lifetime.stderr
@@ -1,4 +1,4 @@
-warning: use of deprecated method `jni::Env::<'local>::get_array_elements`: use JPrimitiveArray::get_elements instead. This API will be removed in a future version
+warning: use of deprecated method `jni::Env::<'local>::get_array_elements`: use JPrimitiveArray::get_elements or JPrimitiveArray::into_elements instead. This API will be removed in a future version
   --> tests/ui/fail/auto-elements-lifetime.rs:19:30
    |
 19 |                         env2.get_array_elements(java_array, ReleaseMode::CopyBack)


### PR DESCRIPTION
In #510 the `Env::get_array_elements[_critical]` APIs were update so they could take ownership of an array reference in order to get back some `AutoElements[Critical]` that doesn't borrow from a reference type.

Later we added `JPrimitiveArray::get_elements[_critical]` and marked the `Env` APIs as deprecated, but in doing that we lost (without using a deprecated API) the ability to avoid borrowing because these APIs always borrow from `self`.

This adds alternative `JPrimitiveArray::into_elements[_critical]` APIs that can return `AutoElements[Critical]` that take ownership of `self` instead of borrowing.

Fixes: #814

### Definition of Done

- [x] There are no TODOs left in the code
- [x] Change is covered by [automated tests](https://github.com/jni-rs/jni-rs/blob/master/CONTRIBUTING.md#tests)
- [x] The [coding guidelines](https://github.com/jni-rs/jni-rs/blob/master/CONTRIBUTING.md#the-code-style) are followed
- [x] Public API has documentation
- [x] User-visible changes are mentioned in the Changelog
- [x] The continuous integration build passes
