### PR TITLE
docs: document the class loader lifetime precondition of native method registration

### DIFF
--- a/crates/jni/src/env.rs
+++ b/crates/jni/src/env.rs
@@ -4471,6 +4471,24 @@ See the jni-rs Env documentation for more details.
     ///
     /// - **Instance native methods** must have a `this: JObject<'local>` or `this: MyType<'local>` parameter as the second parameter.
     ///
+    /// The caller must also ensure that the native library providing the function pointers
+    /// outlives `class`. A native library is associated with the class loader that loaded it and
+    /// may be unloaded once that loader is garbage collected, while `class` stays alive as long as
+    /// *its own* defining loader does. Since the registered pointers are not tracked by the JVM,
+    /// calling a native method of `class` after its implementation has been unloaded is undefined
+    /// behaviour, not an `UnsatisfiedLinkError`. In practice this holds when the library is loaded
+    /// by the defining loader of `class`, or by one of that loader's ancestors (a loader is
+    /// strongly referenced by its descendants, so it outlives them).
+    ///
+    /// Note that this hazard is specific to registering methods explicitly: when the JVM resolves
+    /// an exported `Java_*` symbol itself, it only searches libraries loaded by the defining loader
+    /// of the class, so the required lifetime relationship holds by construction. Applications that
+    /// link everything into a single library loaded by the application's own class loader (for
+    /// example a typical Android or Tauri application) also satisfy it, because that library lives
+    /// until the process exits. Code that registers methods on classes belonging to an unrelated
+    /// loader — plugin systems, hot reloading, `URLClassLoader` or `DexClassLoader` — has to
+    /// establish the relationship itself, e.g. by unregistering the methods from `JNI_OnUnload`.
+    ///
     /// # Throws
     ///
     /// - `NoSuchMethodError` - if a method could not be found (based on its name and signature) or

--- a/crates/jni/src/lib.rs
+++ b/crates/jni/src/lib.rs
@@ -60,6 +60,17 @@
 //!    the function name doesn't need to be mangled or exported from a shared
 //!    library)
 //!
+//! The two are not equivalent in one respect worth knowing up front. When the
+//! JVM looks up an exported symbol itself, it only searches libraries loaded by
+//! the defining class loader of the class in question, so the implementation is
+//! guaranteed to outlive the class. Explicit registration bypasses that lookup,
+//! so the caller becomes responsible for the same relationship: if the library
+//! providing the function pointers is unloaded while the class is still alive,
+//! calls to its native methods are undefined behaviour. See the safety
+//! documentation of [`Env::register_native_methods`] for when this matters —
+//! for a single library loaded by the application's own class loader (the usual
+//! case, including Android and Tauri applications) it holds automatically.
+//!
 //! The arguments and return type for a native method implementation are
 //! documented in the JNI specification under "Design" -> "Native Method
 //! Arguments"


### PR DESCRIPTION
Docs only. Follows from the measurements I posted in #833 — happy to drop or reshape any of
it, and equally happy if you'd rather solve it in code instead.

The gap: explicit registration bypasses the JVM's own symbol lookup, and with it a lifetime
guarantee that lookup provides for free. The JVM only searches libraries loaded by the
*defining loader of the class*, so an exported `Java_*` symbol is necessarily provided by a
library that outlives the class. `RegisterNatives` takes pointers the JVM does not track, so
if that library is unloaded while the class is still alive, the call is undefined behaviour
rather than an `UnsatisfiedLinkError`.

I verified the lookup scoping rather than assuming it: with the library kept loaded, the
symbol present (`nm` shows `Java_Test_hello__Ljava_lang_String_2`), and no `RegisterNatives`
call, `Test.hello` still throws `UnsatisfiedLinkError` — the library is invisible to a class
from another loader even while loaded. Details and the other variants are in #833.

Two changes:

- `Env::register_native_methods` — the `# Safety` section covered signatures and
  static/instance mismatches, but not this precondition. Added it, with the practical form
  (library loaded by the defining loader of the class, or by one of its ancestors, since a
  loader is strongly referenced by its descendants).
- The "two approaches" overview in the crate docs presented both paths as equivalent. Noted
  the difference, and that the common single-library case — including a typical Android or
  Tauri application, where the library lives until the process exits — satisfies the
  requirement automatically, so this is not a warning aimed at most users. Plugin systems,
  hot reloading and `URLClassLoader`/`DexClassLoader` are the affected shapes, and
  `JNI_OnUnload` is where they can fix it (measured working in #833, with its costs listed
  there).

`cargo doc -p jni --no-deps` is clean apart from three pre-existing `JavaVM::new` link
warnings; `cargo fmt --check` passes.
