### PR TITLE
doc: Fix broken links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `Env::{set_field, set_static_field}` no longer throw `WrongJValueType` when passed array values for array signatures ([#811](https://github.com/jni-rs/jni-rs/pull/811))
 - Some `std` paths emitted by `bind_java_type` were not fully qualified with a `::` prefix ([#816](https://github.com/jni-rs/jni-rs/pull/816))
 - Avoid `ExceptionCheck` calls within `GetPrimitiveArrayCritical` section (avoiding Hotspot warnings about JNI calls not being allowed in critical sections) ([#817](https://github.com/jni-rs/jni-rs/pull/817))
+- Fix some broken links in the documentation.
 
 ## [0.22.4] — 2026-03-16
 

--- a/crates/jni/src/lib.rs
+++ b/crates/jni/src/lib.rs
@@ -268,11 +268,11 @@
 //!     https://docs.oracle.com/en/java/javase/21/docs/specs/jni/index.html
 //! [jni-tips]: https://developer.android.com/training/articles/perf-jni
 //! [jni-rs-examples]:
-//!     https://github.com/jni-rs/jni-rs/tree/master/examples
+//!     https://github.com/jni-rs/jni-rs/tree/master/crates/jni/examples
 //! [jni-rs-mylib-example]:
-//!     https://github.com/jni-rs/jni-rs/tree/master/mylib-example
-//! [jni-rs-its]: https://github.com/jni-rs/jni-rs/tree/master/tests
-//! [jni-rs-benches]: https://github.com/jni-rs/jni-rs/tree/master/benches
+//!     https://github.com/jni-rs/jni-rs/tree/master/crates/jni/mylib-example
+//! [jni-rs-its]: https://github.com/jni-rs/jni-rs/tree/master/crates/jni/tests
+//! [jni-rs-benches]: https://github.com/jni-rs/jni-rs/tree/master/crates/jni/benches
 //! [users-servo]:
 //!     https://github.com/servo/servo/tree/main/ports/servoshell/egl/android
 //! [users-ejb]:
@@ -282,7 +282,7 @@
 //! [projects-jnr]: https://github.com/jnr/jnr-ffi/
 //! [projects-graalvm]: http://www.graalvm.org/docs/why-graal/#for-java-programs
 //! [graalvm-rust]:
-//!     http://www.graalvm.org/docs/reference-manual/languages/llvm/#running-rust
+//!     https://www.graalvm.org/latest/reference-manual/llvm/Compiling/#running-rust
 //! [projects-panama]: https://jdk.java.net/panama/
 
 #[doc = include_str!("../docs/0.22-MIGRATION.md")]

--- a/crates/jni/src/lib.rs
+++ b/crates/jni/src/lib.rs
@@ -249,7 +249,6 @@
 //! ### Open-Source Users
 //! - The Servo browser engine Android [port][users-servo]
 //! - The Exonum framework [Java Binding][users-ejb]
-//! - MaidSafe [Java Binding][users-maidsafe]
 //!
 //! ### Other Projects Simplifying Java and Rust Communication
 //! - Consider [JNR][projects-jnr] if you just need to use a native library with
@@ -277,8 +276,6 @@
 //!     https://github.com/servo/servo/tree/main/ports/servoshell/egl/android
 //! [users-ejb]:
 //!     https://github.com/exonum/exonum-java-binding/tree/master/exonum-java-binding/core/rust
-//! [users-maidsafe]:
-//!     https://github.com/maidsafe/safe_client_libs/tree/master/safe_app_jni
 //! [projects-jnr]: https://github.com/jnr/jnr-ffi/
 //! [projects-graalvm]: http://www.graalvm.org/docs/why-graal/#for-java-programs
 //! [graalvm-rust]:


### PR DESCRIPTION
## Overview

Fix some broken links found in the jni crate doc.

There is one broken link left: https://github.com/maidsafe/safe_client_libs/tree/master/safe_app_jni. I couldn't find the new location (if any) in the maidsafe organization.

### Definition of Done

- [x] There are no TODOs left in the code
- [ ] Change is covered by [automated tests](https://github.com/jni-rs/jni-rs/blob/master/CONTRIBUTING.md#tests)
- [x] The [coding guidelines](https://github.com/jni-rs/jni-rs/blob/master/CONTRIBUTING.md#the-code-style) are followed
- [ ] Public API has documentation
- [x] User-visible changes are mentioned in the Changelog
- [ ] The continuous integration build passes
