### PR TITLE
Remove redundant casts and clones

### DIFF
--- a/crates/jni-macros/src/bind_java_type.rs
+++ b/crates/jni-macros/src/bind_java_type.rs
@@ -3846,7 +3846,7 @@ fn generate_single_native_export(
 
     // Generate the mangled JNI function name
     let mangled_name = if let Some(export_name) = export_name {
-        export_name.clone()
+        export_name
     } else {
         create_jni_fn_name(java_class_dotted, java_method_name, Some(&jni_signature))
     };

--- a/crates/jni-macros/src/native_method.rs
+++ b/crates/jni-macros/src/native_method.rs
@@ -660,7 +660,7 @@ pub fn native_method_impl(input: TokenStream) -> Result<TokenStream> {
 
         // Generate the mangled JNI function name
         let mangled_name = if let NativeMethodExport::WithName(export_name) = input.export {
-            export_name.clone()
+            export_name
         } else {
             create_jni_fn_name(&java_class_dotted, java_method_name, Some(&jni_signature))
         };

--- a/crates/jni-macros/src/types.rs
+++ b/crates/jni-macros/src/types.rs
@@ -660,7 +660,7 @@ impl TypeMappings {
                 .insert_alias(simple_name, &jni_full_path)
                 .expect("Failed to insert built-in jni crate type alias");
             if is_core {
-                type_mappings.core_java.insert(java_class.clone());
+                type_mappings.core_java.insert(java_class);
             }
         }
 
@@ -872,8 +872,7 @@ impl TypeMappings {
             return Ok(());
         }
 
-        self.alias_to_rust
-            .insert(alias.to_string(), rust_type.clone());
+        self.alias_to_rust.insert(alias.to_string(), rust_type);
 
         Ok(())
     }

--- a/crates/jni/src/objects/jobject_array.rs
+++ b/crates/jni/src/objects/jobject_array.rs
@@ -227,7 +227,7 @@ impl<'local, E: Reference + 'local> JObjectArray<'local, E> {
 
     /// Unwrap to the raw jni type.
     pub const fn into_raw(self) -> jobjectArray {
-        self.array.into_raw() as jobjectArray
+        self.array.into_raw()
     }
 
     /// Cast a local reference to a [`JObjectArray<T>`]

--- a/crates/jni/src/objects/jprimitive_array.rs
+++ b/crates/jni/src/objects/jprimitive_array.rs
@@ -136,7 +136,7 @@ impl<'local, T: TypeArray> JPrimitiveArray<'local, T> {
 
     /// Unwrap to the raw jni type.
     pub const fn into_raw(self) -> jarray {
-        self.obj.into_raw() as jarray
+        self.obj.into_raw()
     }
 
     /// Returns the length of the array.


### PR DESCRIPTION
I believe both the casts and the clones are redundant in these cases and can thus be safely removed.

For reference, these changes were found by an optimizer developed as a research project.

CC @nunoplopes