### PR TITLE
Constify FieldSignature and MethodSignature accessors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - `JNIVersion::V24` constant for JNI version 24.0 ([#819](https://github.com/jni-rs/jni-rs/pull/819))
+- The basic accessors on `MethodSignature` and `FieldSignature` are now `const`.
+- `JNIStr::to_bytes` is now `const`.
 
 ### Fixed
 

--- a/crates/jni/src/signature.rs
+++ b/crates/jni/src/signature.rs
@@ -123,17 +123,17 @@ impl<'sig, 'args> MethodSignature<'sig, 'args> {
     }
 
     /// Get the JNI signature string
-    pub fn sig(&self) -> &JNIStr {
+    pub const fn sig(&self) -> &JNIStr {
         self.sig
     }
 
     /// Get the argument types
-    pub fn args(&self) -> &[JavaType] {
+    pub const fn args(&self) -> &[JavaType] {
         self.args
     }
 
     /// Get the return type
-    pub fn ret(&self) -> JavaType {
+    pub const fn ret(&self) -> JavaType {
         self.ret
     }
 }
@@ -178,12 +178,12 @@ impl<'sig> FieldSignature<'sig> {
     }
 
     /// Get the JNI signature string
-    pub fn sig(&self) -> &JNIStr {
+    pub const fn sig(&self) -> &JNIStr {
         self.sig
     }
 
     /// Get the field type
-    pub fn ty(&self) -> JavaType {
+    pub const fn ty(&self) -> JavaType {
         self.ty
     }
 

--- a/crates/jni/src/strings/ffi_str.rs
+++ b/crates/jni/src/strings/ffi_str.rs
@@ -394,7 +394,7 @@ impl JNIStr {
     ///
     /// The returned slice will **not** contain the trailing nul terminator that this JNI
     /// string has.
-    pub fn to_bytes(&self) -> &[u8] {
+    pub const fn to_bytes(&self) -> &[u8] {
         self.as_cstr().to_bytes()
     }
 }


### PR DESCRIPTION
## Overview

This allows (limited, tricky) manipulation of signatures at compile time, to go with the unsafe construction methods.

While here, constify JNIStr::to_bytes as well, since it is merely sugar for composing two other const operations.

### Definition of Done

- [x] There are no TODOs left in the code
- [ ] Change is covered by [automated tests](https://github.com/jni-rs/jni-rs/blob/master/CONTRIBUTING.md#tests) - no other functions have tests *just* for being const.
- [x] The [coding guidelines](https://github.com/jni-rs/jni-rs/blob/master/CONTRIBUTING.md#the-code-style) are followed
- [x] Public API has documentation
- [x] User-visible changes are mentioned in the Changelog
- [x] The continuous integration build passes
