### PR TITLE
Adds JNIVersion::V24 const

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `JNIVersion::V24` constant for JNI version 24.0 ([#819](https://github.com/jni-rs/jni-rs/pull/819))
+
 ### Fixed
 
 - `Env::{set_field, set_static_field}` no longer throw `WrongJValueType` when passed array values for array signatures ([#811](https://github.com/jni-rs/jni-rs/pull/811))

--- a/crates/jni/src/version.rs
+++ b/crates/jni/src/version.rs
@@ -46,6 +46,10 @@ impl JNIVersion {
     pub const V21: Self = JNIVersion {
         ver: jni_sys::JNI_VERSION_21 as u32,
     };
+    /// JNI Version 24.0
+    pub const V24: Self = JNIVersion {
+        ver: jni_sys::JNI_VERSION_24 as u32,
+    };
 
     /// Return a version from a raw version constant like [`jni_sys::JNI_VERSION_1_2`]
     pub fn new(ver: jni_sys::jint) -> Self {


### PR DESCRIPTION
This exposes the `JNI_VERSION_24` constant from `jni.h`

(note that no `JNI_VERSION_22` or `_23` constants were officially allocated and Java SE 25 uses `JNI_VERSION_24` (so there won't be an official `JNI_VERSION_25`)

Closes: #807

